### PR TITLE
build: remove ext-publish-vsix script and references

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -45,7 +45,6 @@ Handle VS Code extension-specific operations (packages with `publisher` field in
 - `ext-version-bumper`: Bump versions for selected extensions
 - `ext-publish-matrix`: Determine publish matrix for extensions
 - `ext-github-releases`: Create GitHub releases for extensions
-- `ext-publish-vsix`: Publish VSIX file to VS Code Marketplace
 
 #### NPM Scripts (npm-\*)
 
@@ -108,10 +107,6 @@ npx tsx .github/scripts/index.ts ext-publish-matrix
 # ext-github-releases
 DRY_RUN=true PRE_RELEASE=false VERSION_BUMP=auto SELECTED_EXTENSIONS=apex-lsp-vscode-extension IS_NIGHTLY=false VSIX_ARTIFACTS_PATH=./vsix-artifacts \
 npx tsx .github/scripts/index.ts ext-github-releases
-
-# ext-publish-vsix
-PACKAGE_DIR=./packages/apex-lsp-vscode-extension VSCE_PERSONAL_ACCESS_TOKEN=token PRE_RELEASE=false DRY_RUN=true \
-npx tsx .github/scripts/index.ts ext-publish-vsix
 ```
 
 #### NPM Scripts
@@ -252,14 +247,14 @@ jobs:
 
 ### NPM-Specific Variables
 
-| Variable             | Description                      | Example                                      |
-| -------------------- | -------------------------------- | -------------------------------------------- |
+| Variable             | Description                      | Example                                     |
+| -------------------- | -------------------------------- | ------------------------------------------- |
 | `SELECTED_PACKAGE`   | NPM package selection mode       | `none`, `all`, `changed`, `apex-lsp-shared` |
 | `AVAILABLE_PACKAGES` | Available NPM packages           | `apex-lsp-shared,apex-parser-ast`           |
 | `CHANGED_PACKAGES`   | Changed NPM packages             | `apex-lsp-shared`                           |
 | `SELECTED_PACKAGES`  | JSON array of selected packages  | `["apex-lsp-shared"]`                       |
 | `MATRIX_PACKAGE`     | Current matrix package           | `apex-lsp-shared`                           |
-| `INPUT_BASE_BRANCH`  | Base branch for change detection | `main`                                       |
+| `INPUT_BASE_BRANCH`  | Base branch for change detection | `main`                                      |
 
 ### Utility Variables
 
@@ -272,7 +267,7 @@ jobs:
 | `WORKFLOW`          | Workflow name            | `release`                           |
 | `RUN_ID`            | Workflow run ID          | `123456789`                         |
 | `ACTOR`             | Actor performing action  | `github-actions`                    |
-| `DETAILS`           | JSON details             | `{"packages":"apex-lsp-shared"}`   |
+| `DETAILS`           | JSON details             | `{"packages":"apex-lsp-shared"}`    |
 | `ACTION`            | Action being performed   | `release`                           |
 | `LOG_FILE`          | Custom log file path     | `./custom-audit.log`                |
 

--- a/.github/scripts/RELEASE_SCRIPTS.md
+++ b/.github/scripts/RELEASE_SCRIPTS.md
@@ -58,9 +58,6 @@ npx tsx .github/scripts/index.ts ext-publish-matrix
 
 # Create GitHub releases for extensions
 npx tsx .github/scripts/index.ts ext-github-releases
-
-# Publish VSIX file to VS Code Marketplace
-npx tsx .github/scripts/index.ts ext-publish-vsix
 ```
 
 #### NPM Commands (prefixed with "npm-")
@@ -217,7 +214,6 @@ The release scripts are organized in the `.github/scripts` folder:
 ├── ext-version-bumper.ts     # Bump versions for extensions
 ├── ext-publish-matrix.ts     # Determine publish matrix
 ├── ext-github-releases.ts    # Create GitHub releases
-├── ext-publish-vsix.ts       # Publish VSIX to marketplace
 ├── npm-change-detector.ts    # Detect NPM package changes
 ├── npm-package-selector.ts   # Select NPM packages
 ├── npm-package-details.ts    # Extract NPM package details
@@ -237,7 +233,6 @@ The release scripts are organized in the `.github/scripts` folder:
 - **`ext-version-bumper.ts`**: Bump versions for selected extensions
 - **`ext-publish-matrix.ts`**: Determine publish matrix for extensions
 - **`ext-github-releases.ts`**: Create GitHub releases for extensions
-- **`ext-publish-vsix.ts`**: Publish VSIX file to VS Code Marketplace
 
 #### NPM Modules
 

--- a/.github/scripts/index.ts
+++ b/.github/scripts/index.ts
@@ -39,7 +39,6 @@ import { displayExtensionReleasePlan } from './ext-release-plan';
 import { bumpVersions } from './ext-version-bumper';
 import { determinePublishMatrix } from './ext-publish-matrix';
 import { createGitHubReleases } from './ext-github-releases';
-import { publishVsix } from './ext-publish-vsix';
 import { logAuditEvent } from './audit-logger';
 
 import { log, setOutput } from './utils';
@@ -292,23 +291,6 @@ program
       });
     } catch (error) {
       log.error(`Failed to bump versions: ${error}`);
-      process.exit(1);
-    }
-  });
-
-program
-  .command('ext-publish-vsix')
-  .description('Publish VSIX file to VS Code Marketplace')
-  .action(async () => {
-    try {
-      publishVsix({
-        packageDir: process.env.PACKAGE_DIR || '',
-        vsceToken: process.env.VSCE_PERSONAL_ACCESS_TOKEN || '',
-        isPreRelease: process.env.PRE_RELEASE === 'true',
-        dryRun: process.env.DRY_RUN === 'true',
-      });
-    } catch (error) {
-      log.error(`Failed to publish VSIX: ${error}`);
       process.exit(1);
     }
   });

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -143,7 +143,6 @@ The workflows use TypeScript-based release scripts located in `.github/scripts/`
 - `ext-version-bumper`: Bump versions for selected extensions
 - `ext-publish-matrix`: Determine publish matrix for extensions
 - `ext-github-releases`: Create GitHub releases for extensions
-- `ext-publish-vsix`: Publish VSIX file to VS Code Marketplace
 
 #### NPM Scripts (npm-\*)
 


### PR DESCRIPTION
Eliminated the ext-publish-vsix command from the release scripts