### PR TITLE
refactor: simplify ProtocolHandler — only apexlib:// needs explicit handling W-21638371

### DIFF
--- a/packages/apex-lsp-testbed/test/accuracy/__snapshots__/lsp-requests.quality.ts.snap
+++ b/packages/apex-lsp-testbed/test/accuracy/__snapshots__/lsp-requests.quality.ts.snap
@@ -1,13 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {
-  type: 'request',
-  method: 'textDocument/documentSymbol',
-  id: 9,
-  params: [Object],
-  performance: [Object],
-  result: [Array]
-}: textDocument/documentSymbol-request 1`] = `
+exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {\\n  type: 'request',\\n  method: 'textDocument/documentSymbol',\\n  id: 9,\\n  params: [Object],\\n  performance: [Object],\\n  result: [Array]\\n}: textDocument/documentSymbol-request 1`] = `
 {
   "actualResponse": [
     {
@@ -272,14 +265,7 @@ exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP 
 }
 `;
 
-exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {
-  type: 'request',
-  method: 'textDocument/documentSymbol',
-  id: 15,
-  params: [Object],
-  performance: [Object],
-  result: [Array]
-}: textDocument/documentSymbol-request 1`] = `
+exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {\\n  type: 'request',\\n  method: 'textDocument/documentSymbol',\\n  id: 15,\\n  params: [Object],\\n  performance: [Object],\\n  result: [Array]\\n}: textDocument/documentSymbol-request 1`] = `
 {
   "actualResponse": [
     {
@@ -544,14 +530,7 @@ exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP 
 }
 `;
 
-exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {
-  type: 'request',
-  method: 'textDocument/documentSymbol',
-  id: 21,
-  params: [Object],
-  performance: [Object],
-  result: [Array]
-}: textDocument/documentSymbol-request 1`] = `
+exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {\\n  type: 'request',\\n  method: 'textDocument/documentSymbol',\\n  id: 21,\\n  params: [Object],\\n  performance: [Object],\\n  result: [Array]\\n}: textDocument/documentSymbol-request 1`] = `
 {
   "actualResponse": [
     {
@@ -669,14 +648,7 @@ exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP 
 }
 `;
 
-exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {
-  type: 'request',
-  method: 'textDocument/documentSymbol',
-  id: 27,
-  params: [Object],
-  performance: [Object],
-  result: [Array]
-}: textDocument/documentSymbol-request 1`] = `
+exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {\\n  type: 'request',\\n  method: 'textDocument/documentSymbol',\\n  id: 27,\\n  params: [Object],\\n  performance: [Object],\\n  result: [Array]\\n}: textDocument/documentSymbol-request 1`] = `
 {
   "actualResponse": [
     {
@@ -794,14 +766,7 @@ exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP 
 }
 `;
 
-exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {
-  type: 'request',
-  method: 'textDocument/documentSymbol',
-  id: 33,
-  params: [Object],
-  performance: [Object],
-  result: [Array]
-}: textDocument/documentSymbol-request 1`] = `
+exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {\\n  type: 'request',\\n  method: 'textDocument/documentSymbol',\\n  id: 33,\\n  params: [Object],\\n  performance: [Object],\\n  result: [Array]\\n}: textDocument/documentSymbol-request 1`] = `
 {
   "actualResponse": [
     {
@@ -1115,14 +1080,7 @@ exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP 
 }
 `;
 
-exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {
-  type: 'request',
-  method: 'textDocument/documentSymbol',
-  id: 39,
-  params: [Object],
-  performance: [Object],
-  result: [Array]
-}: textDocument/documentSymbol-request 1`] = `
+exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {\\n  type: 'request',\\n  method: 'textDocument/documentSymbol',\\n  id: 39,\\n  params: [Object],\\n  performance: [Object],\\n  result: [Array]\\n}: textDocument/documentSymbol-request 1`] = `
 {
   "actualResponse": [
     {
@@ -1736,14 +1694,7 @@ exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP 
 }
 `;
 
-exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {
-  type: 'request',
-  method: 'textDocument/documentSymbol',
-  id: 45,
-  params: [Object],
-  performance: [Object],
-  result: [Array]
-}: textDocument/documentSymbol-request 1`] = `
+exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {\\n  type: 'request',\\n  method: 'textDocument/documentSymbol',\\n  id: 45,\\n  params: [Object],\\n  performance: [Object],\\n  result: [Array]\\n}: textDocument/documentSymbol-request 1`] = `
 {
   "actualResponse": [
     {
@@ -2057,14 +2008,7 @@ exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP 
 }
 `;
 
-exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {
-  type: 'request',
-  method: 'textDocument/documentSymbol',
-  id: 51,
-  params: [Object],
-  performance: [Object],
-  result: [Array]
-}: textDocument/documentSymbol-request 1`] = `
+exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {\\n  type: 'request',\\n  method: 'textDocument/documentSymbol',\\n  id: 51,\\n  params: [Object],\\n  performance: [Object],\\n  result: [Array]\\n}: textDocument/documentSymbol-request 1`] = `
 {
   "actualResponse": [
     {
@@ -2825,14 +2769,7 @@ exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP 
 }
 `;
 
-exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {
-  type: 'request',
-  method: 'textDocument/documentSymbol',
-  id: 57,
-  params: [Object],
-  performance: [Object],
-  result: [Array]
-}: textDocument/documentSymbol-request 1`] = `
+exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {\\n  type: 'request',\\n  method: 'textDocument/documentSymbol',\\n  id: 57,\\n  params: [Object],\\n  performance: [Object],\\n  result: [Array]\\n}: textDocument/documentSymbol-request 1`] = `
 {
   "actualResponse": [
     {
@@ -2950,14 +2887,7 @@ exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP 
 }
 `;
 
-exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {
-  type: 'request',
-  method: 'textDocument/documentSymbol',
-  id: 63,
-  params: [Object],
-  performance: [Object],
-  result: [Array]
-}: textDocument/documentSymbol-request 1`] = `
+exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {\\n  type: 'request',\\n  method: 'textDocument/documentSymbol',\\n  id: 63,\\n  params: [Object],\\n  performance: [Object],\\n  result: [Array]\\n}: textDocument/documentSymbol-request 1`] = `
 {
   "actualResponse": [
     {
@@ -3173,14 +3103,7 @@ exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP 
 }
 `;
 
-exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {
-  type: 'request',
-  method: 'textDocument/documentSymbol',
-  id: 69,
-  params: [Object],
-  performance: [Object],
-  result: [Array]
-}: textDocument/documentSymbol-request 1`] = `
+exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {\\n  type: 'request',\\n  method: 'textDocument/documentSymbol',\\n  id: 69,\\n  params: [Object],\\n  performance: [Object],\\n  result: [Array]\\n}: textDocument/documentSymbol-request 1`] = `
 {
   "actualResponse": [
     {
@@ -3445,14 +3368,7 @@ exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP 
 }
 `;
 
-exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {
-  type: 'request',
-  method: 'textDocument/documentSymbol',
-  id: 96,
-  params: [Object],
-  performance: [Object],
-  result: [Array]
-}: textDocument/documentSymbol-request 1`] = `
+exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {\\n  type: 'request',\\n  method: 'textDocument/documentSymbol',\\n  id: 96,\\n  params: [Object],\\n  performance: [Object],\\n  result: [Array]\\n}: textDocument/documentSymbol-request 1`] = `
 {
   "actualResponse": [
     {
@@ -3570,12 +3486,7 @@ exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP 
 }
 `;
 
-exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {
-  type: 'request',
-  method: 'textDocument/documentSymbol',
-  id: 101,
-  params: [Object]
-}: textDocument/documentSymbol-request 1`] = `
+exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {\\n  type: 'request',\\n  method: 'textDocument/documentSymbol',\\n  id: 101,\\n  params: [Object]\\n}: textDocument/documentSymbol-request 1`] = `
 {
   "actualResponse": [
     {
@@ -3642,14 +3553,7 @@ exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP 
 }
 `;
 
-exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {
-  type: 'request',
-  method: 'textDocument/documentSymbol',
-  id: 175,
-  params: [Object],
-  performance: [Object],
-  result: [Array]
-}: textDocument/documentSymbol-request 1`] = `
+exports[`LSP Request/Response Accuracy textDocument/documentSymbol requests LSP textDocument/documentSymbol request/response matches snapshot for request {\\n  type: 'request',\\n  method: 'textDocument/documentSymbol',\\n  id: 175,\\n  params: [Object],\\n  performance: [Object],\\n  result: [Array]\\n}: textDocument/documentSymbol-request 1`] = `
 {
   "actualResponse": [
     {

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
@@ -40,7 +40,6 @@ import {
   PatternAnalysis,
 } from '../types/metrics';
 import {
-  hasUriScheme,
   createFileUri,
   extractFilePath,
   isStandardApexUri,
@@ -313,7 +312,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
     symbolTable?: SymbolTable,
   ): void {
     // Convert fileUri to proper URI format to match symbol ID generation
-    const properUri = hasUriScheme(fileUri) ? fileUri : createFileUri(fileUri);
+    const properUri = createFileUri(fileUri);
 
     // Generate unified ID for the symbol if not already present
     if (!symbol.key.unifiedId) {
@@ -511,7 +510,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
     }
 
     // Convert fileUri to proper URI format to match how symbols are stored
-    const properUri = hasUriScheme(fileUri) ? fileUri : createFileUri(fileUri);
+    const properUri = createFileUri(fileUri);
 
     // Normalize URI using the same logic as getSymbolsInFile() to ensure consistency
     // This ensures we use the same normalized URI that was used when registering SymbolTables
@@ -530,7 +529,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
    */
   getSymbolTableForFile(fileUri: string): SymbolTable | undefined {
     // Convert fileUri to proper URI format to match how symbols are stored
-    const properUri = hasUriScheme(fileUri) ? fileUri : createFileUri(fileUri);
+    const properUri = createFileUri(fileUri);
 
     // Normalize URI using the same logic as getSymbolsInFile() to ensure consistency
     const normalizedUri = extractFilePathFromUri(properUri);
@@ -1119,7 +1118,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
    */
   removeFile(fileUri: string): void {
     // Convert fileUri to proper URI format to match how symbols are stored
-    const properUri = hasUriScheme(fileUri) ? fileUri : createFileUri(fileUri);
+    const properUri = createFileUri(fileUri);
 
     // Normalize URI using extractFilePathFromUri to match how symbols are stored
     // This ensures consistency with addSymbolTable which uses normalized URIs
@@ -1750,9 +1749,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
       const addStartTime = Date.now();
 
       // Convert fileUri to proper URI format to match symbol ID generation
-      const properUri = hasUriScheme(fileUri)
-        ? fileUri
-        : createFileUri(fileUri);
+      const properUri = createFileUri(fileUri);
 
       // Normalize URI using extractFilePathFromUri to ensure consistency with SymbolTable registration
       // This ensures that fileIndex lookups will find the symbols
@@ -2641,9 +2638,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
   ): Effect.Effect<void, never, never> {
     const self = this;
     return Effect.gen(function* () {
-      const properUri = hasUriScheme(fileUri)
-        ? fileUri
-        : createFileUri(fileUri);
+      const properUri = createFileUri(fileUri);
       const normalizedUri = extractFilePathFromUri(properUri);
 
       // Skip if already resolving this file (prevents redundant work from overlapping LSP requests)
@@ -3065,9 +3060,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
             typeRef.resolvedSymbolId = targetSymbol.id;
 
             // Find source symbol for graph edge
-            const properUri = hasUriScheme(fileUri)
-              ? fileUri
-              : createFileUri(fileUri);
+            const properUri = createFileUri(fileUri);
             const normalizedUri = extractFilePathFromUri(properUri);
             let sourceSymbol = self.findContainingSymbolForReference(
               typeRef,
@@ -3127,9 +3120,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
 
           // If resolution failed (artifact not loaded), defer for later
           // For cross-file references, we still need a source symbol for deferral
-          const properUri = hasUriScheme(fileUri)
-            ? fileUri
-            : createFileUri(fileUri);
+          const properUri = createFileUri(fileUri);
           const normalizedUri = extractFilePathFromUri(properUri);
           let sourceSymbol = self.findContainingSymbolForReference(
             typeRef,
@@ -3700,9 +3691,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
         // Look for the member within the containing class scope
         // 'this' can only reference class-scoped members, so we must look in the containing class
         if (containingClass && fileUri) {
-          const normalizedUri = extractFilePathFromUri(
-            hasUriScheme(fileUri) ? fileUri : createFileUri(fileUri),
-          );
+          const normalizedUri = extractFilePathFromUri(createFileUri(fileUri));
 
           // Find all symbols with the member name
           const allSymbolsWithName = this.findSymbolByName(member);
@@ -3745,7 +3734,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
           // If fileUri is provided, prefer same-file symbols
           if (fileUri) {
             const normalizedUri = extractFilePathFromUri(
-              hasUriScheme(fileUri) ? fileUri : createFileUri(fileUri),
+              createFileUri(fileUri),
             );
             const sameFileSymbol = symbols.find(
               (s) => s.fileUri === normalizedUri,
@@ -6282,7 +6271,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
   ): ApexSymbol | null {
     // Normalize URI to match how symbols are stored in the graph
     // This ensures consistency with addSymbolTable which uses normalized URIs
-    const properUri = hasUriScheme(fileUri) ? fileUri : createFileUri(fileUri);
+    const properUri = createFileUri(fileUri);
     const normalizedUri = extractFilePathFromUri(properUri);
 
     // Invalidate cache to ensure we get fresh symbols (they were just added)
@@ -8543,9 +8532,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
         // If symbol table not found, try alternative URI formats before loading
         if (!symbolTable) {
           // Try with proper URI format if contextFile is not already a URI
-          const properUri = hasUriScheme(contextFile)
-            ? contextFile
-            : createFileUri(contextFile);
+          const properUri = createFileUri(contextFile);
           if (properUri !== contextFile) {
             symbolTable = this.symbolGraph.getSymbolTableForFile(properUri);
           }
@@ -8560,9 +8547,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
         ) {
           // Check if we're already loading this file to prevent recursive loops
           const normalizedUri = extractFilePathFromUri(
-            hasUriScheme(contextFile)
-              ? contextFile
-              : createFileUri(contextFile),
+            createFileUri(contextFile),
           );
 
           if (this.loadingSymbolTables.has(normalizedUri)) {
@@ -8580,9 +8565,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
             // Prevent recursive loops - if we're already loading this file, skip
             // Use normalized URI for the check to match what addSymbolTable uses
             const normalizedUri = extractFilePathFromUri(
-              hasUriScheme(contextFile)
-                ? contextFile
-                : createFileUri(contextFile),
+              createFileUri(contextFile),
             );
             if (this.loadingSymbolTables.has(normalizedUri)) {
               this.logger.debug(

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
@@ -40,9 +40,8 @@ import {
   PatternAnalysis,
 } from '../types/metrics';
 import {
-  getProtocolType,
+  hasUriScheme,
   createFileUri,
-  isUserCodeUri,
   extractFilePath,
   isStandardApexUri,
   extractApexLibPath,
@@ -314,8 +313,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
     symbolTable?: SymbolTable,
   ): void {
     // Convert fileUri to proper URI format to match symbol ID generation
-    const properUri =
-      getProtocolType(fileUri) !== null ? fileUri : createFileUri(fileUri);
+    const properUri = hasUriScheme(fileUri) ? fileUri : createFileUri(fileUri);
 
     // Generate unified ID for the symbol if not already present
     if (!symbol.key.unifiedId) {
@@ -513,8 +511,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
     }
 
     // Convert fileUri to proper URI format to match how symbols are stored
-    const properUri =
-      getProtocolType(fileUri) !== null ? fileUri : createFileUri(fileUri);
+    const properUri = hasUriScheme(fileUri) ? fileUri : createFileUri(fileUri);
 
     // Normalize URI using the same logic as getSymbolsInFile() to ensure consistency
     // This ensures we use the same normalized URI that was used when registering SymbolTables
@@ -533,8 +530,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
    */
   getSymbolTableForFile(fileUri: string): SymbolTable | undefined {
     // Convert fileUri to proper URI format to match how symbols are stored
-    const properUri =
-      getProtocolType(fileUri) !== null ? fileUri : createFileUri(fileUri);
+    const properUri = hasUriScheme(fileUri) ? fileUri : createFileUri(fileUri);
 
     // Normalize URI using the same logic as getSymbolsInFile() to ensure consistency
     const normalizedUri = extractFilePathFromUri(properUri);
@@ -587,7 +583,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
       const fileUri = this.symbolGraph['symbolFileMap'].get(symbolId);
       if (fileUri) {
         // Convert URI back to clean file path for consistency with test expectations
-        const cleanPath = isUserCodeUri(fileUri)
+        const cleanPath = fileUri.startsWith('file://')
           ? extractFilePath(fileUri)
           : fileUri;
         files.add(cleanPath);
@@ -1123,8 +1119,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
    */
   removeFile(fileUri: string): void {
     // Convert fileUri to proper URI format to match how symbols are stored
-    const properUri =
-      getProtocolType(fileUri) !== null ? fileUri : createFileUri(fileUri);
+    const properUri = hasUriScheme(fileUri) ? fileUri : createFileUri(fileUri);
 
     // Normalize URI using extractFilePathFromUri to match how symbols are stored
     // This ensures consistency with addSymbolTable which uses normalized URIs
@@ -1755,8 +1750,9 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
       const addStartTime = Date.now();
 
       // Convert fileUri to proper URI format to match symbol ID generation
-      const properUri =
-        getProtocolType(fileUri) !== null ? fileUri : createFileUri(fileUri);
+      const properUri = hasUriScheme(fileUri)
+        ? fileUri
+        : createFileUri(fileUri);
 
       // Normalize URI using extractFilePathFromUri to ensure consistency with SymbolTable registration
       // This ensures that fileIndex lookups will find the symbols
@@ -2645,8 +2641,9 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
   ): Effect.Effect<void, never, never> {
     const self = this;
     return Effect.gen(function* () {
-      const properUri =
-        getProtocolType(fileUri) !== null ? fileUri : createFileUri(fileUri);
+      const properUri = hasUriScheme(fileUri)
+        ? fileUri
+        : createFileUri(fileUri);
       const normalizedUri = extractFilePathFromUri(properUri);
 
       // Skip if already resolving this file (prevents redundant work from overlapping LSP requests)
@@ -3068,10 +3065,9 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
             typeRef.resolvedSymbolId = targetSymbol.id;
 
             // Find source symbol for graph edge
-            const properUri =
-              getProtocolType(fileUri) !== null
-                ? fileUri
-                : createFileUri(fileUri);
+            const properUri = hasUriScheme(fileUri)
+              ? fileUri
+              : createFileUri(fileUri);
             const normalizedUri = extractFilePathFromUri(properUri);
             let sourceSymbol = self.findContainingSymbolForReference(
               typeRef,
@@ -3131,10 +3127,9 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
 
           // If resolution failed (artifact not loaded), defer for later
           // For cross-file references, we still need a source symbol for deferral
-          const properUri =
-            getProtocolType(fileUri) !== null
-              ? fileUri
-              : createFileUri(fileUri);
+          const properUri = hasUriScheme(fileUri)
+            ? fileUri
+            : createFileUri(fileUri);
           const normalizedUri = extractFilePathFromUri(properUri);
           let sourceSymbol = self.findContainingSymbolForReference(
             typeRef,
@@ -3706,9 +3701,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
         // 'this' can only reference class-scoped members, so we must look in the containing class
         if (containingClass && fileUri) {
           const normalizedUri = extractFilePathFromUri(
-            getProtocolType(fileUri) !== null
-              ? fileUri
-              : createFileUri(fileUri),
+            hasUriScheme(fileUri) ? fileUri : createFileUri(fileUri),
           );
 
           // Find all symbols with the member name
@@ -3752,9 +3745,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
           // If fileUri is provided, prefer same-file symbols
           if (fileUri) {
             const normalizedUri = extractFilePathFromUri(
-              getProtocolType(fileUri) !== null
-                ? fileUri
-                : createFileUri(fileUri),
+              hasUriScheme(fileUri) ? fileUri : createFileUri(fileUri),
             );
             const sameFileSymbol = symbols.find(
               (s) => s.fileUri === normalizedUri,
@@ -6291,8 +6282,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
   ): ApexSymbol | null {
     // Normalize URI to match how symbols are stored in the graph
     // This ensures consistency with addSymbolTable which uses normalized URIs
-    const properUri =
-      getProtocolType(fileUri) !== null ? fileUri : createFileUri(fileUri);
+    const properUri = hasUriScheme(fileUri) ? fileUri : createFileUri(fileUri);
     const normalizedUri = extractFilePathFromUri(properUri);
 
     // Invalidate cache to ensure we get fresh symbols (they were just added)
@@ -8553,10 +8543,9 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
         // If symbol table not found, try alternative URI formats before loading
         if (!symbolTable) {
           // Try with proper URI format if contextFile is not already a URI
-          const properUri =
-            getProtocolType(contextFile) !== null
-              ? contextFile
-              : createFileUri(contextFile);
+          const properUri = hasUriScheme(contextFile)
+            ? contextFile
+            : createFileUri(contextFile);
           if (properUri !== contextFile) {
             symbolTable = this.symbolGraph.getSymbolTableForFile(properUri);
           }
@@ -8571,7 +8560,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
         ) {
           // Check if we're already loading this file to prevent recursive loops
           const normalizedUri = extractFilePathFromUri(
-            getProtocolType(contextFile) !== null
+            hasUriScheme(contextFile)
               ? contextFile
               : createFileUri(contextFile),
           );
@@ -8591,7 +8580,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
             // Prevent recursive loops - if we're already loading this file, skip
             // Use normalized URI for the check to match what addSymbolTable uses
             const normalizedUri = extractFilePathFromUri(
-              getProtocolType(contextFile) !== null
+              hasUriScheme(contextFile)
                 ? contextFile
                 : createFileUri(contextFile),
             );

--- a/packages/apex-parser-ast/src/types/ProtocolHandler.ts
+++ b/packages/apex-parser-ast/src/types/ProtocolHandler.ts
@@ -6,72 +6,19 @@
  * repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-/**
- * Supported URI protocols in the Apex language server
- */
-export type UriProtocol = 'file' | 'apexlib' | 'builtin' | 'other';
-
-const PROTOCOL_PREFIXES = {
-  file: 'file://',
-  apexlib: 'apexlib://',
-  builtin: 'built-in://',
-} as const;
+const FILE_URI_PREFIX = 'file://';
 
 export const APEXLIB_RESOURCE_PREFIX =
   'apexlib://resources/StandardApexLibrary/';
 
 /**
- * Determine the protocol type from a URI string
- * Recognizes known protocols (file://, apexlib://, builtin://) and also
- * detects any URI with a protocol scheme (e.g., vscode-test-web://, vscode-vfs://)
- * to preserve VS Code web environment URIs.
- *
- * @param uri The URI to analyze
- * @returns The protocol type or null if it's a plain path without protocol
+ * True if the string already has a URI scheme (not a plain path).
+ * Supports double-slash schemes (e.g. file://, vscode-test-web://) and
+ * single-slash schemes (e.g. memfs:/, vscode-vfs:/). Plain paths and Windows
+ * drive paths are not treated as URIs.
  */
-export const getProtocolType = (uri: string): UriProtocol | null => {
-  if (uri.startsWith(PROTOCOL_PREFIXES.file)) {
-    return 'file';
-  }
-  if (uri.startsWith(PROTOCOL_PREFIXES.apexlib)) {
-    return 'apexlib';
-  }
-  if (uri.startsWith(PROTOCOL_PREFIXES.builtin)) {
-    return 'builtin';
-  }
-  // Check if this URI has any protocol scheme (e.g., vscode-test-web://, vscode-vfs://, etc.)
-  // This preserves VS Code web URIs and other non-standard schemes
-  if (uri.includes('://')) {
-    return 'other';
-  }
-  // Recognize single-slash URI schemes with 2+ char names (e.g., memfs:/path, vscode-vfs:/path).
-  // Per RFC 3986, a scheme is [a-zA-Z][a-zA-Z0-9+.-]* followed by ':'.
-  // Using '+' (not '*') to require at least 2-char schemes, excluding Windows drive letters (C:/).
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]+:\//.test(uri)) {
-    return 'other';
-  }
-  return null;
-};
-
-/**
- * Check if a URI uses a specific protocol
- * @param uri The URI to check
- * @param protocol The protocol to check for
- * @returns True if the URI uses the specified protocol
- */
-export const hasProtocol = (uri: string, protocol: UriProtocol): boolean => {
-  if (protocol === 'other') {
-    // For 'other', check if it has any protocol but not our known ones
-    // Supports both double-slash (vscode-test-web://) and single-slash (memfs:/) schemes
-    return (
-      !uri.startsWith(PROTOCOL_PREFIXES.file) &&
-      !uri.startsWith(PROTOCOL_PREFIXES.apexlib) &&
-      !uri.startsWith(PROTOCOL_PREFIXES.builtin) &&
-      (uri.includes('://') || /^[a-zA-Z][a-zA-Z0-9+.-]+:\//.test(uri))
-    );
-  }
-  return uri.startsWith(PROTOCOL_PREFIXES[protocol]);
-};
+export const hasUriScheme = (uri: string): boolean =>
+  uri.includes('://') || /^[a-zA-Z][a-zA-Z0-9+.-]+:\//.test(uri);
 
 /**
  * Create a file URI from a file path
@@ -82,11 +29,10 @@ export const hasProtocol = (uri: string, protocol: UriProtocol): boolean => {
  * @returns The file URI
  */
 export const createFileUri = (fileUri: string): string => {
-  // If it already has a protocol, return as-is to preserve VS Code web URIs
-  if (getProtocolType(fileUri) !== null) {
+  if (hasUriScheme(fileUri)) {
     return fileUri;
   }
-  return `${PROTOCOL_PREFIXES.file}${fileUri}`;
+  return `${FILE_URI_PREFIX}${fileUri}`;
 };
 
 /**
@@ -96,13 +42,6 @@ export const createFileUri = (fileUri: string): string => {
  */
 export const createApexLibUri = (resourcePath: string): string =>
   `${APEXLIB_RESOURCE_PREFIX}${resourcePath}`;
-/**
- * Create a builtin URI
- * @param typeName The built-in type name
- * @returns The builtin URI
- */
-export const createBuiltinUri = (typeName: string): string =>
-  `${PROTOCOL_PREFIXES.builtin}${typeName}`;
 
 /**
  * Extract the file path from a file URI
@@ -110,10 +49,10 @@ export const createBuiltinUri = (typeName: string): string =>
  * @returns The file path
  */
 export const extractFilePath = (uri: string): string => {
-  if (!hasProtocol(uri, 'file')) {
+  if (!uri.startsWith(FILE_URI_PREFIX)) {
     throw new Error(`Expected file URI, got: ${uri}`);
   }
-  return uri.replace(PROTOCOL_PREFIXES.file, '');
+  return uri.slice(FILE_URI_PREFIX.length);
 };
 
 /**
@@ -122,7 +61,7 @@ export const extractFilePath = (uri: string): string => {
  * @returns The resource path
  */
 export const extractApexLibPath = (uri: string): string => {
-  if (!hasProtocol(uri, 'apexlib')) {
+  if (!uri.startsWith('apexlib://')) {
     throw new Error(`Expected apexlib URI, got: ${uri}`);
   }
   const match = uri.match(/apexlib:\/\/resources\/StandardApexLibrary\/(.+)/);
@@ -133,85 +72,23 @@ export const extractApexLibPath = (uri: string): string => {
 };
 
 /**
- * Extract the type name from a builtin URI
- * @param uri The builtin URI
- * @returns The type name
- */
-export const extractBuiltinType = (uri: string): string => {
-  if (!hasProtocol(uri, 'builtin')) {
-    throw new Error(`Expected builtin URI, got: ${uri}`);
-  }
-  return uri.replace(PROTOCOL_PREFIXES.builtin, '');
-};
-
-/**
  * Check if a URI represents standard Apex library content
  * @param uri The URI to check
  * @returns True if this is a standard Apex library URI
  */
 export const isStandardApexUri = (uri: string): boolean =>
-  hasProtocol(uri, 'apexlib');
+  uri.startsWith('apexlib://');
 
 /**
- * Check if a URI represents user code
- * @param uri The URI to check
- * @returns True if this is a user code URI
- */
-export const isUserCodeUri = (uri: string): boolean => hasProtocol(uri, 'file');
-
-/**
- * Check if a URI represents a built-in type
- * @param uri The URI to check
- * @returns True if this is a built-in type URI
- */
-export const isBuiltinUri = (uri: string): boolean =>
-  hasProtocol(uri, 'builtin');
-
-/**
- * Convert a file path to the appropriate URI based on content analysis
- * @param fileUri The file path to convert
- * @param isStandardApexNamespace Function to check if a namespace is standard Apex
- * @returns The appropriate URI
- */
-export const convertToAppropriateUri = (
-  fileUri: string,
-  isStandardApexNamespace: (namespace: string) => boolean,
-): string => {
-  // Check if this is a standard Apex class
-  if (fileUri.includes('/') && fileUri.endsWith('.cls')) {
-    const namespace = fileUri.split('/')[0];
-    if (isStandardApexNamespace(namespace)) {
-      return createApexLibUri(fileUri);
-    }
-  }
-
-  return createFileUri(fileUri);
-};
-
-/**
- * Get the file path from any supported URI type
- * For VS Code web URIs and other non-standard protocols, returns the URI as-is
- * since they should be treated as opaque identifiers.
+ * Get the file path from any supported URI type.
+ * Only apexlib:// is rewritten to a resource path; all other URIs are returned as-is.
  *
  * @param uri The URI to extract path from
- * @returns The file path or the URI itself for non-standard protocols
+ * @returns The StandardApexLibrary-relative path for apexlib, otherwise the URI unchanged
  */
 export const getFilePathFromUri = (uri: string): string => {
-  const protocol = getProtocolType(uri);
-
-  switch (protocol) {
-    case 'file':
-      return extractFilePath(uri);
-    case 'apexlib':
-      return extractApexLibPath(uri);
-    case 'builtin':
-      return extractBuiltinType(uri);
-    case 'other':
-      // For VS Code web URIs and other non-standard protocols, return as-is
-      // These are opaque identifiers that should be preserved
-      return uri;
-    default:
-      // Plain path without protocol - return as-is
-      return uri;
+  if (uri.startsWith('apexlib://')) {
+    return extractApexLibPath(uri);
   }
+  return uri;
 };

--- a/packages/apex-parser-ast/src/types/UriBasedIdGenerator.ts
+++ b/packages/apex-parser-ast/src/types/UriBasedIdGenerator.ts
@@ -8,11 +8,10 @@
 
 import { normalizeApexPath } from '../utils/PathUtils';
 import {
-  getProtocolType,
+  hasUriScheme,
   createApexLibUri,
   createFileUri,
   isStandardApexUri,
-  isUserCodeUri,
   getFilePathFromUri,
 } from './ProtocolHandler';
 
@@ -22,10 +21,8 @@ import {
  * @returns Proper URI string
  */
 const convertToUri = (fileUri: string): string => {
-  // If the fileUri is already a URI (has protocol), return it as-is
-  const protocol = getProtocolType(fileUri);
-  if (protocol !== null) {
-    return fileUri; // Valid URI, return as-is
+  if (hasUriScheme(fileUri)) {
+    return fileUri;
   }
 
   // Normalize the path to ensure consistent standard Apex path detection
@@ -175,50 +172,38 @@ export const generateSymbolId = (
 };
 
 /**
- * Extract just the file path from a URI that may contain symbol name and line number
- * Uses the same logic as parseSymbolId() to handle all protocols consistently
- * @param uri The URI that may contain symbol information
- * @returns The base file URI without symbol parts
+ * Extract just the file path from a URI that may contain symbol name and line number.
+ * Scheme-agnostic: treats file://, memfs:, vscode-test-web://, built-in://, apexlib://,
+ * and plain paths the same. Only {@link getFilePathFromUri} in ProtocolHandler
+ * rewrites apexlib:// (stdlib resource path).
+ *
+ * Order: extension heuristic (works for memfs:/…/Foo.cls:Symbol and file:///…/Foo.cls:Symbol),
+ * then hierarchical :// URIs (path colon or authority colon, e.g. built-in://apex:Name).
  */
 export const extractFilePathFromUri = (uri: string): string => {
-  const protocol = getProtocolType(uri);
-
-  // For known double-slash protocols, find the symbol separator after the authority
-  if (protocol === 'file' || protocol === 'apexlib' || protocol === 'builtin') {
-    // file:///path/to/file.cls:ClassName  ->  file:///path/to/file.cls
-    // built-in://apex:SomeName            ->  built-in://apex
-    const protocolEnd = uri.indexOf('://');
-    if (protocolEnd !== -1) {
-      const afterScheme = protocolEnd + 3; // Skip "://"
-      const pathStart = uri.indexOf('/', afterScheme);
-      if (pathStart !== -1) {
-        // Has path component: symbol separator is a colon within the path
-        const symbolSep = uri.indexOf(':', pathStart);
-        if (symbolSep !== -1) {
-          return uri.substring(0, symbolSep);
-        }
-      } else {
-        // No path component (e.g., built-in://apex:Name) — colon in authority
-        const symbolSep = uri.indexOf(':', afterScheme);
-        if (symbolSep !== -1) {
-          return uri.substring(0, symbolSep);
-        }
-      }
-    }
-    return uri;
-  }
-
-  // For 'other' protocols (memfs:, vscode-test-web://, etc.) and plain paths,
-  // find the colon that separates URI from symbol parts.
-  // A symbol separator colon appears AFTER the last path segment (after the file extension).
-  // Use file-extension heuristic: if the URI contains a recognized extension, the symbol
-  // separator is the first colon after that extension.
-  const extMatch = uri.match(/\.(cls|trigger|apex|soql|page|component|app)/);
+  const extMatch = uri.match(/\.(cls|trigger|apex)/);
   if (extMatch) {
     const extEnd = extMatch.index! + extMatch[0].length;
     const symbolSep = uri.indexOf(':', extEnd);
     if (symbolSep !== -1) {
       return uri.substring(0, symbolSep);
+    }
+  }
+
+  const protocolEnd = uri.indexOf('://');
+  if (protocolEnd !== -1) {
+    const afterScheme = protocolEnd + 3;
+    const pathStart = uri.indexOf('/', afterScheme);
+    if (pathStart !== -1) {
+      const symbolSep = uri.indexOf(':', pathStart);
+      if (symbolSep !== -1) {
+        return uri.substring(0, symbolSep);
+      }
+    } else {
+      const symbolSep = uri.indexOf(':', afterScheme);
+      if (symbolSep !== -1) {
+        return uri.substring(0, symbolSep);
+      }
     }
   }
 
@@ -260,16 +245,6 @@ export const parseSymbolId = (
 export const isStandardApexId = (id: string): boolean => {
   const parsed = parseSymbolId(id);
   return isStandardApexUri(parsed.uri);
-};
-
-/**
- * Check if an ID is a user code ID
- * @param id The ID to check
- * @returns True if this is a user code ID
- */
-export const isUserCodeId = (id: string): boolean => {
-  const parsed = parseSymbolId(id);
-  return isUserCodeUri(parsed.uri);
 };
 
 /**

--- a/packages/apex-parser-ast/test/types/ProtocolHandler.test.ts
+++ b/packages/apex-parser-ast/test/types/ProtocolHandler.test.ts
@@ -7,86 +7,60 @@
  */
 
 import {
-  getProtocolType,
-  hasProtocol,
+  hasUriScheme,
   createFileUri,
+  createApexLibUri,
+  getFilePathFromUri,
 } from '../../src/types/ProtocolHandler';
 
 describe('ProtocolHandler', () => {
-  describe('getProtocolType', () => {
-    it('should recognize file:// URIs', () => {
-      expect(getProtocolType('file:///path/to/File.cls')).toBe('file');
+  describe('hasUriScheme', () => {
+    it('should return true for file:// URIs', () => {
+      expect(hasUriScheme('file:///path/to/File.cls')).toBe(true);
     });
 
-    it('should recognize apexlib:// URIs', () => {
+    it('should return true for apexlib:// URIs', () => {
       expect(
-        getProtocolType(
+        hasUriScheme(
           'apexlib://resources/StandardApexLibrary/System/String.cls',
         ),
-      ).toBe('apexlib');
-    });
-
-    it('should recognize built-in:// URIs', () => {
-      expect(getProtocolType('built-in://Object')).toBe('builtin');
-    });
-
-    it('should recognize double-slash other protocols', () => {
-      expect(getProtocolType('vscode-test-web://mount/path/File.cls')).toBe(
-        'other',
-      );
-    });
-
-    it('should recognize single-slash memfs: URIs', () => {
-      expect(getProtocolType('memfs:/MyProject/path/File.cls')).toBe('other');
-    });
-
-    it('should recognize single-slash vscode-vfs: URIs', () => {
-      expect(getProtocolType('vscode-vfs:/path/File.cls')).toBe('other');
-    });
-
-    it('should return null for plain relative paths', () => {
-      expect(getProtocolType('src/classes/File.cls')).toBeNull();
-    });
-
-    it('should return null for plain absolute paths', () => {
-      expect(getProtocolType('/Users/me/src/File.cls')).toBeNull();
-    });
-
-    it('should return null for Windows drive letters (backslash)', () => {
-      expect(getProtocolType('C:\\Users\\me\\File.cls')).toBeNull();
-    });
-
-    it('should return null for Windows drive letters (forward slash)', () => {
-      expect(getProtocolType('C:/Users/me/File.cls')).toBeNull();
-    });
-
-    it('should return null for empty string', () => {
-      expect(getProtocolType('')).toBeNull();
-    });
-  });
-
-  describe('hasProtocol', () => {
-    it('should detect file protocol', () => {
-      expect(hasProtocol('file:///path/to/File.cls', 'file')).toBe(true);
-      expect(hasProtocol('memfs:/path/File.cls', 'file')).toBe(false);
-    });
-
-    it('should detect other protocol for double-slash URIs', () => {
-      expect(
-        hasProtocol('vscode-test-web://mount/path/File.cls', 'other'),
       ).toBe(true);
     });
 
-    it('should detect other protocol for single-slash URIs', () => {
-      expect(hasProtocol('memfs:/MyProject/path/File.cls', 'other')).toBe(true);
+    it('should return true for built-in:// URIs', () => {
+      expect(hasUriScheme('built-in://Object')).toBe(true);
     });
 
-    it('should not detect other for known protocols', () => {
-      expect(hasProtocol('file:///path/File.cls', 'other')).toBe(false);
+    it('should return true for double-slash other protocols', () => {
+      expect(hasUriScheme('vscode-test-web://mount/path/File.cls')).toBe(true);
     });
 
-    it('should not detect other for Windows forward-slash paths', () => {
-      expect(hasProtocol('C:/Users/me/File.cls', 'other')).toBe(false);
+    it('should return true for single-slash memfs: URIs', () => {
+      expect(hasUriScheme('memfs:/MyProject/path/File.cls')).toBe(true);
+    });
+
+    it('should return true for single-slash vscode-vfs: URIs', () => {
+      expect(hasUriScheme('vscode-vfs:/path/File.cls')).toBe(true);
+    });
+
+    it('should return false for plain relative paths', () => {
+      expect(hasUriScheme('src/classes/File.cls')).toBe(false);
+    });
+
+    it('should return false for plain absolute paths', () => {
+      expect(hasUriScheme('/Users/me/src/File.cls')).toBe(false);
+    });
+
+    it('should return false for Windows drive letters (backslash)', () => {
+      expect(hasUriScheme('C:\\Users\\me\\File.cls')).toBe(false);
+    });
+
+    it('should return false for Windows drive letters (forward slash)', () => {
+      expect(hasUriScheme('C:/Users/me/File.cls')).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(hasUriScheme('')).toBe(false);
     });
   });
 
@@ -113,6 +87,20 @@ describe('ProtocolHandler', () => {
       expect(createFileUri('vscode-test-web://mount/File.cls')).toBe(
         'vscode-test-web://mount/File.cls',
       );
+    });
+  });
+
+  describe('getFilePathFromUri', () => {
+    it('should map apexlib URIs to StandardApexLibrary-relative paths', () => {
+      const uri = createApexLibUri('System/System.cls');
+      expect(getFilePathFromUri(uri)).toBe('System/System.cls');
+    });
+
+    it('should pass through file:// and other URIs unchanged', () => {
+      expect(getFilePathFromUri('file:///path/File.cls')).toBe(
+        'file:///path/File.cls',
+      );
+      expect(getFilePathFromUri('memfs:/p/File.cls')).toBe('memfs:/p/File.cls');
     });
   });
 });

--- a/packages/apex-parser-ast/test/types/UriBasedIdGenerator.test.ts
+++ b/packages/apex-parser-ast/test/types/UriBasedIdGenerator.test.ts
@@ -10,7 +10,6 @@ import {
   generateSymbolId,
   parseSymbolId,
   isStandardApexId,
-  isUserCodeId,
   getFilePathFromId,
   extractFilePathFromUri,
 } from '../../src/types/UriBasedIdGenerator';
@@ -135,20 +134,14 @@ describe('UriBasedIdGenerator', () => {
       expect(isStandardApexId(userId)).toBe(false);
     });
 
-    it('should identify user code IDs correctly', () => {
-      const standardId = `${createApexLibUri('System/System.cls')}:System`;
-      const userId = `${createFileUri('/path/to/MyClass.cls')}:MyClass`;
-
-      expect(isUserCodeId(standardId)).toBe(false);
-      expect(isUserCodeId(userId)).toBe(true);
-    });
-
     it('should extract file paths correctly', () => {
       const standardId = `${createApexLibUri('System/System.cls')}:System`;
       const userId = `${createFileUri('/path/to/MyClass.cls')}:MyClass`;
 
       expect(getFilePathFromId(standardId)).toBe('System/System.cls');
-      expect(getFilePathFromId(userId)).toBe('/path/to/MyClass.cls');
+      expect(getFilePathFromId(userId)).toBe(
+        createFileUri('/path/to/MyClass.cls'),
+      );
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

Simplifies URI protocol handling so only `apexlib://` is explicitly discriminated. All other schemes (`file://`, `memfs:`, `vscode-test-web://`, etc.) are pass-through.

- Replace `UriProtocol` union, `getProtocolType`, `hasProtocol`, `isUserCodeUri`, `PROTOCOL_PREFIXES` with a single `hasUriScheme` helper (internal to `createFileUri` and `convertToUri`)
- `getFilePathFromUri` only rewrites `apexlib://` → stdlib-relative path; everything else returned unchanged
- `extractFilePathFromUri` unified to one scheme-agnostic flow (extension heuristic, then `://` authority fallback)
- Remove dead exports: `createBuiltinUri`, `extractBuiltinType`, `isBuiltinUri`, `convertToAppropriateUri`, `BUILTIN_URI_PREFIX`, `isUserCodeId`
- Replace redundant `hasUriScheme(x) ? x : createFileUri(x)` pattern in ApexSymbolManager with direct `createFileUri(x)` calls

Net: −209 lines across 5 files.

### What issues does this PR fix or reference?

@W-21638371@