### PR TITLE
build(apex-lsp-vscode-extension): bump @salesforce/apex-tmlanguage to ^2.0.3 W-21964610

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5670,9 +5670,9 @@
       "link": true
     },
     "node_modules/@salesforce/apex-tmlanguage": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/apex-tmlanguage/-/apex-tmlanguage-2.0.2.tgz",
-      "integrity": "sha512-j7WpUCVlUUuYAmC6oiFDzFc0SDNSupWN8CMnf6PxOFN8guN3ZQ3baZ2KDkBvaIyey3AiIy5aneDmfkPQhnEaCQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-tmlanguage/-/apex-tmlanguage-2.0.3.tgz",
+      "integrity": "sha512-nWdEG14infcL9vpyWeDIA8A+nFuDXM7xWN0L5EvFLF8XfTnNUDlpPnA/etQXZZrcWcIa/1Zbg4o4wHNmfCZM4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -29123,7 +29123,7 @@
       "devDependencies": {
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
-        "@salesforce/apex-tmlanguage": "^2.0.2",
+        "@salesforce/apex-tmlanguage": "^2.0.3",
         "@salesforce/esbuild-presets": "^0.1.0",
         "@salesforce/vscode-services": "^66.2.2",
         "@types/vscode": "^1.90.0",

--- a/packages/apex-lsp-vscode-extension/package.json
+++ b/packages/apex-lsp-vscode-extension/package.json
@@ -880,7 +880,7 @@
     "@salesforce/vscode-services": "^66.2.2",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
-    "@salesforce/apex-tmlanguage": "^2.0.2",
+    "@salesforce/apex-tmlanguage": "^2.0.3",
     "@salesforce/esbuild-presets": "^0.1.0",
     "@types/vscode": "^1.90.0",
     "@vscode/vsce": "^3.7.1",


### PR DESCRIPTION
### What does this PR do?

- Bump `@salesforce/apex-tmlanguage` to `^2.0.3` in `packages/apex-lsp-vscode-extension`
- Refresh `package-lock.json`

### What issues does this PR fix or reference?

@W-21964610@


Made with [Cursor](https://cursor.com)