### PR TITLE
refactor(apex-lsp-parser-ast): eliminate `any` type usage in semantic validators - W-21324737

### DIFF
--- a/packages/apex-parser-ast/src/parser/listeners/ApexSymbolCollectorListener.ts
+++ b/packages/apex-parser-ast/src/parser/listeners/ApexSymbolCollectorListener.ts
@@ -148,6 +148,7 @@ import {
   isVariableOrFieldDeclarationContext,
   isMethodDeclarationContext,
   isMethodCallContext,
+  getTypeNameFromCreatedName,
 } from '../../utils/contextTypeGuards';
 import { ResourceLoader } from '../../utils/resourceLoader';
 import { DEFAULT_SALESFORCE_API_VERSION } from '../../constants/constants';
@@ -5196,24 +5197,9 @@ export class ApexSymbolCollectorListener
       }
 
       // Handle regular class constructor calls
-      const anyId = firstPair.anyId();
-      if (anyId) {
-        const typeName = anyId.text;
-
-        // Build qualified name if there are multiple pairs
-        if (idCreatedNamePairs.length > 1) {
-          const parts: string[] = [typeName];
-          for (let i = 1; i < idCreatedNamePairs.length; i++) {
-            const pair = idCreatedNamePairs[i];
-            const pairId = pair.anyId();
-            if (pairId) {
-              parts.push(pairId.text);
-            }
-          }
-          return createTypeInfo(parts.join('.'));
-        }
-
-        return createTypeInfo(typeName);
+      const qualifiedName = getTypeNameFromCreatedName(createdName);
+      if (qualifiedName) {
+        return createTypeInfo(qualifiedName);
       }
     }
 

--- a/packages/apex-parser-ast/src/semantics/validation/validators/AbstractMethodBodyValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/AbstractMethodBodyValidator.ts
@@ -8,7 +8,7 @@
 
 import { Effect } from 'effect';
 import type { SymbolTable, MethodSymbol } from '../../../types/symbol';
-import { isMethodSymbol } from '../../../utils/symbolNarrowing';
+import { isBlockSymbol, isMethodSymbol } from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -82,9 +82,9 @@ export const AbstractMethodBodyValidator: Validator = {
         // Find class block first (if it exists)
         const classBlock = allSymbols.find(
           (s) =>
-            s.kind === 'block' &&
+            isBlockSymbol(s) &&
             s.parentId === method.parentId &&
-            (s as any).scopeType === 'class',
+            s.scopeType === 'class',
         );
         const classBlockId = classBlock?.id;
 
@@ -124,7 +124,8 @@ export const AbstractMethodBodyValidator: Validator = {
                   (s) => s.parentId === method.id && s.kind === 'block',
                 );
                 const methodBlock = childBlocks.find(
-                  (block) => (block as any).scopeType === 'method',
+                  (block) =>
+                    isBlockSymbol(block) && block.scopeType === 'method',
                 );
                 if (methodBlock) {
                   const methodBlockChildren = allSymbols.filter(

--- a/packages/apex-parser-ast/src/semantics/validation/validators/AbstractMethodImplementationValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/AbstractMethodImplementationValidator.ts
@@ -14,8 +14,11 @@ import type {
   MethodSymbol,
   ScopeSymbol,
 } from '../../../types/symbol';
-import { SymbolKind } from '../../../types/symbol';
-import { isMethodSymbol, isBlockSymbol } from '../../../utils/symbolNarrowing';
+import {
+  isMethodSymbol,
+  isBlockSymbol,
+  isClassSymbol,
+} from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -43,7 +46,7 @@ function findParentClassInSameFile(
   const childFileUri = childClass.fileUri;
 
   const allClasses = allSymbols.filter(
-    (s) => s.kind === SymbolKind.Class && s.fileUri === childFileUri,
+    (s) => isClassSymbol(s) && s.fileUri === childFileUri,
   ) as TypeSymbol[];
 
   // Check if child class is an inner class extending its outer class
@@ -103,7 +106,6 @@ function findMethodsInClass(
   for (const symbol of allSymbols) {
     if (
       isMethodSymbol(symbol) &&
-      symbol.kind === SymbolKind.Method &&
       (symbol.parentId === classBlock?.id || symbol.parentId === classSymbol.id)
     ) {
       methods.push(symbol);
@@ -211,9 +213,7 @@ export const AbstractMethodImplementationValidator: Validator = {
       const tier = options.tier || ValidationTier.IMMEDIATE;
 
       // Get all classes in the file
-      const classes = allSymbols.filter(
-        (symbol) => symbol.kind === SymbolKind.Class,
-      ) as TypeSymbol[];
+      const classes = allSymbols.filter(isClassSymbol);
 
       // Check each concrete class
       for (const cls of classes) {
@@ -238,7 +238,7 @@ export const AbstractMethodImplementationValidator: Validator = {
         ) as ScopeSymbol | undefined;
 
         const classMethods = allSymbols.filter((s) => {
-          if (s.kind !== SymbolKind.Method) {
+          if (!isMethodSymbol(s)) {
             return false;
           }
           return (

--- a/packages/apex-parser-ast/src/semantics/validation/validators/AnnotationPropertyValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/AnnotationPropertyValidator.ts
@@ -10,7 +10,6 @@ import { Effect, Layer } from 'effect';
 import type {
   SymbolTable,
   MethodSymbol,
-  TypeSymbol,
   Annotation,
 } from '../../../types/symbol';
 import type {
@@ -24,6 +23,12 @@ import { ValidationError, type Validator } from '../ValidatorRegistry';
 import { localizeTyped } from '../../../i18n/messageInstance';
 import { ErrorCodes } from '../../../generated/ErrorCodes';
 import { SymbolKind } from '../../../types/symbol';
+import {
+  isClassOrInterfaceSymbol,
+  isMethodSymbol,
+  isFieldSymbol,
+  isPropertySymbol,
+} from '../../../utils/symbolNarrowing';
 import {
   ArtifactLoadingHelper,
   ArtifactLoadingHelperLive,
@@ -836,12 +841,7 @@ export const AnnotationPropertyValidator: Validator = {
       const allSymbols = symbolTable.getAllSymbols();
 
       // Validate @RestResource classes
-      const classes = allSymbols.filter(
-        (symbol): symbol is TypeSymbol =>
-          (symbol.kind === SymbolKind.Class ||
-            symbol.kind === SymbolKind.Interface) &&
-          'annotations' in symbol,
-      );
+      const classes = allSymbols.filter(isClassOrInterfaceSymbol);
 
       for (const classSymbol of classes) {
         if (!classSymbol.annotations) {
@@ -1397,10 +1397,7 @@ export const AnnotationPropertyValidator: Validator = {
               // @isTest on class with @TestSetup methods: cannot have seeAllData
               // Check if there are any @TestSetup methods in the file
               // (TIER 1: same-file only, so all methods belong to classes in this file)
-              const allMethods = allSymbols.filter(
-                (symbol): symbol is MethodSymbol =>
-                  symbol.kind === SymbolKind.Method && 'parameters' in symbol,
-              );
+              const allMethods = allSymbols.filter(isMethodSymbol);
               const hasTestSetupMethods = allMethods.some((method) =>
                 method.annotations?.some(
                   (ann) => ann.name.toLowerCase() === 'testsetup',
@@ -1428,10 +1425,7 @@ export const AnnotationPropertyValidator: Validator = {
       }
 
       // Validate @InvocableMethod methods
-      const methods = allSymbols.filter(
-        (symbol): symbol is MethodSymbol =>
-          symbol.kind === SymbolKind.Method && 'parameters' in symbol,
-      );
+      const methods = allSymbols.filter(isMethodSymbol);
 
       for (const method of methods) {
         // General annotation property validation for method annotations
@@ -1984,10 +1978,7 @@ export const AnnotationPropertyValidator: Validator = {
 
       // Validate field and property annotations
       const fieldsAndProperties = allSymbols.filter(
-        (symbol) =>
-          (symbol.kind === SymbolKind.Field ||
-            symbol.kind === SymbolKind.Property) &&
-          'annotations' in symbol,
+        (symbol) => isFieldSymbol(symbol) || isPropertySymbol(symbol),
       );
 
       for (const fieldOrProperty of fieldsAndProperties) {

--- a/packages/apex-parser-ast/src/semantics/validation/validators/AnnotationPropertyValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/AnnotationPropertyValidator.ts
@@ -736,7 +736,7 @@ function resolveTestForTypes(
       const expectedKind =
         ref.prefix === 'ApexClass' ? SymbolKind.Class : SymbolKind.Trigger;
 
-      const found = symbols.find((s: any) => s.kind === expectedKind) as any;
+      const found = symbols.find((s) => s.kind === expectedKind);
 
       if (found) {
         results.set(ref.typeName, { found: true, kind: found.kind });
@@ -769,9 +769,7 @@ function resolveTestForTypes(
           const symbols = symbolManager.findSymbolByName(typeName);
           const expectedKind =
             ref.prefix === 'ApexClass' ? SymbolKind.Class : SymbolKind.Trigger;
-          const found = symbols.find(
-            (s: any) => s.kind === expectedKind,
-          ) as any;
+          const found = symbols.find((s) => s.kind === expectedKind);
           if (found) {
             results.set(typeName, { found: true, kind: found.kind });
           }
@@ -1355,7 +1353,7 @@ export const AnnotationPropertyValidator: Validator = {
                   errors.push({
                     message: formatError.message,
                     location: annotation.location,
-                    code: formatError.code as any,
+                    code: formatError.code,
                   });
                 }
 
@@ -1874,7 +1872,7 @@ export const AnnotationPropertyValidator: Validator = {
                     errors.push({
                       message: formatError.message,
                       location: annotation.location,
-                      code: formatError.code as any,
+                      code: formatError.code,
                     });
                   }
 
@@ -2400,7 +2398,7 @@ export const AnnotationPropertyValidator: Validator = {
                   errors.push({
                     message: formatError.message,
                     location: annotation.location,
-                    code: formatError.code as any,
+                    code: formatError.code,
                   });
                 }
 

--- a/packages/apex-parser-ast/src/semantics/validation/validators/AssignmentAccessValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/AssignmentAccessValidator.ts
@@ -154,9 +154,8 @@ function validateChainedWriteAccess(
 
     // Set validation state on final reference
     if (ref.accessValidationState === 'syntax_only') {
-      (ref as any).accessValidationState = 'fully_validated';
-      (ref as any).validatedAccess =
-        errors.length === 0 ? ref.access : 'invalid';
+      ref.accessValidationState = 'fully_validated';
+      ref.validatedAccess = errors.length === 0 ? ref.access : 'invalid';
     }
   });
 }

--- a/packages/apex-parser-ast/src/semantics/validation/validators/AuraEnabledValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/AuraEnabledValidator.ts
@@ -22,7 +22,11 @@ import { ValidationTier } from '../ValidationTier';
 import { ValidationError, type Validator } from '../ValidatorRegistry';
 import { localizeTyped } from '../../../i18n/messageInstance';
 import { ErrorCodes } from '../../../generated/ErrorCodes';
-import { SymbolKind } from '../../../types/symbol';
+import {
+  isMethodSymbol,
+  isFieldSymbol,
+  isPropertySymbol,
+} from '../../../utils/symbolNarrowing';
 
 /**
  * Helper to check if a method has @AuraEnabled annotation
@@ -73,14 +77,9 @@ export const AuraEnabledValidator: Validator = {
       // Get all @AuraEnabled methods
       const auraMethods: MethodSymbol[] = [];
       for (const symbol of allSymbols) {
-        if (
-          symbol.kind === SymbolKind.Method &&
-          'parameters' in symbol &&
-          'returnType' in symbol
-        ) {
-          const method = symbol as MethodSymbol;
-          if (hasAuraEnabledAnnotation(method)) {
-            auraMethods.push(method);
+        if (isMethodSymbol(symbol)) {
+          if (hasAuraEnabledAnnotation(symbol)) {
+            auraMethods.push(symbol);
           }
         }
       }
@@ -89,19 +88,13 @@ export const AuraEnabledValidator: Validator = {
       // Note: @AuraEnabled is valid on Properties, but fields can also have annotations
       const auraFields: VariableSymbol[] = [];
       for (const symbol of allSymbols) {
-        if (
-          (symbol.kind === SymbolKind.Field ||
-            symbol.kind === SymbolKind.Property) &&
-          'type' in symbol
-        ) {
-          const field = symbol as VariableSymbol;
-          // Check annotations directly from ApexSymbol
+        if (isFieldSymbol(symbol) || isPropertySymbol(symbol)) {
           const hasAuraEnabled =
-            field.annotations?.some(
+            symbol.annotations?.some(
               (ann) => ann.name.toLowerCase() === 'auraenabled',
             ) || false;
           if (hasAuraEnabled) {
-            auraFields.push(field);
+            auraFields.push(symbol);
           }
         }
       }

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ClassHierarchyValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ClassHierarchyValidator.ts
@@ -7,12 +7,8 @@
  */
 
 import { Effect } from 'effect';
-import type {
-  SymbolTable,
-  ApexSymbol,
-  TypeSymbol,
-} from '../../../types/symbol';
-import { SymbolKind } from '../../../types/symbol';
+import type { SymbolTable, TypeSymbol } from '../../../types/symbol';
+import { isClassSymbol } from '../../../utils/symbolNarrowing';
 import type {
   ValidationErrorInfo,
   ValidationWarningInfo,
@@ -73,9 +69,7 @@ export const ClassHierarchyValidator: Validator = {
       const allSymbols = symbolTable.getAllSymbols();
 
       // Filter to class symbols
-      const classes = allSymbols.filter(
-        (symbol) => symbol.kind === SymbolKind.Class,
-      ) as TypeSymbol[];
+      const classes = allSymbols.filter(isClassSymbol);
 
       // Check 1: Missing superclasses and invalid types (first pass)
       const missingSuperclasses: string[] = [];
@@ -110,17 +104,8 @@ export const ClassHierarchyValidator: Validator = {
             });
           }
 
-          // Check 4: Superclass must be a class (not interface/enum)
-          // This is already enforced by finding in classes array, but validate explicitly
-          if (superClass.kind !== SymbolKind.Class) {
-            errors.push({
-              message:
-                `Class '${cls.name}' cannot extend '${superClass.name}' ` +
-                `(expected class, found ${superClass.kind})`,
-              location: cls.location,
-              code: 'INVALID_SUPERCLASS_TYPE',
-            });
-          }
+          // Superclass is already guaranteed to be a class kind since
+          // it was found in the `classes` array filtered by isClassSymbol.
         }
       }
 
@@ -135,9 +120,7 @@ export const ClassHierarchyValidator: Validator = {
 
         for (const typeName of missingSuperclasses) {
           const symbols = symbolManager.findSymbolByName(typeName);
-          const classSymbol = symbols.find(
-            (s: ApexSymbol) => s.kind === SymbolKind.Class,
-          ) as TypeSymbol | undefined;
+          const classSymbol = symbols.find(isClassSymbol);
 
           if (classSymbol) {
             foundInManager.push(classSymbol);
@@ -170,9 +153,7 @@ export const ClassHierarchyValidator: Validator = {
             ...loadResult.alreadyLoaded,
           ]) {
             const symbols = symbolManager.findSymbolByName(typeName);
-            const classSymbol = symbols.find(
-              (s: ApexSymbol) => s.kind === SymbolKind.Class,
-            ) as TypeSymbol | undefined;
+            const classSymbol = symbols.find(isClassSymbol);
 
             if (classSymbol && !foundInManager.includes(classSymbol)) {
               loadedClasses.push(classSymbol);
@@ -193,9 +174,7 @@ export const ClassHierarchyValidator: Validator = {
         // Use getAllSymbolsForCompletion() which is available on ISymbolManager interface
         const allSymbolsFromManager =
           symbolManager.getAllSymbolsForCompletion();
-        const managerClasses = allSymbolsFromManager.filter(
-          (s: ApexSymbol) => s.kind === SymbolKind.Class,
-        ) as TypeSymbol[];
+        const managerClasses = allSymbolsFromManager.filter(isClassSymbol);
 
         // Merge with current classes, avoiding duplicates
         const classNames = new Set(allClasses.map((c) => c.name.toLowerCase()));
@@ -268,16 +247,8 @@ export const ClassHierarchyValidator: Validator = {
           });
         }
 
-        // Check invalid type (shouldn't happen if loaded correctly, but validate)
-        if (superClass.kind !== SymbolKind.Class) {
-          errors.push({
-            message:
-              `Class '${cls.name}' cannot extend '${superClass.name}' ` +
-              `(expected class, found ${superClass.kind})`,
-            location: cls.location,
-            code: 'INVALID_SUPERCLASS_TYPE',
-          });
-        }
+        // Superclass is already guaranteed to be a class kind since
+        // it was found in the `allClasses` array filtered by isClassSymbol.
       }
 
       yield* Effect.logDebug(

--- a/packages/apex-parser-ast/src/semantics/validation/validators/CollectionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/CollectionValidator.ts
@@ -45,6 +45,7 @@ import type { ParserRuleContext } from 'antlr4ts';
 import { ISymbolManager } from '../ArtifactLoadingHelper';
 import type { ISymbolManager as ISymbolManagerInterface } from '../../../types/ISymbolManager';
 import { SymbolKind } from '../../../types/symbol';
+import { isFieldSymbol } from '../../../utils/symbolNarrowing';
 import {
   resolveExpressionTypeRecursive,
   isNumericType,
@@ -1123,7 +1124,7 @@ function validateListIndexType(
       if (
         variable.kind === SymbolKind.Variable ||
         variable.kind === SymbolKind.Parameter ||
-        variable.kind === SymbolKind.Field
+        isFieldSymbol(variable)
       ) {
         const varSymbol = variable as VariableSymbol;
         if (varSymbol.type?.name) {

--- a/packages/apex-parser-ast/src/semantics/validation/validators/CollectionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/CollectionValidator.ts
@@ -23,6 +23,7 @@ import {
   MethodCallExpressionContext,
   DotExpressionContext,
   DotMethodCallContext,
+  TypeRefContext,
 } from '@apexdevtools/apex-parser';
 import type {
   SymbolTable,
@@ -185,121 +186,56 @@ class CollectionListener extends BaseApexParserListener<void> {
       return;
     }
 
-    // Check for collection types (List, Set, Map)
-    let createdNameTypeName = (createdName as any).typeName?.();
-    let listToken: any = null;
-    let setToken: any = null;
-    let mapToken: any = null;
-
-    if (createdNameTypeName) {
-      listToken = createdNameTypeName.LIST?.() || null;
-      setToken = createdNameTypeName.SET?.() || null;
-      mapToken = createdNameTypeName.MAP?.() || null;
+    // Grammar: createdName : idCreatedNamePair (DOT idCreatedNamePair)*
+    // Grammar: idCreatedNamePair : anyId (LT typeList GT)?
+    // Grammar: anyId : Identifier | LIST | SET | MAP | ...
+    const idCreatedNamePairs = createdName.idCreatedNamePair();
+    if (!idCreatedNamePairs || idCreatedNamePairs.length === 0) {
+      return;
     }
 
-    // If not found, check idCreatedNamePair structure
-    if (!listToken && !setToken && !mapToken) {
-      const idCreatedNamePairs = createdName.idCreatedNamePair();
-      if (idCreatedNamePairs && idCreatedNamePairs.length > 0) {
-        const firstPair = idCreatedNamePairs[0];
-        const anyId = firstPair.anyId?.();
-        const pairTypeName = (firstPair as any).typeName?.();
-        if (pairTypeName) {
-          listToken = pairTypeName.LIST?.() || null;
-          setToken = pairTypeName.SET?.() || null;
-          mapToken = pairTypeName.MAP?.() || null;
-        } else if (anyId) {
-          // For idCreatedNamePair, check anyId directly using parser methods
-          // Grammar: anyId : Identifier | LIST | SET | MAP | ...
-          // AnyIdContext should expose LIST(), SET(), MAP() methods
-          listToken = (anyId as any).LIST?.() || null;
-          setToken = (anyId as any).SET?.() || null;
-          mapToken = (anyId as any).MAP?.() || null;
-        }
-      }
+    const firstPair = idCreatedNamePairs[0];
+    const anyId = firstPair.anyId();
+    if (!anyId) {
+      return;
     }
+
+    const listToken = anyId.LIST() ?? null;
+    const setToken = anyId.SET() ?? null;
+    const mapToken = anyId.MAP() ?? null;
 
     if (listToken || setToken || mapToken) {
       const collectionType = listToken ? 'List' : setToken ? 'Set' : 'Map';
 
-      // Extract element type from type arguments
       let elementType: string | undefined;
       let keyType: string | undefined;
       let valueType: string | undefined;
 
-      // Helper to extract type name from TypeRefContext
-      const extractTypeName = (typeRef: any): string | undefined => {
-        if (!typeRef) return undefined;
-        // Try typeName() first (more accurate)
-        const typeNames = typeRef.typeName?.();
+      const extractTypeName = (typeRef: TypeRefContext): string | undefined => {
+        const typeNames = typeRef.typeName();
         if (typeNames && typeNames.length > 0) {
           const typeName = typeNames[0];
-          const ids = typeName.id?.();
-          if (ids) {
-            if (Array.isArray(ids) && ids.length > 0) {
-              return ids.map((id: any) => id.text).join('.');
-            } else if (!Array.isArray(ids) && ids.text) {
-              return ids.text;
-            }
+          const id = typeName.id();
+          if (id) {
+            return id.text;
           }
         }
-        // Fallback to text
         return typeRef.text?.trim() || undefined;
       };
 
-      // Try to get type arguments from createdNameTypeName first
-      let typeRefs: any[] = [];
-      if (createdNameTypeName) {
-        const typeArguments = createdNameTypeName.typeArguments();
-        const typeList = typeArguments?.typeList();
-        typeRefs = typeList?.typeRef() || [];
-      } else {
-        // For idCreatedNamePair, check if createdName has typeArguments directly
-        const createdNameTypeArgs = (createdName as any).typeArguments?.();
-        if (createdNameTypeArgs) {
-          const typeList = createdNameTypeArgs.typeList?.();
-          typeRefs = typeList?.typeRef() || [];
-        } else {
-          // Check if firstPair has typeArguments
-          const idCreatedNamePairs = createdName.idCreatedNamePair();
-          if (idCreatedNamePairs && idCreatedNamePairs.length > 0) {
-            const firstPair = idCreatedNamePairs[0];
-            const pairTypeName = (firstPair as any).typeName?.();
-            if (pairTypeName) {
-              const typeArguments = pairTypeName.typeArguments();
-              const typeList = typeArguments?.typeList();
-              typeRefs = typeList?.typeRef() || [];
-            } else {
-              // Check if firstPair itself has typeArguments
-              const pairTypeArgs = (firstPair as any).typeArguments?.();
-              if (pairTypeArgs) {
-                const typeList = pairTypeArgs.typeList?.();
-                typeRefs = typeList?.typeRef() || [];
-              } else {
-                // For idCreatedNamePair, use parser method: typeList() from grammar rule
-                // Grammar: idCreatedNamePair : anyId (LT typeList GT)?
-                const typeList = firstPair.typeList?.();
-                if (typeList) {
-                  typeRefs = typeList.typeRef() || [];
-                }
-              }
-            }
-          }
-        }
-      }
+      // Grammar: idCreatedNamePair : anyId (LT typeList GT)?
+      const typeList = firstPair.typeList();
+      const typeRefs: TypeRefContext[] = typeList?.typeRef() ?? [];
 
       if (collectionType === 'Map' && typeRefs.length >= 2) {
-        // Map has key and value types
         keyType = extractTypeName(typeRefs[0]);
         valueType = extractTypeName(typeRefs[1]);
       } else if (typeRefs.length > 0) {
-        // List/Set has element type
         elementType = extractTypeName(typeRefs[0]);
       }
 
-      // Extract initializer text (if any)
-      const classCreatorRest = (creator as any).classCreatorRest?.();
-      const arguments_ = classCreatorRest?.arguments?.();
+      const classCreatorRest = creator.classCreatorRest();
+      const arguments_ = classCreatorRest?.arguments();
       const initializerText = arguments_?.text || '';
 
       this.collectionInitializers.push({
@@ -349,14 +285,12 @@ class CollectionListener extends BaseApexParserListener<void> {
         let baseExpression: ExpressionContext | null = null;
         const parent = ctx.parent;
         if (parent instanceof DotExpressionContext) {
-          const dotExpr = parent as DotExpressionContext;
-          const baseExpr = dotExpr.expression();
+          const baseExpr = parent.expression();
           if (baseExpr) {
             baseExpression = baseExpr;
           }
         }
 
-        // If we couldn't get base from parent, use the ctx itself as fallback
         if (!baseExpression) {
           baseExpression = ctx as ExpressionContext;
         }
@@ -402,8 +336,7 @@ class CollectionListener extends BaseApexParserListener<void> {
       let baseExpression: ExpressionContext | null = null;
       const parent = ctx.parent;
       if (parent instanceof DotExpressionContext) {
-        const dotExpr = parent as DotExpressionContext;
-        const baseExpr = dotExpr.expression();
+        const baseExpr = parent.expression();
         if (baseExpr) {
           baseExpression = baseExpr;
         }

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ConstructorValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ConstructorValidator.ts
@@ -44,6 +44,7 @@ import { ValidationTier } from '../ValidationTier';
 import { ValidationError, type Validator } from '../ValidatorRegistry';
 import { localizeTyped } from '../../../i18n/messageInstance';
 import { ErrorCodes } from '../../../generated/ErrorCodes';
+import type { ErrorCodeKey } from '../../../generated/messages_en_US';
 import { BaseApexParserListener } from '../../../parser/listeners/BaseApexParserListener';
 import { ISymbolManager } from '../ArtifactLoadingHelper';
 import { isContextType } from '../../../utils/contextTypeGuards';
@@ -135,21 +136,19 @@ class ConstructorListener extends BaseApexParserListener<void> {
     }
 
     // Check if this is a super() or this() call
-    const superToken = (methodCall as any).SUPER?.();
-    const thisToken = (methodCall as any).THIS?.();
+    const superToken = methodCall.SUPER?.();
+    const thisToken = methodCall.THIS?.();
 
     if (superToken || thisToken) {
       const isSuper = !!superToken;
       const line = ctx.start.line;
       const column = ctx.start.charPositionInLine;
 
-      // Get arguments from expressionList
       const expressionList = methodCall.expressionList?.();
       const args = expressionList
         ? this.extractArgumentsAsString(expressionList)
         : '';
 
-      // Get the statement containing this call
       const statementContext: StatementContext =
         this.statementStack.length > 0
           ? this.statementStack[this.statementStack.length - 1]
@@ -202,7 +201,7 @@ class ConstructorListener extends BaseApexParserListener<void> {
  */
 interface ConstructorBodyCheckResult {
   errors: Array<{
-    code: string;
+    code: ErrorCodeKey;
     line: number;
     column: number;
     message?: string;
@@ -230,7 +229,7 @@ function checkConstructorBody(
   symbolTable: SymbolTable,
 ): ConstructorBodyCheckResult {
   const errors: Array<{
-    code: string;
+    code: ErrorCodeKey;
     line: number;
     column: number;
     message?: string;
@@ -423,8 +422,8 @@ function extractMethodName(
         return id.text || null;
       }
       // For this() and super() calls, return null (they're constructor calls, not instance methods)
-      const thisToken = (methodCall as any).THIS?.();
-      const superToken = (methodCall as any).SUPER?.();
+      const thisToken = methodCall.THIS?.();
+      const superToken = methodCall.SUPER?.();
       if (thisToken || superToken) {
         return null; // Constructor calls are allowed
       }
@@ -551,16 +550,8 @@ function isStringLiteral(expr: ExpressionContext | ParserRuleContext): boolean {
           return !!literal.StringLiteral?.();
         }
       }
-      // Also check if primary has literalPrimary() method (alternative structure)
-      const literalPrimary = (primary as any).literalPrimary?.();
-      if (literalPrimary) {
-        const literal = literalPrimary.literal?.() as
-          | LiteralContext
-          | undefined;
-        if (literal) {
-          return !!literal.StringLiteral?.();
-        }
-      }
+      // LiteralPrimaryContext extends PrimaryContext — the instanceof check
+      // above already covers this case; no fallback needed.
     }
   }
 
@@ -585,23 +576,18 @@ function isNumericLiteral(
 ): boolean {
   if (!expr) return false;
 
-  // Check for PrimaryExpressionContext -> literalPrimary -> literal -> INTEGER_LITERAL or DECIMAL_LITERAL
   if (isContextType(expr, PrimaryExpressionContext)) {
     const primaryExpr = expr as PrimaryExpressionContext;
     const primary = primaryExpr.primary?.();
-    if (primary) {
-      const literalPrimary = (primary as any).literalPrimary?.();
-      if (literalPrimary) {
-        const literal = literalPrimary.literal?.() as
-          | LiteralContext
-          | undefined;
-        if (literal) {
-          // Use method calls like StringLiteral(), not properties like INTEGER_LITERAL
-          const intLiteral = literal.IntegerLiteral?.();
-          const longLiteral = literal.LongLiteral?.();
-          const numberLiteral = literal.NumberLiteral?.();
-          return !!(intLiteral || longLiteral || numberLiteral);
-        }
+    if (primary && isContextType(primary, LiteralPrimaryContext)) {
+      const literal = (primary as LiteralPrimaryContext).literal?.() as
+        | LiteralContext
+        | undefined;
+      if (literal) {
+        const intLiteral = literal.IntegerLiteral?.();
+        const longLiteral = literal.LongLiteral?.();
+        const numberLiteral = literal.NumberLiteral?.();
+        return !!(intLiteral || longLiteral || numberLiteral);
       }
     }
   }
@@ -627,18 +613,13 @@ function isBooleanLiteral(
 ): boolean {
   if (!expr) return false;
 
-  // Check for PrimaryExpressionContext -> literalPrimary -> literal -> BOOLEAN_LITERAL
   if (isContextType(expr, PrimaryExpressionContext)) {
     const primaryExpr = expr as PrimaryExpressionContext;
     const primary = primaryExpr.primary?.();
-    if (primary) {
-      const literalPrimary = (primary as any).literalPrimary?.();
-      if (literalPrimary) {
-        const literal = literalPrimary.literal?.();
-        if (literal) {
-          const booleanLiteral = (literal as any).BOOLEAN_LITERAL?.();
-          return !!booleanLiteral;
-        }
+    if (primary && isContextType(primary, LiteralPrimaryContext)) {
+      const literal = (primary as LiteralPrimaryContext).literal?.();
+      if (literal) {
+        return !!literal.BooleanLiteral?.();
       }
     }
   }
@@ -910,7 +891,7 @@ function validateConstructorSignature(
     // This is more reliable than getAllSymbolsForCompletion which may not include all constructors
     if (targetClass.fileUri) {
       // Try to get SymbolTable directly for more complete symbol access
-      const parentSymbolTable = (symbolManager as any).getSymbolTableForFile?.(
+      const parentSymbolTable = symbolManager.getSymbolTableForFile(
         targetClass.fileUri,
       );
       const fileSymbols = parentSymbolTable
@@ -1461,8 +1442,8 @@ export const ConstructorValidator: Validator = {
               for (const bodyError of bodyCheckResult.errors) {
                 errors.push({
                   message: bodyError.message
-                    ? localizeTyped(bodyError.code as any, bodyError.message)
-                    : localizeTyped(bodyError.code as any),
+                    ? localizeTyped(bodyError.code, bodyError.message)
+                    : localizeTyped(bodyError.code),
                   location: {
                     symbolRange: {
                       startLine: bodyError.line,
@@ -1477,7 +1458,7 @@ export const ConstructorValidator: Validator = {
                       endColumn: bodyError.column + 10,
                     },
                   },
-                  code: bodyError.code as any,
+                  code: bodyError.code,
                 });
               }
             }

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ConstructorValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ConstructorValidator.ts
@@ -48,7 +48,11 @@ import type { ErrorCodeKey } from '../../../generated/messages_en_US';
 import { BaseApexParserListener } from '../../../parser/listeners/BaseApexParserListener';
 import { ISymbolManager } from '../ArtifactLoadingHelper';
 import { isContextType } from '../../../utils/contextTypeGuards';
-import { isBlockSymbol } from '../../../utils/symbolNarrowing';
+import {
+  isBlockSymbol,
+  isClassSymbol,
+  isConstructorSymbol,
+} from '../../../utils/symbolNarrowing';
 
 /**
  * Information about a super()/this() call found in a constructor
@@ -838,9 +842,7 @@ function validateConstructorSignature(
 
     // Find the target class - try to find it from all available symbols
     const targetClassSymbols = symbolManager.findSymbolByName(targetClassName);
-    let targetClass = targetClassSymbols.find(
-      (s: ApexSymbol) => s.kind === SymbolKind.Class,
-    ) as TypeSymbol | undefined;
+    let targetClass = targetClassSymbols.find(isClassSymbol);
 
     if (!targetClass) {
       // Class not found - skip validation (may be in different file/package)
@@ -856,8 +858,7 @@ function validateConstructorSignature(
     // Find constructors by name - constructors have the same name as their class
     // First, get all constructors with matching name
     const allMatchingConstructors = allSymbolsForCompletion.filter(
-      (s: ApexSymbol) =>
-        s.kind === SymbolKind.Constructor && s.name === targetClassName,
+      (s: ApexSymbol) => isConstructorSymbol(s) && s.name === targetClassName,
     ) as MethodSymbol[];
 
     // Build set of valid parent IDs for constructors.
@@ -900,8 +901,7 @@ function validateConstructorSignature(
 
       // Find the class symbol from this file (might have different ID)
       const fileClass = fileSymbols.find(
-        (s: ApexSymbol) =>
-          s.kind === SymbolKind.Class && s.name === targetClassName,
+        (s: ApexSymbol) => isClassSymbol(s) && s.name === targetClassName,
       ) as TypeSymbol | undefined;
 
       if (fileClass) {
@@ -919,7 +919,7 @@ function validateConstructorSignature(
 
         // Use constructors from the file, matching by fileClass.id or class block id
         const fileConstructors = fileSymbols.filter((s: ApexSymbol) => {
-          if (s.kind === SymbolKind.Constructor && s.name === targetClassName) {
+          if (isConstructorSymbol(s) && s.name === targetClassName) {
             return parentIdMatches(s.parentId);
           }
           return false;
@@ -959,8 +959,7 @@ function validateConstructorSignature(
     // Also include same-file symbols
     const sameFileSymbols = symbolTable.getAllSymbols();
     const sameFileConstructors = sameFileSymbols.filter(
-      (s: ApexSymbol) =>
-        s.kind === SymbolKind.Constructor && s.name === targetClassName,
+      (s: ApexSymbol) => isConstructorSymbol(s) && s.name === targetClassName,
     ) as MethodSymbol[];
 
     // Merge, avoiding duplicates and matching by parentId if available
@@ -1127,22 +1126,19 @@ function findContainingClass(
   let current: ApexSymbol | null = constructor;
 
   while (current) {
-    // Check if current is a class
-    if (current.kind === SymbolKind.Class) {
-      return current as TypeSymbol;
+    if (isClassSymbol(current)) {
+      return current;
     }
 
-    // Check if current's parent is a class
     if (current.parentId) {
       const parent = allSymbols.find((s) => s.id === current!.parentId);
-      if (parent && parent.kind === SymbolKind.Class) {
-        return parent as TypeSymbol;
+      if (isClassSymbol(parent)) {
+        return parent;
       }
-      // If parent is a block, check its parent
-      if (parent && parent.kind === SymbolKind.Block && parent.parentId) {
+      if (isBlockSymbol(parent) && parent.parentId) {
         const grandParent = allSymbols.find((s) => s.id === parent!.parentId);
-        if (grandParent && grandParent.kind === SymbolKind.Class) {
-          return grandParent as TypeSymbol;
+        if (isClassSymbol(grandParent)) {
+          return grandParent;
         }
       }
       current = parent ?? null;
@@ -1168,9 +1164,9 @@ function findParentClassInSameFile(
   const superClassName = childClass.superClass.trim().toLowerCase();
   const childFileUri = childClass.fileUri;
 
-  const allClasses = allSymbols.filter(
-    (s) => s.kind === SymbolKind.Class && s.fileUri === childFileUri,
-  ) as TypeSymbol[];
+  const allClasses = allSymbols
+    .filter(isClassSymbol)
+    .filter((s) => s.fileUri === childFileUri);
 
   // Check if child class is an inner class extending its outer class
   if (childClass.parentId) {
@@ -1201,7 +1197,7 @@ function hasDefaultConstructor(
   // Find all constructors for this class
   const constructors = allSymbols.filter(
     (s) =>
-      s.kind === SymbolKind.Constructor &&
+      isConstructorSymbol(s) &&
       s.name === classSymbol.name &&
       (s.parentId === classSymbol.id ||
         (s.parentId && s.parentId.startsWith(classSymbol.id + ':'))),
@@ -1298,9 +1294,7 @@ export const ConstructorValidator: Validator = {
 
         // Check each constructor for violations
         const allSymbols = symbolTable.getAllSymbols();
-        const constructors = allSymbols.filter(
-          (s) => s.kind === SymbolKind.Constructor,
-        ) as MethodSymbol[];
+        const constructors = allSymbols.filter(isConstructorSymbol);
 
         const constructorInfos = listener.getConstructorInfos();
 
@@ -1499,9 +1493,7 @@ export const ConstructorValidator: Validator = {
         // Check for INVALID_CONSTRUCTOR: When a constructor is required but not defined
         // This happens when a class extends another class that has no default constructor
         // and the subclass doesn't define any constructors
-        const classes = allSymbols.filter(
-          (s) => s.kind === SymbolKind.Class,
-        ) as TypeSymbol[];
+        const classes = allSymbols.filter(isClassSymbol);
 
         for (const classSymbol of classes) {
           // Skip if class has no superclass

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ControlFlowValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ControlFlowValidator.ts
@@ -21,6 +21,8 @@ import {
   ForStatementContext,
   WhileStatementContext,
   DoWhileStatementContext,
+  MethodDeclarationContext,
+  ConstructorDeclarationContext,
   ParseTreeWalker,
 } from '@apexdevtools/apex-parser';
 import type { SymbolTable, SymbolLocation } from '../../../types/symbol';
@@ -34,6 +36,7 @@ import { ValidationTier } from '../ValidationTier';
 import { ValidationError, type Validator } from '../ValidatorRegistry';
 import { localizeTyped } from '../../../i18n/messageInstance';
 import { ErrorCodes } from '../../../generated/ErrorCodes';
+import type { ErrorCodeKey } from '../../../generated/messages_en_US';
 import { BaseApexParserListener } from '../../../parser/listeners/BaseApexParserListener';
 import type { ParserRuleContext } from 'antlr4ts';
 
@@ -64,7 +67,7 @@ function getLocationFromContext(ctx: ParserRuleContext): SymbolLocation {
 class ControlFlowListener extends BaseApexParserListener<void> {
   private errors: Array<{
     ctx: ParserRuleContext;
-    code: string;
+    code: ErrorCodeKey;
   }> = [];
   private loopDepth = 0; // Track nesting depth of loops
   private methodDepth = 0; // Track nesting depth of methods
@@ -96,20 +99,19 @@ class ControlFlowListener extends BaseApexParserListener<void> {
   // Enhanced for loops also use ForStatementContext in Apex parser
   // We track them the same way as regular for loops
 
-  enterMethodDeclaration(ctx: any): void {
+  enterMethodDeclaration(ctx: MethodDeclarationContext): void {
     this.methodDepth++;
   }
 
-  exitMethodDeclaration(ctx: any): void {
+  exitMethodDeclaration(ctx: MethodDeclarationContext): void {
     this.methodDepth--;
   }
 
-  enterConstructorDeclaration(ctx: any): void {
-    // Constructors are like methods for return statement validation
+  enterConstructorDeclaration(ctx: ConstructorDeclarationContext): void {
     this.methodDepth++;
   }
 
-  exitConstructorDeclaration(ctx: any): void {
+  exitConstructorDeclaration(ctx: ConstructorDeclarationContext): void {
     this.methodDepth--;
   }
 
@@ -146,7 +148,7 @@ class ControlFlowListener extends BaseApexParserListener<void> {
 
   getErrors(): Array<{
     ctx: ParserRuleContext;
-    code: string;
+    code: ErrorCodeKey;
   }> {
     return this.errors;
   }
@@ -251,7 +253,7 @@ export const ControlFlowValidator: Validator = {
         for (const { ctx, code } of controlFlowErrors) {
           const location = getLocationFromContext(ctx);
           errors.push({
-            message: localizeTyped(code as any),
+            message: localizeTyped(code),
             location,
             code,
           });

--- a/packages/apex-parser-ast/src/semantics/validation/validators/DeprecationValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/DeprecationValidator.ts
@@ -9,12 +9,17 @@
 import { Effect } from 'effect';
 import type {
   SymbolTable,
-  TypeSymbol,
   MethodSymbol,
   VariableSymbol,
   SymbolLocation,
 } from '../../../types/symbol';
-import { SymbolKind, SymbolVisibility } from '../../../types/symbol';
+import { SymbolVisibility } from '../../../types/symbol';
+import {
+  isMethodSymbol,
+  isFieldSymbol,
+  isPropertySymbol,
+  inTypeSymbolGroup,
+} from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -64,8 +69,8 @@ function loadCrossFileDeprecatedTypes(
 
   // Collect type names from method return types and parameters
   for (const symbol of allSymbols) {
-    if (symbol.kind === SymbolKind.Method) {
-      const method = symbol as MethodSymbol;
+    if (isMethodSymbol(symbol)) {
+      const method = symbol;
       if (method.returnType?.name) {
         const returnTypeName = method.returnType.name.toLowerCase();
         typeNames.add(returnTypeName);
@@ -86,11 +91,8 @@ function loadCrossFileDeprecatedTypes(
           }
         }
       }
-    } else if (
-      symbol.kind === SymbolKind.Field ||
-      symbol.kind === SymbolKind.Property
-    ) {
-      const field = symbol as VariableSymbol;
+    } else if (isFieldSymbol(symbol) || isPropertySymbol(symbol)) {
+      const field = symbol;
       if (field.type?.name) {
         const fieldTypeName = field.type.name.toLowerCase();
         typeNames.add(fieldTypeName);
@@ -133,12 +135,7 @@ function loadCrossFileDeprecatedTypes(
     // Try to find the type in other files
     // findSymbolByName is case-insensitive, so either case should work
     const foundSymbols = symbolManager.findSymbolByName(typeName);
-    const foundSymbol = foundSymbols.find(
-      (s) =>
-        s.kind === SymbolKind.Class ||
-        s.kind === SymbolKind.Interface ||
-        s.kind === SymbolKind.Enum,
-    ) as TypeSymbol | undefined;
+    const foundSymbol = foundSymbols.find(inTypeSymbolGroup);
 
     if (foundSymbol && hasDeprecatedAnnotation(foundSymbol)) {
       deprecatedTypes.add(normalizedTypeName);
@@ -183,12 +180,7 @@ function checkIfTypeIsDeprecated(
   // Try to find the type in other files
   // findSymbolByName is case-insensitive, so either case should work
   const foundSymbols = symbolManager.findSymbolByName(typeName);
-  const foundSymbol = foundSymbols.find(
-    (s) =>
-      s.kind === SymbolKind.Class ||
-      s.kind === SymbolKind.Interface ||
-      s.kind === SymbolKind.Enum,
-  ) as TypeSymbol | undefined;
+  const foundSymbol = foundSymbols.find(inTypeSymbolGroup);
 
   if (foundSymbol && hasDeprecatedAnnotation(foundSymbol)) {
     deprecatedTypes.add(normalizedName);
@@ -238,15 +230,9 @@ export const DeprecationValidator: Validator = {
       // Find all deprecated types in the same file
       const deprecatedTypes = new Set<string>();
       for (const symbol of allSymbols) {
-        if (
-          (symbol.kind === SymbolKind.Class ||
-            symbol.kind === SymbolKind.Interface ||
-            symbol.kind === SymbolKind.Enum) &&
-          'annotations' in symbol
-        ) {
-          const typeSymbol = symbol as TypeSymbol;
-          if (hasDeprecatedAnnotation(typeSymbol)) {
-            deprecatedTypes.add(typeSymbol.name.toLowerCase());
+        if (inTypeSymbolGroup(symbol) && 'annotations' in symbol) {
+          if (hasDeprecatedAnnotation(symbol)) {
+            deprecatedTypes.add(symbol.name.toLowerCase());
           }
         }
       }
@@ -266,9 +252,7 @@ export const DeprecationValidator: Validator = {
       // Validate global methods
       const globalMethods = allSymbols.filter(
         (s): s is MethodSymbol =>
-          s.kind === SymbolKind.Method &&
-          'parameters' in s &&
-          'returnType' in s &&
+          isMethodSymbol(s) &&
           s.modifiers?.visibility === SymbolVisibility.Global,
       );
 
@@ -364,8 +348,7 @@ export const DeprecationValidator: Validator = {
       // Validate global fields
       const globalFields = allSymbols.filter(
         (s): s is VariableSymbol =>
-          (s.kind === SymbolKind.Field || s.kind === SymbolKind.Property) &&
-          'type' in s &&
+          (isFieldSymbol(s) || isPropertySymbol(s)) &&
           s.modifiers?.visibility === SymbolVisibility.Global,
       );
 
@@ -417,8 +400,7 @@ export const DeprecationValidator: Validator = {
       // Validate WebService fields
       const webserviceFields = allSymbols.filter(
         (s): s is VariableSymbol =>
-          (s.kind === SymbolKind.Field || s.kind === SymbolKind.Property) &&
-          'type' in s &&
+          (isFieldSymbol(s) || isPropertySymbol(s)) &&
           s.modifiers?.isWebService === true,
       );
 

--- a/packages/apex-parser-ast/src/semantics/validation/validators/DuplicateAnnotationMethodValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/DuplicateAnnotationMethodValidator.ts
@@ -7,12 +7,9 @@
  */
 
 import { Effect } from 'effect';
-import type {
-  SymbolTable,
-  MethodSymbol,
-  TypeSymbol,
-} from '../../../types/symbol';
-import { SymbolKind, SymbolVisibility } from '../../../types/symbol';
+import type { SymbolTable, MethodSymbol } from '../../../types/symbol';
+import { SymbolVisibility } from '../../../types/symbol';
+import { isMethodSymbol, isClassSymbol } from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -98,7 +95,7 @@ export const DuplicateAnnotationMethodValidator: Validator = {
       // Filter to method symbols only
       const methods = allSymbols.filter(
         (symbol): symbol is MethodSymbol =>
-          symbol.kind === 'method' && 'parameters' in symbol,
+          isMethodSymbol(symbol) && 'parameters' in symbol,
       );
 
       // Group methods by parent
@@ -130,9 +127,8 @@ export const DuplicateAnnotationMethodValidator: Validator = {
         if (remoteActionMethods.length > 0) {
           // Check if parent is a global class
           const isGlobalClass =
-            parent.kind === SymbolKind.Class &&
-            (parent as TypeSymbol).modifiers?.visibility ===
-              SymbolVisibility.Global;
+            isClassSymbol(parent) &&
+            parent.modifiers?.visibility === SymbolVisibility.Global;
 
           if (isGlobalClass) {
             for (const method of remoteActionMethods) {

--- a/packages/apex-parser-ast/src/semantics/validation/validators/DuplicateSymbolValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/DuplicateSymbolValidator.ts
@@ -9,6 +9,11 @@
 import { Effect } from 'effect';
 import type { SymbolTable, ApexSymbol } from '../../../types/symbol';
 import { SymbolKind } from '../../../types/symbol';
+import {
+  isFieldSymbol,
+  isMethodSymbol,
+  isConstructorSymbol,
+} from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -83,9 +88,7 @@ export const DuplicateSymbolValidator: Validator = {
       const allSymbols = symbolTable.getAllSymbols();
 
       // Check for duplicate fields (existing logic)
-      const fields = allSymbols.filter(
-        (symbol) => symbol.kind === SymbolKind.Field,
-      );
+      const fields = allSymbols.filter(isFieldSymbol);
 
       // Group fields by parent (class/type)
       const fieldsByParent = new Map<string, ApexSymbol[]>();
@@ -251,10 +254,7 @@ function findContainingMethod(
     visited.add(current.id);
 
     // Check if current is a method/constructor
-    if (
-      current.kind === SymbolKind.Method ||
-      current.kind === SymbolKind.Constructor
-    ) {
+    if (isMethodSymbol(current) || isConstructorSymbol(current)) {
       return current;
     }
 
@@ -265,11 +265,7 @@ function findContainingMethod(
         break;
       }
 
-      // Check if parent is a method/constructor
-      if (
-        parent.kind === SymbolKind.Method ||
-        parent.kind === SymbolKind.Constructor
-      ) {
+      if (isMethodSymbol(parent) || isConstructorSymbol(parent)) {
         return parent;
       }
 

--- a/packages/apex-parser-ast/src/semantics/validation/validators/DuplicateTypeNameValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/DuplicateTypeNameValidator.ts
@@ -8,7 +8,7 @@
 
 import { Effect } from 'effect';
 import type { SymbolTable, TypeSymbol } from '../../../types/symbol';
-import { SymbolKind } from '../../../types/symbol';
+import { inTypeSymbolGroup } from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -66,13 +66,7 @@ export const DuplicateTypeNameValidator: Validator = {
 
       // Filter to types (classes, interfaces, enums)
       // Constructors have SymbolKind.Constructor, so they're automatically excluded
-      const types = allSymbols.filter(
-        (symbol): symbol is TypeSymbol =>
-          (symbol.kind === SymbolKind.Class ||
-            symbol.kind === SymbolKind.Interface ||
-            symbol.kind === SymbolKind.Enum) &&
-          'annotations' in symbol,
-      );
+      const types = allSymbols.filter(inTypeSymbolGroup);
 
       // Deduplicate by object reference - prevents same symbol object appearing multiple times
       // but allows legitimate duplicates (different objects with same ID) to both be checked

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ExceptionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ExceptionValidator.ts
@@ -29,7 +29,12 @@ import type {
   MethodSymbol,
   ApexSymbol,
 } from '../../../types/symbol';
-import { SymbolKind } from '../../../types/symbol';
+import {
+  isClassSymbol,
+  isClassOrInterfaceSymbol,
+  isConstructorSymbol,
+  inTypeSymbolGroup,
+} from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -303,8 +308,8 @@ export const ExceptionValidator: Validator = {
         const exceptionClasses = listener.getExceptionClasses();
         for (const { ctx, name } of exceptionClasses) {
           const classSymbol = allSymbols.find(
-            (s) => s.kind === SymbolKind.Class && s.name === name,
-          ) as TypeSymbol | undefined;
+            (s): s is TypeSymbol => isClassSymbol(s) && s.name === name,
+          );
 
           if (classSymbol) {
             const isExceptionClass = extendsException(classSymbol);
@@ -343,10 +348,9 @@ export const ExceptionValidator: Validator = {
             ) {
               // Check if superclass extends Exception
               const superClassSymbol = allSymbols.find(
-                (s) =>
-                  s.kind === SymbolKind.Class &&
-                  s.name === classSymbol.superClass,
-              ) as TypeSymbol | undefined;
+                (s): s is TypeSymbol =>
+                  isClassSymbol(s) && s.name === classSymbol.superClass,
+              );
 
               if (!superClassSymbol || !extendsException(superClassSymbol)) {
                 errors.push({
@@ -372,17 +376,17 @@ export const ExceptionValidator: Validator = {
 
         for (const { ctx, className } of constructors) {
           const classSymbol = allSymbols.find(
-            (s) => s.kind === SymbolKind.Class && s.name === className,
-          ) as TypeSymbol | undefined;
+            (s): s is TypeSymbol => isClassSymbol(s) && s.name === className,
+          );
 
           // Only check exception classes
           if (classSymbol && extendsException(classSymbol)) {
             const constructorSymbol = allSymbols.find(
-              (s) =>
-                s.kind === SymbolKind.Constructor &&
+              (s): s is MethodSymbol =>
+                isConstructorSymbol(s) &&
                 s.name === className &&
                 s.parentId === classSymbol.id,
-            ) as MethodSymbol | undefined;
+            );
 
             if (constructorSymbol) {
               const paramCount = constructorSymbol.parameters.length;
@@ -508,11 +512,10 @@ export const ExceptionValidator: Validator = {
             } else {
               // Check if the type symbol extends Exception
               const typeSymbol = allSymbols.find(
-                (s) =>
-                  (s.kind === SymbolKind.Class ||
-                    s.kind === SymbolKind.Interface) &&
+                (s): s is TypeSymbol =>
+                  isClassOrInterfaceSymbol(s) &&
                   s.name.toLowerCase() === normalizedType,
-              ) as TypeSymbol | undefined;
+              );
 
               // If type symbol found and it doesn't extend Exception, report error
               if (typeSymbol && !extendsException(typeSymbol)) {
@@ -596,12 +599,9 @@ function findTypeSymbolByName(
   return Effect.gen(function* () {
     // First, try to find in same file
     const sameFileType = allSymbols.find(
-      (s) =>
-        (s.kind === SymbolKind.Class ||
-          s.kind === SymbolKind.Interface ||
-          s.kind === SymbolKind.Enum) &&
-        s.name.toLowerCase() === typeName.toLowerCase(),
-    ) as TypeSymbol | undefined;
+      (s): s is TypeSymbol =>
+        inTypeSymbolGroup(s) && s.name.toLowerCase() === typeName.toLowerCase(),
+    );
 
     if (sameFileType) {
       return sameFileType;
@@ -609,12 +609,9 @@ function findTypeSymbolByName(
 
     // Try to find via symbol manager (cross-file)
     const symbols = symbolManager.findSymbolByName(typeName);
-    const typeSymbol = symbols.find(
-      (s: ApexSymbol) =>
-        s.kind === SymbolKind.Class ||
-        s.kind === SymbolKind.Interface ||
-        s.kind === SymbolKind.Enum,
-    ) as TypeSymbol | undefined;
+    const typeSymbol = symbols.find((s: ApexSymbol): s is TypeSymbol =>
+      inTypeSymbolGroup(s),
+    );
 
     if (typeSymbol) {
       return typeSymbol;
@@ -622,13 +619,8 @@ function findTypeSymbolByName(
 
     // Try FQN lookup
     const fqnSymbol = symbolManager.findSymbolByFQN(typeName);
-    if (
-      fqnSymbol &&
-      (fqnSymbol.kind === SymbolKind.Class ||
-        fqnSymbol.kind === SymbolKind.Interface ||
-        fqnSymbol.kind === SymbolKind.Enum)
-    ) {
-      return fqnSymbol as TypeSymbol;
+    if (inTypeSymbolGroup(fqnSymbol)) {
+      return fqnSymbol;
     }
 
     return null;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ExceptionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ExceptionValidator.ts
@@ -45,7 +45,10 @@ import type { ParserRuleContext } from 'antlr4ts';
 import { ISymbolManager } from '../ArtifactLoadingHelper';
 import { normalizeStandardTypeName } from '../utils/standardTypeIdentity';
 import type { ISymbolManager as ISymbolManagerInterface } from '../../../types/ISymbolManager';
-import { isContextType } from '../../../utils/contextTypeGuards';
+import {
+  isContextType,
+  getTypeNameFromCreatedName,
+} from '../../../utils/contextTypeGuards';
 
 /**
  * Helper to check if a type extends Exception
@@ -564,10 +567,7 @@ function resolveThrowExpressionType(
       const newExpr = expression as NewExpressionContext;
       const createdName = newExpr.creator()?.createdName();
       if (createdName) {
-        const typeName = createdName
-          .idCreatedNamePair()
-          .map((p) => p.anyId().text)
-          .join('.');
+        const typeName = getTypeNameFromCreatedName(createdName);
         if (typeName) {
           const typeSymbol = yield* findTypeSymbolByName(
             symbolManager,

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ExceptionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ExceptionValidator.ts
@@ -562,11 +562,13 @@ function resolveThrowExpressionType(
     // Check for new expression: new MyException()
     if (isContextType(expression, NewExpressionContext)) {
       const newExpr = expression as NewExpressionContext;
-      const typeRef = (newExpr as any).typeRef?.();
-      if (typeRef) {
-        const typeName = extractTypeNameFromTypeRef(typeRef);
+      const createdName = newExpr.creator()?.createdName();
+      if (createdName) {
+        const typeName = createdName
+          .idCreatedNamePair()
+          .map((p) => p.anyId().text)
+          .join('.');
         if (typeName) {
-          // Try to find the type symbol
           const typeSymbol = yield* findTypeSymbolByName(
             symbolManager,
             typeName,
@@ -581,24 +583,6 @@ function resolveThrowExpressionType(
     // For now, return null (conservative - don't report false positives)
     return null;
   });
-}
-
-/**
- * Extract type name from TypeRefContext
- */
-function extractTypeNameFromTypeRef(typeRef: any): string | null {
-  try {
-    const qualifiedName = typeRef.qualifiedName?.();
-    if (qualifiedName) {
-      const ids = qualifiedName.id();
-      if (ids && ids.length > 0) {
-        return ids.map((id: any) => id.text).join('.');
-      }
-    }
-    return null;
-  } catch {
-    return null;
-  }
 }
 
 /**

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ExpressionTypeValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ExpressionTypeValidator.ts
@@ -52,6 +52,7 @@ import {
   isContextType,
   isMethodCallContext,
 } from '../../../utils/contextTypeGuards';
+import { isPropertySymbol } from '../../../utils/symbolNarrowing';
 
 /**
  * Helper function to create SymbolLocation from parse tree context
@@ -182,14 +183,13 @@ class ExpressionTypeListener extends BaseApexParserListener<void> {
       }
 
       // Check properties
-      if (symbol.kind === SymbolKind.Property) {
-        const property = symbol as VariableSymbol;
-        if (property.type) {
-          const typeName = property.type.name || '';
+      if (isPropertySymbol(symbol)) {
+        if (symbol.type) {
+          const typeName = symbol.type.name || '';
           if (isVoidType(typeName)) {
             voidErrors.push({
               code: ErrorCodes.INVALID_VOID_PROPERTY,
-              symbolLocation: property.location,
+              symbolLocation: symbol.location,
             });
           }
         }

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ExpressionTypeValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ExpressionTypeValidator.ts
@@ -45,6 +45,7 @@ import { ValidationTier } from '../ValidationTier';
 import { ValidationError, type Validator } from '../ValidatorRegistry';
 import { localizeTyped } from '../../../i18n/messageInstance';
 import { ErrorCodes } from '../../../generated/ErrorCodes';
+import type { ErrorCodeKey } from '../../../generated/messages_en_US';
 import { BaseApexParserListener } from '../../../parser/listeners/BaseApexParserListener';
 import type { ParserRuleContext } from 'antlr4ts';
 import { isContextType } from '../../../utils/contextTypeGuards';
@@ -125,7 +126,7 @@ function isValidAssignmentTarget(
  */
 interface ExpressionValidationError {
   ctx?: ParserRuleContext;
-  code: string;
+  code: ErrorCodeKey;
   symbolLocation?: SymbolLocation;
 }
 
@@ -426,7 +427,7 @@ class ExpressionTypeListener extends BaseApexParserListener<void> {
             const hasMethodCall =
               primaryCtx &&
               (isContextType(primaryCtx, IdPrimaryContext) ||
-                (primaryCtx as any).methodCall !== undefined);
+                'methodCall' in primaryCtx);
             if (!hasMethodCall) {
               // Primary expression without method call is invalid as statement
               // (unless it's increment/decrement which we already checked)
@@ -591,7 +592,7 @@ export const ExpressionTypeValidator: Validator = {
           }
 
           errors.push({
-            message: localizeTyped(errorInfo.code as any),
+            message: localizeTyped(errorInfo.code),
             location,
             code: errorInfo.code,
           });
@@ -615,7 +616,7 @@ export const ExpressionTypeValidator: Validator = {
           };
 
           errors.push({
-            message: localizeTyped(errorInfo.code as any),
+            message: localizeTyped(errorInfo.code),
             location,
             code: errorInfo.code,
           });

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ExpressionTypeValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ExpressionTypeValidator.ts
@@ -48,7 +48,10 @@ import { ErrorCodes } from '../../../generated/ErrorCodes';
 import type { ErrorCodeKey } from '../../../generated/messages_en_US';
 import { BaseApexParserListener } from '../../../parser/listeners/BaseApexParserListener';
 import type { ParserRuleContext } from 'antlr4ts';
-import { isContextType } from '../../../utils/contextTypeGuards';
+import {
+  isContextType,
+  isMethodCallContext,
+} from '../../../utils/contextTypeGuards';
 
 /**
  * Helper function to create SymbolLocation from parse tree context
@@ -422,12 +425,10 @@ class ExpressionTypeListener extends BaseApexParserListener<void> {
             const primary = expr as PrimaryExpressionContext;
             // Check if primary contains a method call
             const primaryCtx = primary.primary();
-            // Check if primary context has a method call
-            // PrimaryContext doesn't have methodCall() directly, so we check the structure
             const hasMethodCall =
               primaryCtx &&
               (isContextType(primaryCtx, IdPrimaryContext) ||
-                'methodCall' in primaryCtx);
+                isMethodCallContext(primaryCtx));
             if (!hasMethodCall) {
               // Primary expression without method call is invalid as statement
               // (unless it's increment/decrement which we already checked)

--- a/packages/apex-parser-ast/src/semantics/validation/validators/InnerTypeValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/InnerTypeValidator.ts
@@ -63,7 +63,7 @@ class StaticBlockListener extends BaseApexParserListener<void> {
     this.classStack.pop();
   }
 
-  enterBlock(ctx: any): void {
+  enterBlock(ctx: BlockContext): void {
     if (ctx.parent && this.isStaticBlock(ctx) && this.classStack.length > 0) {
       const currentClass = this.classStack[this.classStack.length - 1];
       if (currentClass.isInner) {
@@ -76,7 +76,7 @@ class StaticBlockListener extends BaseApexParserListener<void> {
     }
   }
 
-  private isStaticBlock(ctx: any): boolean {
+  private isStaticBlock(ctx: BlockContext): boolean {
     const parent = ctx.parent;
     if (!parent) return false;
     const children = parent.children ?? [];

--- a/packages/apex-parser-ast/src/semantics/validation/validators/InnerTypeValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/InnerTypeValidator.ts
@@ -24,8 +24,10 @@ import type {
   ApexSymbol,
   ScopeSymbol,
 } from '../../../types/symbol';
-import { SymbolKind } from '../../../types/symbol';
-import { isBlockSymbol } from '../../../utils/symbolNarrowing';
+import {
+  isBlockSymbol,
+  isClassOrInterfaceSymbol,
+} from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -122,9 +124,7 @@ export const InnerTypeValidator: Validator = {
 
       const allSymbols = symbolTable.getAllSymbols();
 
-      const typeSymbols = allSymbols.filter(
-        (s) => s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-      ) as TypeSymbol[];
+      const typeSymbols = allSymbols.filter(isClassOrInterfaceSymbol);
 
       for (const typeSymbol of typeSymbols) {
         if (!typeSymbol.parentId) continue;
@@ -135,9 +135,7 @@ export const InnerTypeValidator: Validator = {
 
         if (!parent) continue;
 
-        const parentIsType =
-          parent.kind === SymbolKind.Class ||
-          parent.kind === SymbolKind.Interface;
+        const parentIsType = isClassOrInterfaceSymbol(parent);
         const parentIsInner =
           parentIsType && (parent as TypeSymbol).parentId != null;
 
@@ -149,7 +147,7 @@ export const InnerTypeValidator: Validator = {
         );
         const hasInnerTypes = allSymbols.some(
           (s) =>
-            (s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface) &&
+            isClassOrInterfaceSymbol(s) &&
             s.id !== typeSymbol.id &&
             (s.parentId === typeSymbol.id || s.parentId === typeBlock?.id),
         );

--- a/packages/apex-parser-ast/src/semantics/validation/validators/InstanceofValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/InstanceofValidator.ts
@@ -22,7 +22,7 @@ import {
   CastExpressionContext,
 } from '@apexdevtools/apex-parser';
 import type { SymbolTable, SymbolLocation } from '../../../types/symbol';
-import { SymbolKind } from '../../../types/symbol';
+import { inTypeSymbolGroup } from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -268,11 +268,7 @@ export const InstanceofValidator: Validator = {
 
         // For non-Object RHS, ensure we can resolve (allSymbols has same-file types)
         const rightInAll = allSymbols.find(
-          (s) =>
-            (s.kind === SymbolKind.Class ||
-              s.kind === SymbolKind.Interface ||
-              s.kind === SymbolKind.Enum) &&
-            s.name.toLowerCase() === rightBase,
+          (s) => inTypeSymbolGroup(s) && s.name.toLowerCase() === rightBase,
         );
         const rightSymbols = rightInAll
           ? [rightInAll]

--- a/packages/apex-parser-ast/src/semantics/validation/validators/InstanceofValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/InstanceofValidator.ts
@@ -90,7 +90,7 @@ class InstanceofCollectorListener extends BaseApexParserListener<
     };
     parent?: ParserRuleContext;
   }): void {
-    const literal = (ctx as any).literal?.();
+    const literal = ctx.literal?.();
     if (!literal) return;
     let litType:
       | 'integer'
@@ -107,13 +107,13 @@ class InstanceofCollectorListener extends BaseApexParserListener<
     else if (literal.BooleanLiteral?.()) litType = 'boolean';
     else if (literal.NULL?.()) litType = 'null';
     if (litType) {
-      let current: ParserRuleContext | null = (ctx as any).parent || null;
+      let current: ParserRuleContext | null = ctx.parent || null;
       while (current) {
         if (current instanceof ExpressionContext) {
           this.literalTypes.set(current, litType);
           break;
         }
-        current = (current as any).parent || null;
+        current = current.parent || null;
       }
     }
   }

--- a/packages/apex-parser-ast/src/semantics/validation/validators/InterfaceHierarchyValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/InterfaceHierarchyValidator.ts
@@ -13,7 +13,7 @@ import type {
   TypeSymbol,
   MethodSymbol,
 } from '../../../types/symbol';
-import { SymbolKind, SymbolVisibility } from '../../../types/symbol';
+import { SymbolVisibility } from '../../../types/symbol';
 import type {
   ValidationErrorInfo,
   ValidationWarningInfo,
@@ -25,7 +25,12 @@ import {
   ArtifactLoadingHelper,
   ISymbolManager,
 } from '../ArtifactLoadingHelper';
-import { isBlockSymbol } from '../../../utils/symbolNarrowing';
+import {
+  isBlockSymbol,
+  isClassSymbol,
+  isInterfaceSymbol,
+  isMethodSymbol,
+} from '../../../utils/symbolNarrowing';
 import { localizeTyped } from '../../../i18n/messageInstance';
 import { ErrorCodes } from '../../../generated/ErrorCodes';
 
@@ -73,13 +78,9 @@ export const InterfaceHierarchyValidator: Validator = {
       const allSymbols = symbolTable.getAllSymbols();
 
       // Filter to interface and class symbols from current file
-      const localInterfaces = allSymbols.filter(
-        (symbol) => symbol.kind === SymbolKind.Interface,
-      ) as TypeSymbol[];
+      const localInterfaces = allSymbols.filter(isInterfaceSymbol);
 
-      const classes = allSymbols.filter(
-        (symbol) => symbol.kind === SymbolKind.Class,
-      ) as TypeSymbol[];
+      const classes = allSymbols.filter(isClassSymbol);
 
       // For TIER 2 validation, also get interfaces from symbol manager for cross-file detection
       let allInterfaces = [...localInterfaces];
@@ -89,9 +90,8 @@ export const InterfaceHierarchyValidator: Validator = {
         // Use getAllSymbolsForCompletion() which is available on ISymbolManager interface
         const allSymbolsFromManager =
           symbolManager.getAllSymbolsForCompletion();
-        const crossFileInterfaces = allSymbolsFromManager.filter(
-          (s: ApexSymbol) => s.kind === SymbolKind.Interface,
-        ) as TypeSymbol[];
+        const crossFileInterfaces =
+          allSymbolsFromManager.filter(isInterfaceSymbol);
 
         // Merge with current interfaces, avoiding duplicates by ID
         const interfaceIds = new Set(localInterfaces.map((i) => i.id));
@@ -169,7 +169,7 @@ export const InterfaceHierarchyValidator: Validator = {
           } else if (iface) {
             // Check if interface type is valid (not array ref, is interface, not Java type)
             // This matches jorje's ParentTypeResolver.java checks
-            if (iface.kind !== SymbolKind.Interface) {
+            if (!isInterfaceSymbol(iface)) {
               const code = ErrorCodes.INVALID_INTERFACE;
               errors.push({
                 message: localizeTyped(code, ifaceName),
@@ -202,9 +202,7 @@ export const InterfaceHierarchyValidator: Validator = {
           ...loadResult.alreadyLoaded,
         ]) {
           const symbols = symbolManager.findSymbolByName(typeName);
-          const ifaceSymbol = symbols.find(
-            (s: ApexSymbol) => s.kind === SymbolKind.Interface,
-          ) as TypeSymbol | undefined;
+          const ifaceSymbol = symbols.find(isInterfaceSymbol);
 
           if (ifaceSymbol) {
             loadedInterfaces.push(ifaceSymbol);
@@ -283,7 +281,7 @@ export const InterfaceHierarchyValidator: Validator = {
 
           // Check if interface type is valid (not array ref, is interface, not Java type)
           // This matches jorje's ParentTypeResolver.java checks
-          if (iface.kind !== SymbolKind.Interface) {
+          if (!isInterfaceSymbol(iface)) {
             const code = ErrorCodes.INVALID_INTERFACE;
             errors.push({
               message: localizeTyped(code, ifaceName),
@@ -322,7 +320,7 @@ export const InterfaceHierarchyValidator: Validator = {
           const classBlockId = classBlock?.id;
 
           const classMethods = allMethodsForValidation.filter((s) => {
-            if (s.kind !== SymbolKind.Method) {
+            if (!isMethodSymbol(s)) {
               return false;
             }
             // Check if method belongs to this class (direct or via block)
@@ -524,7 +522,7 @@ function getAllInterfaceMethods(
 
     // Look for methods with parentId matching interface or interface block
     const ifaceMethods = allSymbols.filter((s) => {
-      if (s.kind !== SymbolKind.Method) {
+      if (!isMethodSymbol(s)) {
         return false;
       }
       // Check if method belongs to this interface (direct or via block)

--- a/packages/apex-parser-ast/src/semantics/validation/validators/InterfaceHierarchyValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/InterfaceHierarchyValidator.ts
@@ -25,6 +25,7 @@ import {
   ArtifactLoadingHelper,
   ISymbolManager,
 } from '../ArtifactLoadingHelper';
+import { isBlockSymbol } from '../../../utils/symbolNarrowing';
 import { localizeTyped } from '../../../i18n/messageInstance';
 import { ErrorCodes } from '../../../generated/ErrorCodes';
 
@@ -314,9 +315,9 @@ export const InterfaceHierarchyValidator: Validator = {
           // Find class block first (if it exists)
           const classBlock = allMethodsForValidation.find(
             (s) =>
-              s.kind === SymbolKind.Block &&
+              isBlockSymbol(s) &&
               s.parentId === cls.id &&
-              (s as any).scopeType === 'class',
+              s.scopeType === 'class',
           );
           const classBlockId = classBlock?.id;
 
@@ -515,9 +516,9 @@ function getAllInterfaceMethods(
     // Find interface block first (if it exists) - interface blocks use 'class' scopeType
     const interfaceBlock = allSymbols.find(
       (s) =>
-        s.kind === SymbolKind.Block &&
+        isBlockSymbol(s) &&
         s.parentId === currentIface.id &&
-        (s as any).scopeType === 'class',
+        s.scopeType === 'class',
     );
     const interfaceBlockId = interfaceBlock?.id;
 

--- a/packages/apex-parser-ast/src/semantics/validation/validators/LiteralValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/LiteralValidator.ts
@@ -187,8 +187,8 @@ export const LiteralValidator: Validator = {
       );
 
       for (const ref of literalRefs) {
-        const literalType = (ref as any).literalType;
-        const literalValue = (ref as any).literalValue;
+        const literalType = ref.literalType;
+        const literalValue = ref.literalValue;
         const location = ref.location;
 
         if (!literalType || !location) continue;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/MethodCallValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/MethodCallValidator.ts
@@ -51,7 +51,10 @@ import {
 } from '../../../utils/symbolNarrowing';
 import type { ISymbolManager as ISymbolManagerInterface } from '../../../types/ISymbolManager';
 import { BaseApexParserListener } from '../../../parser/listeners/BaseApexParserListener';
-import { isContextType } from '../../../utils/contextTypeGuards';
+import {
+  isContextType,
+  getTypeNameFromCreatedName,
+} from '../../../utils/contextTypeGuards';
 import { ReferenceContext } from '../../../types/symbolReference';
 import { extractBaseTypeForResolution } from '../utils/typeUtils';
 
@@ -96,15 +99,7 @@ class MethodCallListener extends BaseApexParserListener<void> {
     if (creator) {
       const createdName = creator.createdName();
       if (createdName) {
-        // Try to get type name from createdName
-        let typeName: string | null = null;
-
-        const idCreatedNamePairs = createdName.idCreatedNamePair();
-        if (idCreatedNamePairs && idCreatedNamePairs.length > 0) {
-          typeName = idCreatedNamePairs
-            .map((pair) => pair.anyId().text)
-            .join('.');
-        }
+        const typeName = getTypeNameFromCreatedName(createdName);
 
         if (typeName) {
           const start = ctx.start;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/MethodCallValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/MethodCallValidator.ts
@@ -48,6 +48,12 @@ import { ErrorCodes } from '../../../generated/ErrorCodes';
 import {
   isBlockSymbol,
   isVariableSymbol,
+  isClassSymbol,
+  isMethodSymbol,
+  isConstructorSymbol,
+  isEnumSymbol,
+  isInterfaceSymbol,
+  inTypeSymbolGroup,
 } from '../../../utils/symbolNarrowing';
 import type { ISymbolManager as ISymbolManagerInterface } from '../../../types/ISymbolManager';
 import { BaseApexParserListener } from '../../../parser/listeners/BaseApexParserListener';
@@ -238,11 +244,7 @@ function findTypeByName(
     normalizedName.split('<')[0].split('.').pop() || normalizedName;
 
   const sameFile = allSymbols.find(
-    (s) =>
-      (s.kind === SymbolKind.Class ||
-        s.kind === SymbolKind.Interface ||
-        s.kind === SymbolKind.Enum) &&
-      s.name.toLowerCase() === baseName,
+    (s) => inTypeSymbolGroup(s) && s.name.toLowerCase() === baseName,
   ) as TypeSymbol | undefined;
 
   if (sameFile) return sameFile;
@@ -251,10 +253,7 @@ function findTypeByName(
     const symbols = symbolManager.findSymbolByName(typeName);
     const found = symbols?.find(
       (s: ApexSymbol) =>
-        (s.kind === SymbolKind.Class ||
-          s.kind === SymbolKind.Interface ||
-          s.kind === SymbolKind.Enum) &&
-        s.name.toLowerCase() === baseName,
+        inTypeSymbolGroup(s) && s.name.toLowerCase() === baseName,
     );
     if (found) return found as TypeSymbol;
   }
@@ -274,8 +273,7 @@ function findClassByName(
 
   // First, try to find in same file
   const classSymbol = allSymbols.find(
-    (s) =>
-      s.kind === SymbolKind.Class && s.name.toLowerCase() === normalizedName,
+    (s) => isClassSymbol(s) && s.name.toLowerCase() === normalizedName,
   ) as TypeSymbol | undefined;
 
   if (classSymbol) {
@@ -287,7 +285,7 @@ function findClassByName(
     const symbols = symbolManager.findSymbolByName(className);
     const crossFileClass = symbols.find(
       (s: ApexSymbol) =>
-        s.kind === SymbolKind.Class && s.name.toLowerCase() === normalizedName,
+        isClassSymbol(s) && s.name.toLowerCase() === normalizedName,
     ) as TypeSymbol | undefined;
 
     if (crossFileClass) {
@@ -347,7 +345,7 @@ function findMethodInClass(
   // Find methods in the class from same-file symbols
   let methods = allSymbols.filter(
     (s) =>
-      s.kind === SymbolKind.Method &&
+      isMethodSymbol(s) &&
       s.name.toLowerCase() === normalizedName &&
       methodParentIdMatches(s.parentId, classSymbol, validParentIds),
   ) as MethodSymbol[];
@@ -367,7 +365,7 @@ function findMethodInClass(
       );
       methods = fileSymbols.filter(
         (s: ApexSymbol) =>
-          s.kind === SymbolKind.Method &&
+          isMethodSymbol(s) &&
           s.name.toLowerCase() === normalizedName &&
           methodParentIdMatches(s.parentId, classSymbol, fileValidParentIds),
       ) as MethodSymbol[];
@@ -427,7 +425,7 @@ function findContainingClassForCall(
   methodCallLine?: number,
 ): TypeSymbol | null {
   const classes = allSymbols.filter(
-    (s) => s.kind === SymbolKind.Class && s.fileUri === fileUri,
+    (s) => isClassSymbol(s) && s.fileUri === fileUri,
   ) as TypeSymbol[];
 
   if (classes.length === 0) {
@@ -653,8 +651,8 @@ export const MethodCallValidator: Validator = {
                 code: ErrorCodes.INVALID_NEW_ABSTRACT,
               });
             } else if (
-              typeSymbol.kind === SymbolKind.Enum ||
-              typeSymbol.kind === SymbolKind.Interface
+              isEnumSymbol(typeSymbol) ||
+              isInterfaceSymbol(typeSymbol)
             ) {
               errors.push({
                 message: localizeTyped(
@@ -854,7 +852,7 @@ export const MethodCallValidator: Validator = {
             // Find constructors for this class
             const constructors = allSymbols.filter(
               (s) =>
-                s.kind === SymbolKind.Constructor &&
+                isConstructorSymbol(s) &&
                 s.name === classSymbol.name &&
                 (s.parentId === classSymbol.id ||
                   (s.parentId && s.parentId.startsWith(classSymbol.id + ':'))),

--- a/packages/apex-parser-ast/src/semantics/validation/validators/MethodCallValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/MethodCallValidator.ts
@@ -7,7 +7,12 @@
  */
 
 import { Effect } from 'effect';
-import { CharStreams, CommonTokenStream, DefaultErrorStrategy } from 'antlr4ts';
+import {
+  CharStreams,
+  CommonTokenStream,
+  DefaultErrorStrategy,
+  ParserRuleContext,
+} from 'antlr4ts';
 import {
   ApexLexer,
   ApexParser,
@@ -40,7 +45,11 @@ import { ValidationTier } from '../ValidationTier';
 import { ValidationError, type Validator } from '../ValidatorRegistry';
 import { localizeTyped } from '../../../i18n/messageInstance';
 import { ErrorCodes } from '../../../generated/ErrorCodes';
-import { isBlockSymbol } from '../../../utils/symbolNarrowing';
+import {
+  isBlockSymbol,
+  isVariableSymbol,
+} from '../../../utils/symbolNarrowing';
+import type { ISymbolManager as ISymbolManagerInterface } from '../../../types/ISymbolManager';
 import { BaseApexParserListener } from '../../../parser/listeners/BaseApexParserListener';
 import { isContextType } from '../../../utils/contextTypeGuards';
 import { ReferenceContext } from '../../../types/symbolReference';
@@ -63,7 +72,7 @@ interface MethodCallInfo {
   methodName: string;
   line: number;
   column: number;
-  ctx: MethodCallExpressionContext | DotMethodCallContext;
+  ctx: MethodCallExpressionContext | DotMethodCallContext | null;
   receiverName?: string; // Name of the receiver variable (e.g., "obj" in "obj.method()")
   /** True if receiver is a dot expression (obj.field), required for addError */
   receiverIsFieldAccess?: boolean;
@@ -90,29 +99,11 @@ class MethodCallListener extends BaseApexParserListener<void> {
         // Try to get type name from createdName
         let typeName: string | null = null;
 
-        // Check for typeName() directly (for collection types like List, Set, Map)
-        const typeNameNode = (createdName as any).typeName?.();
-        if (typeNameNode) {
-          typeName = typeNameNode.text || null;
-        }
-
-        // If not found, check idCreatedNamePair() structure (for regular types)
-        if (!typeName) {
-          const idCreatedNamePairs = createdName.idCreatedNamePair();
-          if (idCreatedNamePairs && idCreatedNamePairs.length > 0) {
-            const firstPair = idCreatedNamePairs[0];
-            const pairTypeName = (firstPair as any).typeName?.();
-            if (pairTypeName) {
-              typeName = pairTypeName.text || null;
-            }
-            // Also check for anyId() in the pair
-            if (!typeName) {
-              const anyId = firstPair.anyId?.();
-              if (anyId) {
-                typeName = anyId.text || null;
-              }
-            }
-          }
+        const idCreatedNamePairs = createdName.idCreatedNamePair();
+        if (idCreatedNamePairs && idCreatedNamePairs.length > 0) {
+          typeName = idCreatedNamePairs
+            .map((pair) => pair.anyId().text)
+            .join('.');
         }
 
         if (typeName) {
@@ -191,7 +182,7 @@ class MethodCallListener extends BaseApexParserListener<void> {
         methodName: methodName.trim(),
         line: start.line,
         column: start.charPositionInLine,
-        ctx: ctx as any,
+        ctx,
         receiverName,
         receiverIsFieldAccess,
         hasSafeNavigationBeforeCall,
@@ -202,7 +193,7 @@ class MethodCallListener extends BaseApexParserListener<void> {
   /**
    * Extract receiver name from an expression (for dot expressions like obj.method())
    */
-  private extractReceiverName(expr: any): string | undefined {
+  private extractReceiverName(expr: ParserRuleContext): string | undefined {
     if (!expr) return undefined;
 
     // Handle IdPrimaryContext (simple identifier like "obj")
@@ -245,7 +236,7 @@ class MethodCallListener extends BaseApexParserListener<void> {
 function findTypeByName(
   typeName: string,
   allSymbols: ApexSymbol[],
-  symbolManager?: any,
+  symbolManager?: ISymbolManagerInterface,
 ): TypeSymbol | null {
   const normalizedName = typeName.toLowerCase().trim();
   const baseName =
@@ -282,7 +273,7 @@ function findTypeByName(
 function findClassByName(
   className: string,
   allSymbols: ApexSymbol[],
-  symbolManager?: any, // ISymbolManagerInterface - using any to avoid circular dependency
+  symbolManager?: ISymbolManagerInterface,
 ): TypeSymbol | null {
   const normalizedName = className.toLowerCase().trim();
 
@@ -353,7 +344,7 @@ function findMethodInClass(
   methodName: string,
   classSymbol: TypeSymbol,
   allSymbols: ApexSymbol[],
-  symbolManager?: any, // ISymbolManagerInterface - using any to avoid circular dependency
+  symbolManager?: ISymbolManagerInterface,
 ): MethodSymbol | null {
   const normalizedName = methodName.toLowerCase().trim();
   const validParentIds = buildValidParentIdsForClass(classSymbol, allSymbols);
@@ -399,9 +390,8 @@ function findMethodInClassHierarchy(
   methodName: string,
   classSymbol: TypeSymbol,
   allSymbols: ApexSymbol[],
-  symbolManager?: any, // ISymbolManagerInterface - using any to avoid circular dependency
+  symbolManager?: ISymbolManagerInterface,
 ): MethodSymbol | null {
-  // First check the class itself (this now checks symbol manager if needed)
   let method = findMethodInClass(
     methodName,
     classSymbol,
@@ -604,7 +594,7 @@ export const MethodCallValidator: Validator = {
                 location?.identifierRange?.startColumn ??
                 location?.symbolRange?.startColumn ??
                 0,
-              ctx: null as any, // Not available from references
+              ctx: null,
               receiverName,
               receiverIsFieldAccess,
               receiverChain,
@@ -738,11 +728,10 @@ export const MethodCallValidator: Validator = {
                   s.fileUri === fileUri,
               );
 
-              if (receiverSymbol) {
-                const varSymbol = receiverSymbol as any;
-                if (varSymbol.type?.name) {
+              if (receiverSymbol && isVariableSymbol(receiverSymbol)) {
+                if (receiverSymbol.type?.name) {
                   const baseType = extractBaseTypeForResolution(
-                    varSymbol.type.name,
+                    receiverSymbol.type.name,
                   );
                   targetClass = findClassByName(
                     baseType,

--- a/packages/apex-parser-ast/src/semantics/validation/validators/MethodModifierRestrictionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/MethodModifierRestrictionValidator.ts
@@ -13,7 +13,12 @@ import type {
   TypeSymbol,
   MethodSymbol,
 } from '../../../types/symbol';
-import { SymbolKind, SymbolVisibility } from '../../../types/symbol';
+import { SymbolVisibility } from '../../../types/symbol';
+import {
+  isClassSymbol,
+  isBlockSymbol,
+  isMethodSymbol,
+} from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -46,20 +51,19 @@ function findContainingClass(
   let current: ApexSymbol | null = method;
 
   while (current) {
-    if (current.kind === SymbolKind.Class) {
-      return current as TypeSymbol;
+    if (isClassSymbol(current)) {
+      return current;
     }
 
     if (current.parentId) {
       const parent = allSymbols.find((s) => s.id === current!.parentId);
-      if (parent && parent.kind === SymbolKind.Class) {
-        return parent as TypeSymbol;
+      if (isClassSymbol(parent)) {
+        return parent;
       }
-      // If parent is a block, check its parent
-      if (parent && parent.kind === SymbolKind.Block && parent.parentId) {
+      if (isBlockSymbol(parent) && parent.parentId) {
         const grandParent = allSymbols.find((s) => s.id === parent!.parentId);
-        if (grandParent && grandParent.kind === SymbolKind.Class) {
-          return grandParent as TypeSymbol;
+        if (isClassSymbol(grandParent)) {
+          return grandParent;
         }
       }
       current = parent ?? null;
@@ -105,7 +109,7 @@ export const MethodModifierRestrictionValidator: Validator = {
       // Get all methods
       const methods = allSymbols.filter(
         (symbol): symbol is MethodSymbol =>
-          symbol.kind === SymbolKind.Method && 'parameters' in symbol,
+          isMethodSymbol(symbol) && 'parameters' in symbol,
       );
 
       // Group methods by containing class

--- a/packages/apex-parser-ast/src/semantics/validation/validators/MethodOverrideValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/MethodOverrideValidator.ts
@@ -14,8 +14,12 @@ import type {
   ApexSymbol,
   ScopeSymbol,
 } from '../../../types/symbol';
-import { SymbolKind, SymbolVisibility } from '../../../types/symbol';
-import { isMethodSymbol, isBlockSymbol } from '../../../utils/symbolNarrowing';
+import { SymbolVisibility } from '../../../types/symbol';
+import {
+  isClassSymbol,
+  isMethodSymbol,
+  isBlockSymbol,
+} from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -70,7 +74,7 @@ function findParentClassInSameFile(
 
   // Get all classes in the same file
   const allClasses = allSymbols.filter(
-    (s) => s.kind === SymbolKind.Class && s.fileUri === childFileUri, // Same file check
+    (s) => isClassSymbol(s) && s.fileUri === childFileUri, // Same file check
   ) as TypeSymbol[];
 
   // First, check if child class is an inner class extending its outer class
@@ -120,7 +124,6 @@ function findMethodsInClass(
   for (const symbol of allSymbols) {
     if (
       isMethodSymbol(symbol) &&
-      symbol.kind === SymbolKind.Method &&
       (symbol.parentId === classBlock?.id || symbol.parentId === classSymbol.id)
     ) {
       methods.push(symbol);
@@ -169,7 +172,7 @@ function findParentMethod(
   for (const parentMethod of parentMethods) {
     if (
       areMethodSignaturesIdentical(method, parentMethod, tier) &&
-      parentMethod.kind === SymbolKind.Method
+      isMethodSymbol(parentMethod)
     ) {
       return parentMethod;
     }
@@ -231,14 +234,10 @@ export const MethodOverrideValidator: Validator = {
       const tier = options.tier || ValidationTier.IMMEDIATE;
 
       // Get all classes in the file
-      const classes = allSymbols.filter(
-        (symbol) => symbol.kind === SymbolKind.Class,
-      ) as TypeSymbol[];
+      const classes = allSymbols.filter(isClassSymbol);
 
       // Get all methods
-      const methods = allSymbols.filter(
-        (symbol) => isMethodSymbol(symbol) && symbol.kind === SymbolKind.Method,
-      ) as MethodSymbol[];
+      const methods = allSymbols.filter(isMethodSymbol);
 
       // For each method, check override rules
       for (const method of methods) {

--- a/packages/apex-parser-ast/src/semantics/validation/validators/MethodResolutionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/MethodResolutionValidator.ts
@@ -16,7 +16,11 @@ import type {
   ScopeSymbol,
 } from '../../../types/symbol';
 import { SymbolKind, SymbolVisibility } from '../../../types/symbol';
-import { isMethodSymbol, isBlockSymbol } from '../../../utils/symbolNarrowing';
+import {
+  isMethodSymbol,
+  isBlockSymbol,
+  isClassOrInterfaceSymbol,
+} from '../../../utils/symbolNarrowing';
 import {
   ReferenceContext,
   type SymbolReference,
@@ -103,9 +107,9 @@ export const MethodResolutionValidator: Validator = {
       const allSymbols = symbolTable.getAllSymbols();
 
       // Find the containing class for context
-      const containingClass = allSymbols.find(
-        (s) => s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-      ) as TypeSymbol | undefined;
+      const containingClass = allSymbols.find((s): s is TypeSymbol =>
+        isClassOrInterfaceSymbol(s),
+      );
 
       if (!containingClass) {
         // No class context - skip validation
@@ -170,7 +174,7 @@ export const MethodResolutionValidator: Validator = {
           // Methods can have parentId pointing to either the class block or the class symbol
           const allMethodsInClass = allSymbols.filter(
             (s): s is MethodSymbol =>
-              s.kind === SymbolKind.Method &&
+              isMethodSymbol(s) &&
               (s.parentId === classBlock?.id ||
                 s.parentId === containingClass.id),
           );
@@ -337,11 +341,9 @@ export const MethodResolutionValidator: Validator = {
               );
               if (
                 resolutionResult.isResolved &&
-                resolutionResult.symbol &&
-                (resolutionResult.symbol.kind === SymbolKind.Class ||
-                  resolutionResult.symbol.kind === SymbolKind.Interface)
+                isClassOrInterfaceSymbol(resolutionResult.symbol)
               ) {
-                targetClass = resolutionResult.symbol as TypeSymbol;
+                targetClass = resolutionResult.symbol;
                 isStaticCall = false;
               }
             } else {
@@ -351,10 +353,9 @@ export const MethodResolutionValidator: Validator = {
                 symbolManager.getSymbol(qualifierNode.resolvedSymbolId);
               if (
                 preResolvedSymbol &&
-                (preResolvedSymbol.kind === SymbolKind.Class ||
-                  preResolvedSymbol.kind === SymbolKind.Interface)
+                isClassOrInterfaceSymbol(preResolvedSymbol)
               ) {
-                targetClass = preResolvedSymbol as TypeSymbol;
+                targetClass = preResolvedSymbol;
                 if (!receiverType.includes('.') && options.namespace) {
                   const preResolvedNamespace =
                     typeof preResolvedSymbol.namespace === 'string'
@@ -383,11 +384,9 @@ export const MethodResolutionValidator: Validator = {
                     );
                     if (
                       namespacedResult.isResolved &&
-                      namespacedResult.symbol &&
-                      (namespacedResult.symbol.kind === SymbolKind.Class ||
-                        namespacedResult.symbol.kind === SymbolKind.Interface)
+                      isClassOrInterfaceSymbol(namespacedResult.symbol)
                     ) {
-                      targetClass = namespacedResult.symbol as TypeSymbol;
+                      targetClass = namespacedResult.symbol;
                     }
                   }
                 }
@@ -421,11 +420,9 @@ export const MethodResolutionValidator: Validator = {
                 );
                 if (
                   resolutionResult.isResolved &&
-                  resolutionResult.symbol &&
-                  (resolutionResult.symbol.kind === SymbolKind.Class ||
-                    resolutionResult.symbol.kind === SymbolKind.Interface)
+                  isClassOrInterfaceSymbol(resolutionResult.symbol)
                 ) {
-                  targetClass = resolutionResult.symbol as TypeSymbol;
+                  targetClass = resolutionResult.symbol;
                   isStaticCall = true;
                 } else {
                   continue;
@@ -826,8 +823,7 @@ function resolveMethodCallReceiverType(
           // Try class/interface lookup (e.g. for System from stdlib)
           const foundClass = symbolsByName.find(
             (s) =>
-              (s.kind === SymbolKind.Class ||
-                s.kind === SymbolKind.Interface) &&
+              isClassOrInterfaceSymbol(s) &&
               s.name?.toLowerCase() === receiverName.toLowerCase(),
           );
           if (foundClass) {
@@ -962,7 +958,7 @@ function resolveMethodCallReceiverType(
       // Try class/interface lookup
       const foundClass = symbolsByName.find(
         (s) =>
-          (s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface) &&
+          isClassOrInterfaceSymbol(s) &&
           s.name?.toLowerCase() === receiverName.toLowerCase(),
       );
       if (foundClass) {
@@ -1117,30 +1113,19 @@ function findDeclaringClass(
 
   let current: ApexSymbol | null = method;
   while (current) {
-    if (
-      current.kind === SymbolKind.Class ||
-      current.kind === SymbolKind.Interface
-    ) {
-      return current as TypeSymbol;
+    if (isClassOrInterfaceSymbol(current)) {
+      return current;
     }
     if (current.parentId) {
       const parent = resolveParent(current.parentId);
-      if (
-        parent &&
-        (parent.kind === SymbolKind.Class ||
-          parent.kind === SymbolKind.Interface)
-      ) {
-        return parent as TypeSymbol;
+      if (isClassOrInterfaceSymbol(parent)) {
+        return parent;
       }
       // If parent is a block, check its parent
-      if (parent && parent.kind === SymbolKind.Block && parent.parentId) {
+      if (isBlockSymbol(parent) && parent.parentId) {
         const grandParent = resolveParent(parent.parentId);
-        if (
-          grandParent &&
-          (grandParent.kind === SymbolKind.Class ||
-            grandParent.kind === SymbolKind.Interface)
-        ) {
-          return grandParent as TypeSymbol;
+        if (isClassOrInterfaceSymbol(grandParent)) {
+          return grandParent;
         }
       }
       current = parent ?? null;
@@ -1172,9 +1157,8 @@ function isSubclassOf(
       childClass.superClass,
     );
     const superClassSymbol = superClassSymbols.find(
-      (s: ApexSymbol) =>
-        s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-    ) as TypeSymbol | undefined;
+      (s: ApexSymbol): s is TypeSymbol => isClassOrInterfaceSymbol(s),
+    );
 
     if (superClassSymbol) {
       return isSubclassOf(
@@ -1222,10 +1206,7 @@ function findMethodsInClass(
 
   // First, try to get methods from allSymbols (same-file or already loaded)
   let methodsInFile = allSymbols.filter(
-    (s) =>
-      isMethodSymbol(s) &&
-      s.kind === SymbolKind.Method &&
-      s.fileUri === targetFileUri,
+    (s) => isMethodSymbol(s) && s.fileUri === targetFileUri,
   ) as MethodSymbol[];
 
   // If no methods found and this is a standard library class, try to get methods from symbol manager
@@ -1237,8 +1218,8 @@ function findMethodsInClass(
     // For standard library classes, get all symbols from the file using findSymbolsInFile
     const fileSymbols = symbolManager.findSymbolsInFile(targetFileUri);
 
-    methodsInFile = fileSymbols.filter(
-      (s: ApexSymbol) => isMethodSymbol(s) && s.kind === SymbolKind.Method,
+    methodsInFile = fileSymbols.filter((s: ApexSymbol) =>
+      isMethodSymbol(s),
     ) as MethodSymbol[];
   }
 
@@ -1255,11 +1236,8 @@ function findMethodsInClass(
     // Traverse up the parentId chain to find the declaring class
     while (current && !visited.has(current.id)) {
       visited.add(current.id);
-      if (
-        current.kind === SymbolKind.Class ||
-        current.kind === SymbolKind.Interface
-      ) {
-        declaringClass = current as TypeSymbol;
+      if (isClassOrInterfaceSymbol(current)) {
+        declaringClass = current;
         break;
       }
       if (current.parentId) {
@@ -1313,19 +1291,13 @@ function findMethodsInClass(
         // If not found in allSymbols and we have symbolManager, try to get it from symbol manager
         if (!blockParent && symbolManager && parentBlock.parentId) {
           const parentSymbol = symbolManager.getSymbol(parentBlock.parentId);
-          if (
-            parentSymbol &&
-            (parentSymbol.kind === SymbolKind.Class ||
-              parentSymbol.kind === SymbolKind.Interface)
-          ) {
+          if (isClassOrInterfaceSymbol(parentSymbol)) {
             blockParent = parentSymbol;
           }
         }
 
         if (
-          blockParent &&
-          (blockParent.kind === SymbolKind.Class ||
-            blockParent.kind === SymbolKind.Interface) &&
+          isClassOrInterfaceSymbol(blockParent) &&
           blockParent.name === classSymbol.name &&
           blockParent.fileUri === classSymbol.fileUri
         ) {
@@ -1975,9 +1947,8 @@ function findMethodsInSuperclass(
     // Find the superclass type symbol
     const superClassSymbols = symbolManager.findSymbolByName(superClassName);
     const superClassSymbol = superClassSymbols.find(
-      (s: ApexSymbol) =>
-        s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-    ) as TypeSymbol | undefined;
+      (s: ApexSymbol): s is TypeSymbol => isClassOrInterfaceSymbol(s),
+    );
 
     if (!superClassSymbol) {
       // Superclass not found - might need artifact loading

--- a/packages/apex-parser-ast/src/semantics/validation/validators/MethodResolutionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/MethodResolutionValidator.ts
@@ -1383,7 +1383,7 @@ function validateMethodReturnType(
     // Verify we have the right method (name match)
     const chainNodes = methodCall.chainNodes;
     const actualMethodName =
-      chainNodes?.length > 0
+      chainNodes && chainNodes.length > 0
         ? chainNodes[chainNodes.length - 1]?.name
         : methodCall.name?.split('.').pop();
     if (

--- a/packages/apex-parser-ast/src/semantics/validation/validators/MethodResolutionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/MethodResolutionValidator.ts
@@ -17,7 +17,10 @@ import type {
 } from '../../../types/symbol';
 import { SymbolKind, SymbolVisibility } from '../../../types/symbol';
 import { isMethodSymbol, isBlockSymbol } from '../../../utils/symbolNarrowing';
-import { ReferenceContext } from '../../../types/symbolReference';
+import {
+  ReferenceContext,
+  type SymbolReference,
+} from '../../../types/symbolReference';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -158,8 +161,8 @@ export const MethodResolutionValidator: Validator = {
           // Find the class block (methods have parentId pointing to class block, not class symbol)
           const classBlock = allSymbols.find(
             (s) =>
-              s.kind === SymbolKind.Block &&
-              (s as any).scopeType === 'class' &&
+              isBlockSymbol(s) &&
+              s.scopeType === 'class' &&
               s.parentId === containingClass.id,
           );
 
@@ -726,7 +729,7 @@ function extractReceiverNameFromSource(
  * Returns the type name if found, null otherwise
  */
 function resolveMethodCallReceiverType(
-  methodCall: any,
+  methodCall: SymbolReference,
   sourceContent: string,
   symbolTable: SymbolTable,
   symbolManager?: ISymbolManagerInterface,
@@ -1345,7 +1348,7 @@ function findMethodsInClass(
  * Checks if the method call's return type matches the variable it's assigned to
  */
 function validateMethodReturnType(
-  methodCall: any,
+  methodCall: SymbolReference,
   visibleMethods: MethodSymbol[],
   symbolTable: SymbolTable,
   sourceContent: string,
@@ -1378,9 +1381,10 @@ function validateMethodReturnType(
     }
 
     // Verify we have the right method (name match)
+    const chainNodes = methodCall.chainNodes;
     const actualMethodName =
-      methodCall.chainNodes?.length > 0
-        ? methodCall.chainNodes[methodCall.chainNodes.length - 1]?.name
+      chainNodes && chainNodes.length > 0
+        ? chainNodes[chainNodes.length - 1]?.name
         : methodCall.name?.split('.').pop();
     if (
       actualMethodName &&
@@ -1434,7 +1438,7 @@ function validateMethodReturnType(
  * Returns the variable name and type if the method call is on the RHS of an assignment
  */
 function extractAssignmentContext(
-  methodCall: any,
+  methodCall: SymbolReference,
   sourceContent: string,
   symbolTable: SymbolTable,
   symbolManager?: ISymbolManagerInterface,
@@ -1651,7 +1655,7 @@ function areReturnTypesCompatible(
  * Similar to constructor argument extraction but for method calls
  */
 function extractMethodCallArgumentTypes(
-  methodCall: any, // SymbolReference with METHOD_CALL context
+  methodCall: SymbolReference,
   sourceContent: string,
   symbolTable: SymbolTable,
   symbolManager?: ISymbolManagerInterface,

--- a/packages/apex-parser-ast/src/semantics/validation/validators/MethodResolutionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/MethodResolutionValidator.ts
@@ -1383,7 +1383,7 @@ function validateMethodReturnType(
     // Verify we have the right method (name match)
     const chainNodes = methodCall.chainNodes;
     const actualMethodName =
-      chainNodes && chainNodes.length > 0
+      chainNodes?.length > 0
         ? chainNodes[chainNodes.length - 1]?.name
         : methodCall.name?.split('.').pop();
     if (

--- a/packages/apex-parser-ast/src/semantics/validation/validators/MethodSignatureEquivalenceValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/MethodSignatureEquivalenceValidator.ts
@@ -8,7 +8,7 @@
 
 import { Effect } from 'effect';
 import type { SymbolTable, MethodSymbol } from '../../../types/symbol';
-import { SymbolKind } from '../../../types/symbol';
+import { isMethodSymbol } from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -69,9 +69,7 @@ export const MethodSignatureEquivalenceValidator: Validator = {
       const allSymbols = symbolTable.getAllSymbols();
 
       // Filter to method symbols only (not constructors)
-      const allMethods = allSymbols.filter(
-        (symbol) => symbol.kind === SymbolKind.Method,
-      ) as MethodSymbol[];
+      const allMethods = allSymbols.filter(isMethodSymbol);
 
       // Deduplicate methods: for each unique unifiedId, keep only one method
       // This prevents duplicate error reports when duplicate methods are stored

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ModifierValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ModifierValidator.ts
@@ -15,7 +15,17 @@ import type {
   MethodSymbol,
 } from '../../../types/symbol';
 import { SymbolKind, SymbolVisibility } from '../../../types/symbol';
-import { isMethodSymbol, isBlockSymbol } from '../../../utils/symbolNarrowing';
+import {
+  isMethodSymbol,
+  isBlockSymbol,
+  isClassSymbol,
+  isInterfaceSymbol,
+  isEnumSymbol,
+  isTriggerSymbol,
+  inTypeSymbolGroup,
+  isFieldSymbol,
+  isPropertySymbol,
+} from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -41,12 +51,7 @@ import { isStandardTypeAlias } from '../utils/standardTypeIdentity';
  * Check if a symbol is an inner type (class, interface, enum)
  */
 function isInnerType(symbol: ApexSymbol): boolean {
-  return (
-    (symbol.kind === SymbolKind.Class ||
-      symbol.kind === SymbolKind.Interface ||
-      symbol.kind === SymbolKind.Enum) &&
-    symbol.parentId !== null
-  );
+  return inTypeSymbolGroup(symbol) && symbol.parentId !== null;
 }
 
 /**
@@ -57,7 +62,7 @@ function findContainingClass(
   allSymbols: ApexSymbol[],
 ): TypeSymbol | undefined {
   let parentClass: TypeSymbol | undefined = allSymbols.find(
-    (s) => s.id === symbol.parentId && s.kind === SymbolKind.Class,
+    (s) => s.id === symbol.parentId && isClassSymbol(s),
   ) as TypeSymbol | undefined;
 
   if (!parentClass) {
@@ -66,7 +71,7 @@ function findContainingClass(
     ) as ScopeSymbol | undefined;
     if (block && block.scopeType === 'class') {
       parentClass = allSymbols.find(
-        (s) => s.id === block.parentId && s.kind === SymbolKind.Class,
+        (s) => s.id === block.parentId && isClassSymbol(s),
       ) as TypeSymbol | undefined;
     }
   }
@@ -81,14 +86,8 @@ function findContainingType(
   symbol: ApexSymbol,
   allSymbols: ApexSymbol[],
 ): TypeSymbol | undefined {
-  const typeKinds = [
-    SymbolKind.Class,
-    SymbolKind.Interface,
-    SymbolKind.Enum,
-    SymbolKind.Trigger,
-  ];
   let parent = allSymbols.find(
-    (s) => s.id === symbol.parentId && typeKinds.includes(s.kind),
+    (s) => s.id === symbol.parentId && inTypeSymbolGroup(s),
   ) as TypeSymbol | undefined;
   if (!parent) {
     const block = allSymbols.find(
@@ -96,7 +95,7 @@ function findContainingType(
     ) as ScopeSymbol | undefined;
     if (block && block.scopeType === 'class') {
       parent = allSymbols.find(
-        (s) => s.id === block.parentId && typeKinds.includes(s.kind),
+        (s) => s.id === block.parentId && inTypeSymbolGroup(s),
       ) as TypeSymbol | undefined;
     }
   }
@@ -110,10 +109,10 @@ function getUnitTypeForSymbol(
   typeSymbol: TypeSymbol,
   fileUri: string,
 ): UnitType {
-  if (typeSymbol.kind === SymbolKind.Trigger) return 'TRIGGER';
-  if (typeSymbol.kind === SymbolKind.Interface) return 'INTERFACE';
-  if (typeSymbol.kind === SymbolKind.Enum) return 'ENUM';
-  if (typeSymbol.kind === SymbolKind.Class) return 'CLASS';
+  if (isTriggerSymbol(typeSymbol)) return 'TRIGGER';
+  if (isInterfaceSymbol(typeSymbol)) return 'INTERFACE';
+  if (isEnumSymbol(typeSymbol)) return 'ENUM';
+  if (isClassSymbol(typeSymbol)) return 'CLASS';
   if (fileUri.endsWith('.trigger')) return 'TRIGGER';
   if (fileUri.endsWith('.apex')) return 'ANONYMOUS';
   return 'CLASS';
@@ -427,9 +426,7 @@ export const ModifierValidator: Validator = {
         // For interfaces, the listener may sanitize Default→Public; use source when available
         if (
           symbol.parentId === null &&
-          (kind === SymbolKind.Class ||
-            kind === SymbolKind.Interface ||
-            kind === SymbolKind.Enum) &&
+          inTypeSymbolGroup(symbol) &&
           symbol.location
         ) {
           let hasPublicOrGlobal =
@@ -441,7 +438,7 @@ export const ModifierValidator: Validator = {
 
           // Interfaces: listener sanitizes Default to Public; check source for explicit modifier
           if (
-            kind === SymbolKind.Interface &&
+            isInterfaceSymbol(symbol) &&
             hasPublicOrGlobal &&
             options.sourceContent &&
             symbol.location.symbolRange
@@ -477,7 +474,7 @@ export const ModifierValidator: Validator = {
 
         // Check 4c: TYPE_MUST_BE_TOP_LEVEL - inner class cannot implement Database.Batchable/InboundEmailHandler
         if (
-          kind === SymbolKind.Class &&
+          isClassSymbol(symbol) &&
           symbol.parentId !== null &&
           symbol.location
         ) {
@@ -504,7 +501,7 @@ export const ModifierValidator: Validator = {
 
         // Check 4d: DEFINING_TYPE_REQUIRES - abstract method in global class must be global (API 14+)
         if (
-          kind === SymbolKind.Method &&
+          isMethodSymbol(symbol) &&
           modifiers.isAbstract &&
           symbol.location &&
           options.enableVersionSpecificValidation &&
@@ -512,7 +509,7 @@ export const ModifierValidator: Validator = {
         ) {
           const containingType = findContainingType(symbol, allSymbols);
           if (
-            containingType?.kind === SymbolKind.Class &&
+            isClassSymbol(containingType) &&
             containingType.modifiers?.visibility === SymbolVisibility.Global &&
             modifiers.visibility !== SymbolVisibility.Global
           ) {
@@ -530,7 +527,7 @@ export const ModifierValidator: Validator = {
 
         // Check 4e: API 65+ - abstract/override methods require protected, public, or global
         if (
-          kind === SymbolKind.Method &&
+          isMethodSymbol(symbol) &&
           (modifiers.isAbstract || modifiers.isOverride) &&
           symbol.location &&
           options.enableVersionSpecificValidation &&
@@ -570,14 +567,14 @@ export const ModifierValidator: Validator = {
           }
 
           // webService also requires global class
-          if (kind === SymbolKind.Method || kind === SymbolKind.Property) {
+          if (isMethodSymbol(symbol) || isPropertySymbol(symbol)) {
             // Find parent class
             // Methods/properties have parentId pointing to class blocks, not class symbols
             let parentClass: TypeSymbol | undefined;
 
             // First, try direct match (in case parentId points to class symbol)
             parentClass = allSymbols.find(
-              (s) => s.id === symbol.parentId && s.kind === SymbolKind.Class,
+              (s) => s.id === symbol.parentId && isClassSymbol(s),
             ) as TypeSymbol | undefined;
 
             // If not found, symbol.parentId points to a class block
@@ -589,9 +586,7 @@ export const ModifierValidator: Validator = {
               if (methodBlock && methodBlock.scopeType === 'class') {
                 // Class block's parentId points to the class symbol
                 parentClass = allSymbols.find(
-                  (s) =>
-                    s.id === methodBlock.parentId &&
-                    s.kind === SymbolKind.Class,
+                  (s) => s.id === methodBlock.parentId && isClassSymbol(s),
                 ) as TypeSymbol | undefined;
               }
             }
@@ -615,7 +610,7 @@ export const ModifierValidator: Validator = {
         }
 
         // Check 6: Invalid modifier combinations for specific symbol types
-        if (kind === SymbolKind.Field || kind === SymbolKind.Property) {
+        if (isFieldSymbol(symbol) || isPropertySymbol(symbol)) {
           // Protected only for instance member variables per Apex doc
           if (
             modifiers.visibility === SymbolVisibility.Protected &&
@@ -634,7 +629,7 @@ export const ModifierValidator: Validator = {
 
           // Check source content for invalid modifiers on fields
           // (parser sanitizes these, so we need to check source directly)
-          if (options.sourceContent && kind === SymbolKind.Field) {
+          if (options.sourceContent && isFieldSymbol(symbol)) {
             const location = symbol.location;
             if (location && location.symbolRange) {
               const lineIndex = location.symbolRange.startLine - 1;
@@ -689,7 +684,7 @@ export const ModifierValidator: Validator = {
           }
 
           // Virtual not allowed on fields (check symbol table as fallback)
-          if (modifiers.isVirtual && kind === SymbolKind.Field) {
+          if (modifiers.isVirtual && isFieldSymbol(symbol)) {
             errors.push({
               message: localizeTyped(
                 ErrorCodes.MODIFIER_IS_NOT_ALLOWED,
@@ -729,7 +724,7 @@ export const ModifierValidator: Validator = {
         }
 
         // Check 7: Invalid modifiers on methods
-        if (isMethodSymbol(symbol) && symbol.kind === SymbolKind.Method) {
+        if (isMethodSymbol(symbol)) {
           // Protected only for instance methods per Apex doc
           if (
             modifiers.visibility === SymbolVisibility.Protected &&
@@ -819,7 +814,7 @@ export const ModifierValidator: Validator = {
         }
 
         // Check 8: Invalid modifiers on classes
-        if (kind === SymbolKind.Class) {
+        if (isClassSymbol(symbol)) {
           // Final redundant on classes (classes are final by default)
           if (modifiers.isFinal) {
             warnings.push({
@@ -848,7 +843,7 @@ export const ModifierValidator: Validator = {
         }
 
         // Check 9: Invalid modifiers on interfaces
-        if (kind === SymbolKind.Interface) {
+        if (isInterfaceSymbol(symbol)) {
           // Final not allowed on interfaces
           if (modifiers.isFinal) {
             errors.push({
@@ -958,9 +953,9 @@ export const ModifierValidator: Validator = {
 
       // MODIFIER_REQUIRE_AT_LEAST: Test class must have at least one test method
       const classes = allSymbols.filter(
-        (s) => s.kind === SymbolKind.Class && s.parentId === null,
+        (s) => isClassSymbol(s) && s.parentId === null,
       ) as TypeSymbol[];
-      const methods = allSymbols.filter((s) => s.kind === SymbolKind.Method);
+      const methods = allSymbols.filter((s) => isMethodSymbol(s));
 
       for (const classSymbol of classes) {
         const hasIsTestClass =

--- a/packages/apex-parser-ast/src/semantics/validation/validators/NewExpressionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/NewExpressionValidator.ts
@@ -257,13 +257,13 @@ export const NewExpressionValidator: Validator = {
           const outerClassBlock = allSymbols.find(
             (s) =>
               isBlockSymbol(s) &&
-              (s as any).scopeType === 'class' &&
+              s.scopeType === 'class' &&
               s.parentId === outerType.id,
           );
           const innerClassBlock = allSymbols.find(
             (s) =>
               isBlockSymbol(s) &&
-              (s as any).scopeType === 'class' &&
+              s.scopeType === 'class' &&
               s.parentId === resolvedType.id,
           );
           const memberParentIds = [

--- a/packages/apex-parser-ast/src/semantics/validation/validators/NewExpressionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/NewExpressionValidator.ts
@@ -15,7 +15,14 @@ import type {
   ScopeSymbol,
 } from '../../../types/symbol';
 import { SymbolKind } from '../../../types/symbol';
-import { isBlockSymbol } from '../../../utils/symbolNarrowing';
+import {
+  inTypeSymbolGroup,
+  isBlockSymbol,
+  isClassOrInterfaceSymbol,
+  isFieldSymbol,
+  isMethodSymbol,
+  isPropertySymbol,
+} from '../../../utils/symbolNarrowing';
 import { ReferenceContext } from '../../../types/symbolReference';
 import type {
   ValidationResult,
@@ -51,20 +58,19 @@ function extendsException(
   while (current && !visited.has(current.id)) {
     visited.add(current.id);
     if (current.superClass) {
-      const superName = current.superClass.toLowerCase();
+      const superName: string = current.superClass.toLowerCase();
       if (superName === 'exception') {
         return true;
       }
       const superSymbols = symbolManager.findSymbolByName(current.superClass);
-      const fromAll = allSymbols.filter(
-        (s) =>
-          (s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface) &&
-          s.name.toLowerCase() === superName,
+      const fromAll: TypeSymbol[] = allSymbols.filter(
+        (s): s is TypeSymbol =>
+          isClassOrInterfaceSymbol(s) && s.name.toLowerCase() === superName,
       );
-      const superSymbol = [...fromAll, ...superSymbols].find(
-        (s: ApexSymbol) =>
-          s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-      ) as TypeSymbol | undefined;
+      const superSymbol: TypeSymbol | undefined = [
+        ...fromAll,
+        ...superSymbols,
+      ].find(isClassOrInterfaceSymbol);
       current = superSymbol;
     } else if (
       current.interfaces?.some((i) => i.toLowerCase() === 'exception')
@@ -120,9 +126,7 @@ export const NewExpressionValidator: Validator = {
         (r) => r.context === ReferenceContext.CONSTRUCTOR_CALL,
       );
 
-      const containingClass = allSymbols.find(
-        (s) => s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-      ) as TypeSymbol | undefined;
+      const containingClass = allSymbols.find(isClassOrInterfaceSymbol);
 
       if (!containingClass) {
         return { isValid: true, errors, warnings };
@@ -133,23 +137,18 @@ export const NewExpressionValidator: Validator = {
         const innerName = extractInnerTypeName(typeName);
 
         let resolvedType = allSymbols.find(
-          (s) =>
-            (s.kind === SymbolKind.Class ||
-              s.kind === SymbolKind.Interface ||
-              s.kind === SymbolKind.Enum) &&
+          (s): s is TypeSymbol =>
+            inTypeSymbolGroup(s) &&
             (s.name === innerName ||
               s.name === typeName ||
               typeName.endsWith('.' + s.name)),
-        ) as TypeSymbol | undefined;
+        );
 
         if (!resolvedType) {
           const symbols = symbolManager.findSymbolByName(typeName);
-          resolvedType = symbols.find(
-            (s: ApexSymbol) =>
-              s.kind === SymbolKind.Class ||
-              s.kind === SymbolKind.Interface ||
-              s.kind === SymbolKind.Enum,
-          ) as TypeSymbol | undefined;
+          resolvedType = symbols.find((s: ApexSymbol): s is TypeSymbol =>
+            inTypeSymbolGroup(s),
+          );
         }
 
         if (!resolvedType) continue;
@@ -183,24 +182,19 @@ export const NewExpressionValidator: Validator = {
         if (outerType && isBlockSymbol(outerType)) {
           const block = outerType as ScopeSymbol;
           const typeSymbol = allSymbols.find(
-            (s) =>
-              s.id === block.parentId &&
-              (s.kind === SymbolKind.Class ||
-                s.kind === SymbolKind.Interface ||
-                s.kind === SymbolKind.Enum),
+            (s): s is TypeSymbol =>
+              s.id === block.parentId && inTypeSymbolGroup(s),
           );
-          outerType = (typeSymbol as TypeSymbol | undefined) ?? null;
+          outerType = typeSymbol ?? null;
         }
 
         if (!outerType && typeName.includes('.')) {
           const outerName = typeName.split('.')[0];
           outerType =
-            (allSymbols.find(
-              (s) =>
-                (s.kind === SymbolKind.Class ||
-                  s.kind === SymbolKind.Interface) &&
-                s.name === outerName,
-            ) as TypeSymbol | undefined) ?? null;
+            allSymbols.find(
+              (s): s is TypeSymbol =>
+                isClassOrInterfaceSymbol(s) && s.name === outerName,
+            ) ?? null;
         }
 
         if (outerType) {
@@ -240,8 +234,7 @@ export const NewExpressionValidator: Validator = {
 
           const otherInnerTypes = allSymbols.filter(
             (s) =>
-              (s.kind === SymbolKind.Class ||
-                s.kind === SymbolKind.Interface) &&
+              isClassOrInterfaceSymbol(s) &&
               s.parentId === outerType.id &&
               s.name.toLowerCase() === innerName.toLowerCase() &&
               s.id !== resolvedType.id,
@@ -274,9 +267,7 @@ export const NewExpressionValidator: Validator = {
           ].filter(Boolean) as string[];
           const members = allSymbols.filter(
             (s) =>
-              (s.kind === SymbolKind.Field ||
-                s.kind === SymbolKind.Property ||
-                s.kind === SymbolKind.Method) &&
+              (isFieldSymbol(s) || isPropertySymbol(s) || isMethodSymbol(s)) &&
               memberParentIds.includes(s.parentId ?? '') &&
               s.name.toLowerCase() === innerName.toLowerCase(),
           );

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ParameterizedTypeValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ParameterizedTypeValidator.ts
@@ -18,13 +18,12 @@ import {
   ParseTreeWalker,
   TypeRefContext,
 } from '@apexdevtools/apex-parser';
-import type {
-  SymbolTable,
-  SymbolLocation,
-  VariableSymbol,
-  MethodSymbol,
-} from '../../../types/symbol';
-import { SymbolKind } from '../../../types/symbol';
+import type { SymbolTable, SymbolLocation } from '../../../types/symbol';
+import {
+  isVariableSymbol,
+  isMethodSymbol,
+  isConstructorSymbol,
+} from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -279,21 +278,12 @@ export const ParameterizedTypeValidator: Validator = {
         let typeStr: string | undefined;
         let location: SymbolLocation | undefined;
 
-        if (
-          symbol.kind === SymbolKind.Field ||
-          symbol.kind === SymbolKind.Property ||
-          symbol.kind === SymbolKind.Variable ||
-          symbol.kind === SymbolKind.Parameter ||
-          symbol.kind === SymbolKind.EnumValue
-        ) {
-          const v = symbol as VariableSymbol;
+        if (isVariableSymbol(symbol)) {
+          const v = symbol;
           typeStr = v.type?.originalTypeString;
           location = v.location;
-        } else if (
-          symbol.kind === SymbolKind.Method ||
-          symbol.kind === SymbolKind.Constructor
-        ) {
-          const m = symbol as MethodSymbol;
+        } else if (isMethodSymbol(symbol) || isConstructorSymbol(symbol)) {
+          const m = symbol;
           typeStr = m.returnType?.originalTypeString;
           location = m.location;
         }

--- a/packages/apex-parser-ast/src/semantics/validation/validators/PropertyAccessorValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/PropertyAccessorValidator.ts
@@ -33,7 +33,7 @@ import { localizeTyped } from '../../../i18n/messageInstance';
 import { ErrorCodes } from '../../../generated/ErrorCodes';
 import { BaseApexParserListener } from '../../../parser/listeners/BaseApexParserListener';
 import type { ParserRuleContext } from 'antlr4ts';
-import { SymbolKind } from '../../../types/symbol';
+import { isPropertySymbol } from '../../../utils/symbolNarrowing';
 
 /**
  * Helper function to create SymbolLocation from parse tree context
@@ -222,7 +222,7 @@ export const PropertyAccessorValidator: Validator = {
           // Find the property symbol to check if it's final
           const propertySymbol = allSymbols.find(
             (s) =>
-              s.kind === SymbolKind.Property &&
+              isPropertySymbol(s) &&
               s.name?.toLowerCase() === prop.propertyName.toLowerCase(),
           ) as VariableSymbol | undefined;
 

--- a/packages/apex-parser-ast/src/semantics/validation/validators/PropertyAccessorValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/PropertyAccessorValidator.ts
@@ -15,6 +15,9 @@ import {
   ApexLexer,
   ApexParser,
   CaseInsensitiveInputStream,
+  CompilationUnitContext,
+  TriggerUnitContext,
+  BlockContext,
   ParseTreeWalker,
 } from '@apexdevtools/apex-parser';
 import type { SymbolTable, VariableSymbol } from '../../../types/symbol';
@@ -176,7 +179,10 @@ export const PropertyAccessorValidator: Validator = {
 
       try {
         // Use cached parse tree if available, otherwise parse source content
-        let parseTree: any;
+        let parseTree:
+          | CompilationUnitContext
+          | TriggerUnitContext
+          | BlockContext;
         if (options.parseTree) {
           parseTree = options.parseTree;
         } else {

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ReturnStatementValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ReturnStatementValidator.ts
@@ -27,7 +27,10 @@ import type {
   SymbolLocation,
   MethodSymbol,
 } from '../../../types/symbol';
-import { SymbolKind } from '../../../types/symbol';
+import {
+  isMethodSymbol,
+  isTriggerSymbol,
+} from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -347,7 +350,7 @@ export const ReturnStatementValidator: Validator = {
         const allSymbols = symbolTable.getAllSymbols();
         const methods = allSymbols.filter(
           (symbol): symbol is MethodSymbol =>
-            symbol.kind === SymbolKind.Method && 'returnType' in symbol,
+            isMethodSymbol(symbol) && 'returnType' in symbol,
         );
 
         // Build a set of void method names and map of method return types
@@ -382,9 +385,7 @@ export const ReturnStatementValidator: Validator = {
         );
 
         // Check if this is a trigger file
-        const triggers = allSymbols.filter(
-          (symbol) => symbol.kind === SymbolKind.Trigger,
-        );
+        const triggers = allSymbols.filter(isTriggerSymbol);
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const hasTrigger = triggers.length > 0 || isTriggerFile;
 

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ReturnStatementValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ReturnStatementValidator.ts
@@ -38,6 +38,7 @@ import { ValidationTier } from '../ValidationTier';
 import { ValidationError, type Validator } from '../ValidatorRegistry';
 import { localizeTyped } from '../../../i18n/messageInstance';
 import { ErrorCodes } from '../../../generated/ErrorCodes';
+import type { ErrorCodeKey } from '../../../generated/messages_en_US';
 import { BaseApexParserListener } from '../../../parser/listeners/BaseApexParserListener';
 import type { ParserRuleContext } from 'antlr4ts';
 import {
@@ -86,7 +87,7 @@ function isVoidReturnType(method: MethodSymbol): boolean {
 class ReturnStatementListener extends BaseApexParserListener<void> {
   private errors: Array<{
     ctx: ReturnStatementContext;
-    code: string;
+    code: ErrorCodeKey;
     returnType?: string;
     expressionType?: string;
   }> = [];
@@ -170,7 +171,7 @@ class ReturnStatementListener extends BaseApexParserListener<void> {
   }
 
   // Track trigger context (for trigger files)
-  enterTriggerUnit(ctx: any): void {
+  enterTriggerUnit(ctx: TriggerUnitContext): void {
     this.isInTrigger = true;
   }
 
@@ -273,7 +274,7 @@ class ReturnStatementListener extends BaseApexParserListener<void> {
 
   getErrors(): Array<{
     ctx: ReturnStatementContext;
-    code: string;
+    code: ErrorCodeKey;
     returnType?: string;
     expressionType?: string;
   }> {
@@ -439,9 +440,9 @@ export const ReturnStatementValidator: Validator = {
         for (const { ctx, code } of returnErrors) {
           const location = getLocationFromContext(ctx);
           errors.push({
-            message: localizeTyped(code as any),
+            message: localizeTyped(code),
             location,
-            code: code as any,
+            code,
           });
         }
 

--- a/packages/apex-parser-ast/src/semantics/validation/validators/StaticContextValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/StaticContextValidator.ts
@@ -23,16 +23,21 @@ import type {
   SymbolLocation,
   ApexSymbol,
   TypeSymbol,
-  MethodSymbol,
   VariableSymbol,
-  ScopeSymbol,
 } from '../../../types/symbol';
 import { SymbolKind } from '../../../types/symbol';
 import {
   ReferenceContext,
   type SymbolReference,
 } from '../../../types/symbolReference';
-import { isChainedSymbolReference } from '../../../utils/symbolNarrowing';
+import {
+  isChainedSymbolReference,
+  isMethodSymbol,
+  isBlockSymbol,
+  isClassOrInterfaceSymbol,
+  isFieldSymbol,
+  isPropertySymbol,
+} from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -101,8 +106,8 @@ function findStaticContextRanges(
   const ranges: Array<{ startLine: number; endLine: number }> = [];
 
   for (const symbol of allSymbols) {
-    if (symbol.kind === SymbolKind.Method) {
-      const method = symbol as MethodSymbol;
+    if (isMethodSymbol(symbol)) {
+      const method = symbol;
       if (method.modifiers?.isStatic && method.location) {
         // Use symbolRange to include full method body (super/this can appear inside body)
         const start = method.location.symbolRange?.startLine;
@@ -110,8 +115,8 @@ function findStaticContextRanges(
         if (start && end) ranges.push({ startLine: start, endLine: end });
       }
     }
-    if (symbol.kind === SymbolKind.Block) {
-      const block = symbol as ScopeSymbol;
+    if (isBlockSymbol(symbol)) {
+      const block = symbol;
       if (block.modifiers?.isStatic && block.location) {
         const start =
           block.location.symbolRange?.startLine ??
@@ -217,13 +222,10 @@ export const StaticContextValidator: Validator = {
 
       // Prefer top-level class (parentId null) when file has inner classes
       const containingClass = (allSymbols.find(
-        (s) =>
-          (s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface) &&
-          s.parentId === null,
-      ) ??
-        allSymbols.find(
-          (s) => s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-        )) as TypeSymbol | undefined;
+        (s) => isClassOrInterfaceSymbol(s) && s.parentId === null,
+      ) ?? allSymbols.find((s) => isClassOrInterfaceSymbol(s))) as
+        | TypeSymbol
+        | undefined;
 
       if (!containingClass) {
         return { isValid: true, errors, warnings };
@@ -352,9 +354,7 @@ export const StaticContextValidator: Validator = {
               firstNode.resolvedSymbolId,
             );
             if (firstSymbol) {
-              receiverIsStatic =
-                firstSymbol.kind === SymbolKind.Class ||
-                firstSymbol.kind === SymbolKind.Interface;
+              receiverIsStatic = isClassOrInterfaceSymbol(firstSymbol);
             } else {
               // Symbol ID exists but symbol not found - this shouldn't happen, but default to instance
               receiverIsStatic = false;
@@ -372,9 +372,9 @@ export const StaticContextValidator: Validator = {
         if (!ref.resolvedSymbolId) continue;
 
         const symbol = symbolManager.getSymbol(ref.resolvedSymbolId);
-        if (!symbol || symbol.kind !== SymbolKind.Method) continue;
+        if (!symbol || !isMethodSymbol(symbol)) continue;
 
-        const method = symbol as MethodSymbol;
+        const method = symbol;
         const methodIsStatic = method.modifiers?.isStatic ?? false;
 
         // Skip when calling instance method on instance (e.g. response.getStatusCode())
@@ -600,11 +600,7 @@ export const StaticContextValidator: Validator = {
         if (!ref.resolvedSymbolId) continue;
 
         const symbol = symbolManager.getSymbol(ref.resolvedSymbolId);
-        if (
-          !symbol ||
-          (symbol.kind !== SymbolKind.Field &&
-            symbol.kind !== SymbolKind.Property)
-        )
+        if (!symbol || (!isFieldSymbol(symbol) && !isPropertySymbol(symbol)))
           continue;
 
         const field = symbol as VariableSymbol;
@@ -618,8 +614,7 @@ export const StaticContextValidator: Validator = {
             allSymbols.find((s) => s.id === field.parentId);
           if (
             fieldParent &&
-            (fieldParent.kind === SymbolKind.Class ||
-              fieldParent.kind === SymbolKind.Interface) &&
+            isClassOrInterfaceSymbol(fieldParent) &&
             fieldParent.id !== containingClass.id
           ) {
             continue; // Field is on another type - instance access, valid

--- a/packages/apex-parser-ast/src/semantics/validation/validators/StaticContextValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/StaticContextValidator.ts
@@ -20,6 +20,7 @@ import {
 } from '@apexdevtools/apex-parser';
 import type {
   SymbolTable,
+  SymbolLocation,
   ApexSymbol,
   TypeSymbol,
   MethodSymbol,
@@ -111,7 +112,7 @@ function findStaticContextRanges(
     }
     if (symbol.kind === SymbolKind.Block) {
       const block = symbol as ScopeSymbol;
-      if ((block as any).scopeType === 'static' && block.location) {
+      if (block.modifiers?.isStatic && block.location) {
         const start =
           block.location.symbolRange?.startLine ??
           block.location.identifierRange?.startLine;
@@ -300,7 +301,7 @@ export const StaticContextValidator: Validator = {
       }
 
       // 2. Check METHOD_CALL and FIELD_ACCESS for static context violations
-      const callLine = (ref: { location?: any }) =>
+      const callLine = (ref: { location?: SymbolLocation }) =>
         ref.location?.identifierRange?.startLine ??
         ref.location?.symbolRange?.startLine;
 

--- a/packages/apex-parser-ast/src/semantics/validation/validators/SwitchStatementValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/SwitchStatementValidator.ts
@@ -26,7 +26,6 @@ import type {
   SymbolTable,
   SymbolLocation,
   ApexSymbol,
-  EnumSymbol,
   VariableSymbol,
 } from '../../../types/symbol';
 import type {
@@ -44,6 +43,7 @@ import type { ParserRuleContext } from 'antlr4ts';
 import { ISymbolManager } from '../ArtifactLoadingHelper';
 import type { ISymbolManager as ISymbolManagerInterface } from '../../../types/ISymbolManager';
 import { SymbolKind } from '../../../types/symbol';
+import { isEnumSymbol, isVariableSymbol } from '../../../utils/symbolNarrowing';
 import {
   resolveExpressionTypeRecursive,
   type ExpressionTypeInfo,
@@ -328,7 +328,7 @@ function resolveIdentifierType(
     const parentId = enumVal.parentId;
     const allSymbols = symbolTable.getAllSymbols();
     const parent = allSymbols.find((s) => s.id === parentId);
-    if (parent && parent.kind === SymbolKind.Enum) {
+    if (isEnumSymbol(parent)) {
       return parent.name?.toLowerCase() ?? null;
     }
   }
@@ -375,14 +375,8 @@ function findSymbolForWhenIdentifier(
   const allSymbols = symbolTable.getAllSymbols();
   const fileUri = symbolTable.getFileUri();
   symbol = allSymbols.find(
-    (s) =>
-      s.name?.toLowerCase() === nameLower &&
-      (s.kind === SymbolKind.Field ||
-        s.kind === SymbolKind.Variable ||
-        s.kind === SymbolKind.Parameter ||
-        s.kind === SymbolKind.Property ||
-        s.kind === SymbolKind.EnumValue),
-  ) as ApexSymbol | undefined;
+    (s) => s.name?.toLowerCase() === nameLower && isVariableSymbol(s),
+  );
   if (symbol) {
     return symbol;
   }
@@ -390,14 +384,8 @@ function findSymbolForWhenIdentifier(
   // Try symbol manager (cross-file, e.g. enum values)
   const found = symbolManager.findSymbolByName(name);
   return found.find(
-    (s: ApexSymbol) =>
-      s.fileUri === fileUri &&
-      (s.kind === SymbolKind.Field ||
-        s.kind === SymbolKind.Variable ||
-        s.kind === SymbolKind.Parameter ||
-        s.kind === SymbolKind.Property ||
-        s.kind === SymbolKind.EnumValue),
-  ) as ApexSymbol | undefined;
+    (s: ApexSymbol) => s.fileUri === fileUri && isVariableSymbol(s),
+  );
 }
 
 /**
@@ -927,9 +915,7 @@ function validateEnumSwitch(
 
     const enumTypeName = typeInfo.resolvedType;
     const enumSymbols = symbolManager.findSymbolByName(enumTypeName);
-    const enumSymbol = enumSymbols.find(
-      (s: ApexSymbol) => s.kind === SymbolKind.Enum,
-    ) as EnumSymbol | undefined;
+    const enumSymbol = enumSymbols.find(isEnumSymbol);
 
     if (!enumSymbol) {
       // Not an enum type - skip validation
@@ -1014,9 +1000,7 @@ function validateEnumSwitchText(
     // Check if the variable type is an enum
     const enumTypeName = varSymbol.type.name;
     const enumSymbols = symbolManager.findSymbolByName(enumTypeName);
-    const enumSymbol = enumSymbols.find(
-      (s: ApexSymbol) => s.kind === SymbolKind.Enum,
-    ) as EnumSymbol | undefined;
+    const enumSymbol = enumSymbols.find(isEnumSymbol);
 
     if (!enumSymbol) {
       // Not an enum type - skip validation

--- a/packages/apex-parser-ast/src/semantics/validation/validators/SwitchStatementValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/SwitchStatementValidator.ts
@@ -187,9 +187,7 @@ class SwitchListener extends BaseApexParserListener<void> {
   }
 
   enterSwitchStatement(ctx: SwitchStatementContext): void {
-    const expression = (ctx as any).expression?.() as
-      | ExpressionContext
-      | undefined;
+    const expression = ctx.expression();
     const expressionText = expression?.text || '';
     this.switchStatements.push({ ctx, expression, expressionText });
   }

--- a/packages/apex-parser-ast/src/semantics/validation/validators/TestMethodValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/TestMethodValidator.ts
@@ -22,7 +22,10 @@ import { ValidationTier } from '../ValidationTier';
 import { ValidationError, type Validator } from '../ValidatorRegistry';
 import { localizeTyped } from '../../../i18n/messageInstance';
 import { ErrorCodes } from '../../../generated/ErrorCodes';
-import { SymbolKind } from '../../../types/symbol';
+import {
+  isClassOrInterfaceSymbol,
+  isMethodSymbol,
+} from '../../../utils/symbolNarrowing';
 
 /**
  * Helper to check if a method has @isTest annotation
@@ -116,10 +119,7 @@ export const TestMethodValidator: Validator = {
       const allSymbols = symbolTable.getAllSymbols();
 
       // Validate test methods
-      const methods = allSymbols.filter(
-        (symbol): symbol is MethodSymbol =>
-          symbol.kind === SymbolKind.Method && 'parameters' in symbol,
-      );
+      const methods = allSymbols.filter(isMethodSymbol);
 
       for (const method of methods) {
         // Check @isTest methods
@@ -161,12 +161,7 @@ export const TestMethodValidator: Validator = {
       }
 
       // Validate test classes (cannot be exception classes)
-      const classes = allSymbols.filter(
-        (symbol): symbol is TypeSymbol =>
-          (symbol.kind === SymbolKind.Class ||
-            symbol.kind === SymbolKind.Interface) &&
-          'annotations' in symbol,
-      );
+      const classes = allSymbols.filter(isClassOrInterfaceSymbol);
 
       for (const classSymbol of classes) {
         // Check if class has @isTest annotation

--- a/packages/apex-parser-ast/src/semantics/validation/validators/TypeAssignmentValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/TypeAssignmentValidator.ts
@@ -11,14 +11,21 @@ import type {
   SymbolTable,
   VariableSymbol,
   TypeSymbol,
-  MethodSymbol,
   ApexSymbol,
 } from '../../../types/symbol';
 import { SymbolKind } from '../../../types/symbol';
+import {
+  inTypeSymbolGroup,
+  isMethodSymbol,
+  isConstructorSymbol,
+  isVariableSymbol,
+  isFieldSymbol,
+  isPropertySymbol,
+  isChainedSymbolReference,
+} from '../../../utils/symbolNarrowing';
 import type { TypeInfo } from '../../../types/typeInfo';
 import type { SymbolReference } from '../../../types/symbolReference';
 import { ReferenceContext } from '../../../types/symbolReference';
-import { isChainedSymbolReference } from '../../../utils/symbolNarrowing';
 import type { ISymbolManager } from '../../../types/ISymbolManager';
 import type {
   ValidationResult,
@@ -504,7 +511,7 @@ function resolveTypeIfNeeded(
                   firstNode.name,
                 );
                 qualifierSymbol =
-                  qualifierSymbols.find((s) => isTypeSymbol(s)) || null;
+                  qualifierSymbols.find((s) => inTypeSymbolGroup(s)) || null;
                 if (!qualifierSymbol) {
                   // Try as variable (for cases like "property.Id")
                   qualifierSymbol =
@@ -514,7 +521,7 @@ function resolveTypeIfNeeded(
 
               if (qualifierSymbol) {
                 // Find the member (targetNode) in the qualifier's class
-                if (isTypeSymbol(qualifierSymbol)) {
+                if (inTypeSymbolGroup(qualifierSymbol)) {
                   // Qualifier is a class - find method/field in that class
                   // Use findSymbolByName to search for the member
                   if (targetNode.context === ReferenceContext.METHOD_CALL) {
@@ -524,7 +531,7 @@ function resolveTypeIfNeeded(
                     resolvedSymbol =
                       methodSymbols.find(
                         (s: ApexSymbol) =>
-                          s.kind === SymbolKind.Method &&
+                          isMethodSymbol(s) &&
                           s.name === targetNode.name &&
                           s.parentId === qualifierSymbol.id,
                       ) || null;
@@ -537,15 +544,14 @@ function resolveTypeIfNeeded(
                     resolvedSymbol =
                       fieldSymbols.find(
                         (s: ApexSymbol) =>
-                          (s.kind === SymbolKind.Field ||
-                            s.kind === SymbolKind.Property) &&
+                          (isFieldSymbol(s) || isPropertySymbol(s)) &&
                           s.name === targetNode.name &&
                           s.parentId === qualifierSymbol.id,
                       ) || null;
                   }
                 } else if (isVariableSymbol(qualifierSymbol)) {
                   // Qualifier is a variable - get its type and find member in that type
-                  const variableSymbol = qualifierSymbol as VariableSymbol;
+                  const variableSymbol = qualifierSymbol;
                   const qualifierType = variableSymbol.type;
                   if (qualifierType.resolvedSymbol) {
                     const typeSymbol = qualifierType.resolvedSymbol;
@@ -556,7 +562,7 @@ function resolveTypeIfNeeded(
                       resolvedSymbol =
                         methodSymbols.find(
                           (s: ApexSymbol) =>
-                            s.kind === SymbolKind.Method &&
+                            isMethodSymbol(s) &&
                             s.name === targetNode.name &&
                             s.parentId === typeSymbol.id,
                         ) || null;
@@ -569,8 +575,7 @@ function resolveTypeIfNeeded(
                       resolvedSymbol =
                         fieldSymbols.find(
                           (s: ApexSymbol) =>
-                            (s.kind === SymbolKind.Field ||
-                              s.kind === SymbolKind.Property) &&
+                            (isFieldSymbol(s) || isPropertySymbol(s)) &&
                             s.name === targetNode.name &&
                             s.parentId === typeSymbol.id,
                         ) || null;
@@ -583,14 +588,14 @@ function resolveTypeIfNeeded(
               const symbols = symbolManager.findSymbolByName(targetNode.name);
               if (targetRef.context === ReferenceContext.METHOD_CALL) {
                 resolvedSymbol =
-                  symbols.find((s: ApexSymbol) => isMethodSymbol(s)) || null;
+                  symbols.find(
+                    (s: ApexSymbol) =>
+                      isMethodSymbol(s) || isConstructorSymbol(s),
+                  ) || null;
               } else if (targetRef.context === ReferenceContext.FIELD_ACCESS) {
                 resolvedSymbol =
                   symbols.find(
-                    (s: ApexSymbol) =>
-                      isVariableSymbol(s) &&
-                      (s.kind === SymbolKind.Field ||
-                        s.kind === SymbolKind.Property),
+                    (s: ApexSymbol) => isFieldSymbol(s) || isPropertySymbol(s),
                   ) || null;
               }
             }
@@ -599,14 +604,14 @@ function resolveTypeIfNeeded(
             const symbols = symbolManager.findSymbolByName(targetRef.name);
             if (targetRef.context === ReferenceContext.METHOD_CALL) {
               resolvedSymbol =
-                symbols.find((s: ApexSymbol) => isMethodSymbol(s)) || null;
+                symbols.find(
+                  (s: ApexSymbol) =>
+                    isMethodSymbol(s) || isConstructorSymbol(s),
+                ) || null;
             } else if (targetRef.context === ReferenceContext.FIELD_ACCESS) {
               resolvedSymbol =
                 symbols.find(
-                  (s: ApexSymbol) =>
-                    isVariableSymbol(s) &&
-                    (s.kind === SymbolKind.Field ||
-                      s.kind === SymbolKind.Property),
+                  (s: ApexSymbol) => isFieldSymbol(s) || isPropertySymbol(s),
                 ) || null;
             }
           }
@@ -624,8 +629,11 @@ function resolveTypeIfNeeded(
       if (resolvedSymbol) {
         // Handle METHOD_CALL context - extract return type from MethodSymbol
         if (targetRef.context === ReferenceContext.METHOD_CALL) {
-          if (isMethodSymbol(resolvedSymbol)) {
-            const methodSymbol = resolvedSymbol as MethodSymbol;
+          if (
+            isMethodSymbol(resolvedSymbol) ||
+            isConstructorSymbol(resolvedSymbol)
+          ) {
+            const methodSymbol = resolvedSymbol;
             // Get the returnType, preserving original type info
             const returnTypeInfo = convertMethodReturnTypeToTypeInfo(
               methodSymbol.returnType,
@@ -646,7 +654,7 @@ function resolveTypeIfNeeded(
         // Handle FIELD_ACCESS context - extract type from VariableSymbol
         else if (targetRef.context === ReferenceContext.FIELD_ACCESS) {
           if (isVariableSymbol(resolvedSymbol)) {
-            const variableSymbol = resolvedSymbol as VariableSymbol;
+            const variableSymbol = resolvedSymbol;
             // Get the type, preserving original type info
             const variableTypeInfo = convertVariableTypeToTypeInfo(
               variableSymbol.type,
@@ -665,7 +673,7 @@ function resolveTypeIfNeeded(
           }
         }
         // Handle TYPE references - use existing TypeSymbol logic
-        else if (isTypeSymbol(resolvedSymbol)) {
+        else if (inTypeSymbolGroup(resolvedSymbol)) {
           // Convert TypeSymbol to TypeInfo
           return convertTypeSymbolToTypeInfo(
             resolvedSymbol as TypeSymbol,
@@ -677,9 +685,7 @@ function resolveTypeIfNeeded(
 
     // Step 3: Fallback to findSymbolByName if typeReferenceId not available or not resolved
     const symbols = symbolManager.findSymbolByName(typeInfo.name);
-    const typeSymbol = symbols.find((s) => isTypeSymbol(s)) as
-      | TypeSymbol
-      | undefined;
+    const typeSymbol = symbols.find(inTypeSymbolGroup);
     if (typeSymbol) {
       return convertTypeSymbolToTypeInfo(typeSymbol, typeInfo);
     }
@@ -723,33 +729,6 @@ function findSymbolReferenceById(
   } catch {
     return undefined;
   }
-}
-
-/**
- * Check if a symbol is a type symbol (Class, Interface, or Enum)
- */
-function isTypeSymbol(symbol: ApexSymbol): symbol is TypeSymbol {
-  return (
-    symbol.kind === SymbolKind.Class ||
-    symbol.kind === SymbolKind.Interface ||
-    symbol.kind === SymbolKind.Enum
-  );
-}
-
-function isMethodSymbol(symbol: ApexSymbol): symbol is MethodSymbol {
-  return (
-    symbol.kind === SymbolKind.Method || symbol.kind === SymbolKind.Constructor
-  );
-}
-
-function isVariableSymbol(symbol: ApexSymbol): symbol is VariableSymbol {
-  return (
-    symbol.kind === SymbolKind.Property ||
-    symbol.kind === SymbolKind.Field ||
-    symbol.kind === SymbolKind.Variable ||
-    symbol.kind === SymbolKind.Parameter ||
-    symbol.kind === SymbolKind.EnumValue
-  );
 }
 
 /**

--- a/packages/apex-parser-ast/src/semantics/validation/validators/TypeAssignmentValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/TypeAssignmentValidator.ts
@@ -28,6 +28,7 @@ import type {
 import type { ValidationOptions } from '../ValidationTier';
 import { ValidationTier } from '../ValidationTier';
 import { ValidationError, type Validator } from '../ValidatorRegistry';
+import type { ExpressionType } from '../TypePromotionSystem';
 import { StatementValidator } from '../StatementValidator';
 import { localizeTyped } from '../../../i18n/messageInstance';
 import { ErrorCodes } from '../../../generated/ErrorCodes';
@@ -342,15 +343,9 @@ export const TypeAssignmentValidator: Validator = {
 /**
  * Convert TypeInfo to StatementExpressionType for compatibility checking
  */
-function convertTypeInfoToExpressionType(typeInfo: TypeInfo): {
-  kind: 'primitive' | 'object' | 'collection' | 'void' | 'unresolved';
-  name: string;
-  isNullable: boolean;
-  isArray: boolean;
-  isPrimitive?: boolean;
-  isCollection?: boolean;
-  elementType?: any;
-} {
+function convertTypeInfoToExpressionType(
+  typeInfo: TypeInfo,
+): ExpressionType & { isPrimitive?: boolean; isCollection?: boolean } {
   const name = typeInfo.name.toLowerCase();
   const isNull = name === 'null';
 
@@ -483,10 +478,9 @@ function resolveTypeIfNeeded(
           targetRef.context === ReferenceContext.FIELD_ACCESS
         ) {
           // For chained references, check chainNodes
-          const chainedRef = targetRef as any;
-          if (chainedRef.chainNodes && Array.isArray(chainedRef.chainNodes)) {
+          if (isChainedSymbolReference(targetRef) && targetRef.chainNodes) {
             // Find the METHOD_CALL or FIELD_ACCESS node in the chain
-            const targetNode = chainedRef.chainNodes.find(
+            const targetNode = targetRef.chainNodes.find(
               (node: SymbolReference) =>
                 node.context === ReferenceContext.METHOD_CALL ||
                 node.context === ReferenceContext.FIELD_ACCESS,
@@ -495,9 +489,9 @@ function resolveTypeIfNeeded(
               resolvedSymbol = symbolManager.getSymbol(
                 targetNode.resolvedSymbolId,
               );
-            } else if (targetNode && chainedRef.chainNodes.length >= 2) {
+            } else if (targetNode && targetRef.chainNodes.length >= 2) {
               // Chained reference: resolve qualifier first, then find member
-              const firstNode = chainedRef.chainNodes[0];
+              const firstNode = targetRef.chainNodes[0];
               let qualifierSymbol: ApexSymbol | null = null;
 
               // Resolve the qualifier (first node)
@@ -734,7 +728,7 @@ function findSymbolReferenceById(
 /**
  * Check if a symbol is a type symbol (Class, Interface, or Enum)
  */
-function isTypeSymbol(symbol: any): boolean {
+function isTypeSymbol(symbol: ApexSymbol): symbol is TypeSymbol {
   return (
     symbol.kind === SymbolKind.Class ||
     symbol.kind === SymbolKind.Interface ||
@@ -742,19 +736,13 @@ function isTypeSymbol(symbol: any): boolean {
   );
 }
 
-/**
- * Check if a symbol is a method symbol (Method or Constructor)
- */
-function isMethodSymbol(symbol: any): boolean {
+function isMethodSymbol(symbol: ApexSymbol): symbol is MethodSymbol {
   return (
     symbol.kind === SymbolKind.Method || symbol.kind === SymbolKind.Constructor
   );
 }
 
-/**
- * Check if a symbol is a variable symbol (Property, Field, Variable, Parameter, or EnumValue)
- */
-function isVariableSymbol(symbol: any): boolean {
+function isVariableSymbol(symbol: ApexSymbol): symbol is VariableSymbol {
   return (
     symbol.kind === SymbolKind.Property ||
     symbol.kind === SymbolKind.Field ||

--- a/packages/apex-parser-ast/src/semantics/validation/validators/TypeResolutionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/TypeResolutionValidator.ts
@@ -12,7 +12,10 @@ import type {
   TypeSymbol,
   ApexSymbol,
 } from '../../../types/symbol';
-import { SymbolKind } from '../../../types/symbol';
+import {
+  inTypeSymbolGroup,
+  isInterfaceSymbol,
+} from '../../../utils/symbolNarrowing';
 import { ReferenceContext } from '../../../types/symbolReference';
 import type {
   ValidationResult,
@@ -96,30 +99,15 @@ export const TypeResolutionValidator: Validator = {
         const typeName = ref.name;
         const baseName = extractBaseTypeName(typeName);
         const sameFileType = allSymbols.find(
-          (s) =>
-            (s.kind === SymbolKind.Class ||
-              s.kind === SymbolKind.Interface ||
-              s.kind === SymbolKind.Enum) &&
-            s.name.toLowerCase() === baseName,
+          (s) => inTypeSymbolGroup(s) && s.name.toLowerCase() === baseName,
         );
         if (sameFileType) continue;
         if (options.tier === ValidationTier.THOROUGH) {
           const symbols = symbolManager.findSymbolByName(typeName);
-          const found = symbols.find(
-            (s: ApexSymbol) =>
-              s.kind === SymbolKind.Class ||
-              s.kind === SymbolKind.Interface ||
-              s.kind === SymbolKind.Enum,
-          );
+          const found = symbols.find((s: ApexSymbol) => inTypeSymbolGroup(s));
           if (found) continue;
           const fqnSymbol = symbolManager.findSymbolByFQN(typeName);
-          if (
-            fqnSymbol &&
-            (fqnSymbol.kind === SymbolKind.Class ||
-              fqnSymbol.kind === SymbolKind.Interface ||
-              fqnSymbol.kind === SymbolKind.Enum)
-          )
-            continue;
+          if (inTypeSymbolGroup(fqnSymbol)) continue;
         }
         unresolvedTypeNames.push(typeName);
       }
@@ -150,35 +138,23 @@ export const TypeResolutionValidator: Validator = {
 
         // Same-file lookup
         const sameFileType = allSymbols.find(
-          (s) =>
-            (s.kind === SymbolKind.Class ||
-              s.kind === SymbolKind.Interface ||
-              s.kind === SymbolKind.Enum) &&
-            s.name.toLowerCase() === baseName,
-        ) as TypeSymbol | undefined;
+          (s): s is TypeSymbol =>
+            inTypeSymbolGroup(s) && s.name.toLowerCase() === baseName,
+        );
 
         if (sameFileType) {
           typeSymbol = sameFileType;
         } else if (options.tier === ValidationTier.THOROUGH) {
-          // Cross-file lookup via symbolManager (types may have been loaded above)
           const symbols = symbolManager.findSymbolByName(typeName);
-          const found = symbols.find(
-            (s: ApexSymbol) =>
-              s.kind === SymbolKind.Class ||
-              s.kind === SymbolKind.Interface ||
-              s.kind === SymbolKind.Enum,
-          ) as TypeSymbol | undefined;
+          const found = symbols.find((s: ApexSymbol): s is TypeSymbol =>
+            inTypeSymbolGroup(s),
+          );
           if (found) {
             typeSymbol = found;
           } else {
             const fqnSymbol = symbolManager.findSymbolByFQN(typeName);
-            if (
-              fqnSymbol &&
-              (fqnSymbol.kind === SymbolKind.Class ||
-                fqnSymbol.kind === SymbolKind.Interface ||
-                fqnSymbol.kind === SymbolKind.Enum)
-            ) {
-              typeSymbol = fqnSymbol as TypeSymbol;
+            if (inTypeSymbolGroup(fqnSymbol)) {
+              typeSymbol = fqnSymbol;
             }
           }
         }
@@ -204,7 +180,7 @@ export const TypeResolutionValidator: Validator = {
 
         // INVALID_CLASS: When class is required but type is interface or enum
         if (classRequiredContexts.has(ref.context)) {
-          if (typeSymbol.kind === SymbolKind.Interface) {
+          if (isInterfaceSymbol(typeSymbol)) {
             errors.push({
               message: localizeTyped(ErrorCodes.INVALID_CLASS, typeName),
               location: ref.location,

--- a/packages/apex-parser-ast/src/semantics/validation/validators/TypeVisibilityValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/TypeVisibilityValidator.ts
@@ -12,7 +12,11 @@ import type {
   TypeSymbol,
   ApexSymbol,
 } from '../../../types/symbol';
-import { SymbolKind, SymbolVisibility } from '../../../types/symbol';
+import { SymbolVisibility } from '../../../types/symbol';
+import {
+  isClassOrInterfaceSymbol,
+  inTypeSymbolGroup,
+} from '../../../utils/symbolNarrowing';
 import { ReferenceContext } from '../../../types/symbolReference';
 import type {
   ValidationResult,
@@ -77,8 +81,8 @@ export const TypeVisibilityValidator: Validator = {
       const allSymbols = symbolTable.getAllSymbols();
 
       // Find the containing class for context
-      const containingClass = allSymbols.find(
-        (s) => s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
+      const containingClass = allSymbols.find((s) =>
+        isClassOrInterfaceSymbol(s),
       ) as TypeSymbol | undefined;
 
       if (!containingClass) {
@@ -326,10 +330,7 @@ function resolveTypeSymbol(
     // First, try to find in same file
     const sameFileType = allSymbols.find(
       (s) =>
-        (s.kind === SymbolKind.Class ||
-          s.kind === SymbolKind.Interface ||
-          s.kind === SymbolKind.Enum) &&
-        s.name.toLowerCase() === typeName.toLowerCase(),
+        inTypeSymbolGroup(s) && s.name.toLowerCase() === typeName.toLowerCase(),
     ) as TypeSymbol | undefined;
 
     if (sameFileType) {
@@ -338,12 +339,9 @@ function resolveTypeSymbol(
 
     // Try to find via symbol manager (cross-file)
     const symbols = symbolManager.findSymbolByName(typeName);
-    const typeSymbol = symbols.find(
-      (s: ApexSymbol) =>
-        s.kind === SymbolKind.Class ||
-        s.kind === SymbolKind.Interface ||
-        s.kind === SymbolKind.Enum,
-    ) as TypeSymbol | undefined;
+    const typeSymbol = symbols.find((s: ApexSymbol) => inTypeSymbolGroup(s)) as
+      | TypeSymbol
+      | undefined;
 
     if (typeSymbol) {
       return typeSymbol;
@@ -351,13 +349,8 @@ function resolveTypeSymbol(
 
     // Try FQN lookup
     const fqnSymbol = symbolManager.findSymbolByFQN(typeName);
-    if (
-      fqnSymbol &&
-      (fqnSymbol.kind === SymbolKind.Class ||
-        fqnSymbol.kind === SymbolKind.Interface ||
-        fqnSymbol.kind === SymbolKind.Enum)
-    ) {
-      return fqnSymbol as TypeSymbol;
+    if (fqnSymbol && inTypeSymbolGroup(fqnSymbol)) {
+      return fqnSymbol;
     }
 
     return null;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/UnknownAnnotationValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/UnknownAnnotationValidator.ts
@@ -7,11 +7,7 @@
  */
 
 import { Effect } from 'effect';
-import type {
-  SymbolTable,
-  TypeSymbol,
-  Annotation,
-} from '../../../types/symbol';
+import type { SymbolTable, Annotation } from '../../../types/symbol';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -23,6 +19,12 @@ import { ValidationError, type Validator } from '../ValidatorRegistry';
 import { localizeTyped } from '../../../i18n/messageInstance';
 import { ErrorCodes } from '../../../generated/ErrorCodes';
 import { SymbolKind } from '../../../types/symbol';
+import {
+  isClassOrInterfaceSymbol,
+  isMethodSymbol,
+  isFieldSymbol,
+  isPropertySymbol,
+} from '../../../utils/symbolNarrowing';
 import { AnnotationValidator } from '../../annotations/AnnotationValidator';
 
 function getBaseAnnotationName(annotationName: string): string {
@@ -70,16 +72,12 @@ export const UnknownAnnotationValidator: Validator = {
         let annotations: Annotation[] | undefined;
 
         // Extract annotations based on symbol type
-        if (
-          symbol.kind === SymbolKind.Class ||
-          symbol.kind === SymbolKind.Interface
-        ) {
-          const typeSymbol = symbol as TypeSymbol;
-          annotations = typeSymbol.annotations;
+        if (isClassOrInterfaceSymbol(symbol)) {
+          annotations = symbol.annotations;
         } else if (
-          symbol.kind === SymbolKind.Method ||
-          symbol.kind === SymbolKind.Property ||
-          symbol.kind === SymbolKind.Field ||
+          isMethodSymbol(symbol) ||
+          isFieldSymbol(symbol) ||
+          isPropertySymbol(symbol) ||
           symbol.kind === SymbolKind.Parameter
         ) {
           // Methods, properties, fields, and parameters can have annotations

--- a/packages/apex-parser-ast/src/semantics/validation/validators/VariableResolutionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/VariableResolutionValidator.ts
@@ -20,7 +20,10 @@ import {
   isBlockSymbol,
   isChainedSymbolReference,
 } from '../../../utils/symbolNarrowing';
-import { ReferenceContext } from '../../../types/symbolReference';
+import {
+  ReferenceContext,
+  type SymbolReference,
+} from '../../../types/symbolReference';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -83,8 +86,8 @@ export const VariableResolutionValidator: Validator = {
       const chainedTypeRefs = allReferences.filter((ref) =>
         isChainedSymbolReference(ref),
       );
-      const extractedFieldAccesses: any[] = [];
-      const extractedWriteFieldAccesses: any[] = []; // Track write accesses separately
+      const extractedFieldAccesses: SymbolReference[] = [];
+      const extractedWriteFieldAccesses: SymbolReference[] = [];
 
       for (const chainedRef of chainedTypeRefs) {
         if (chainedRef.chainNodes && Array.isArray(chainedRef.chainNodes)) {
@@ -1112,7 +1115,7 @@ function findMethodInClassHierarchy(
 function resolveTargetTypeWithArrayAccess(
   targetType: TypeSymbol | null,
   variableTypeName: string | undefined,
-  fieldRef: any,
+  fieldRef: SymbolReference,
   sourceContent: string | undefined,
   symbolManager: ISymbolManagerInterface,
 ): Effect.Effect<TypeSymbol | null, never, never> {
@@ -1143,7 +1146,7 @@ function resolveTargetTypeWithArrayAccess(
  * For qualified field access like "obj.field", extracts "obj"
  */
 function extractObjectNameFromFieldAccess(
-  fieldRef: any, // SymbolReference with FIELD_ACCESS context
+  fieldRef: SymbolReference,
   sourceContent: string,
 ): string | null {
   if (!sourceContent || !fieldRef.location) {

--- a/packages/apex-parser-ast/src/semantics/validation/validators/VariableResolutionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/VariableResolutionValidator.ts
@@ -19,6 +19,10 @@ import { SymbolKind, SymbolVisibility } from '../../../types/symbol';
 import {
   isBlockSymbol,
   isChainedSymbolReference,
+  isClassOrInterfaceSymbol,
+  isFieldSymbol,
+  isMethodSymbol,
+  isPropertySymbol,
 } from '../../../utils/symbolNarrowing';
 import {
   ReferenceContext,
@@ -248,9 +252,7 @@ export const VariableResolutionValidator: Validator = {
       const allSymbols = symbolTable.getAllSymbols();
 
       // Find the containing class for context
-      const containingClass = allSymbols.find(
-        (s) => s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-      ) as TypeSymbol | undefined;
+      const containingClass = allSymbols.find(isClassOrInterfaceSymbol);
 
       // Validate variable usages
       for (const variableRef of variableUsages) {
@@ -379,7 +381,7 @@ export const VariableResolutionValidator: Validator = {
         }
 
         // Check visibility if it's a field (not a local variable or parameter)
-        if (variable.kind === SymbolKind.Field && containingClass) {
+        if (isFieldSymbol(variable) && containingClass) {
           const isVisible = yield* isVariableVisible(
             variable as VariableSymbol,
             containingClass,
@@ -572,11 +574,7 @@ export const VariableResolutionValidator: Validator = {
                   }
                 }
                 const resolvedType =
-                  (typeSymbols.find(
-                    (s: ApexSymbol) =>
-                      s.kind === SymbolKind.Class ||
-                      s.kind === SymbolKind.Interface,
-                  ) as TypeSymbol | undefined) ?? null;
+                  typeSymbols.find(isClassOrInterfaceSymbol) ?? null;
                 if (resolvedType) {
                   targetType = yield* resolveTargetTypeWithArrayAccess(
                     resolvedType,
@@ -632,11 +630,7 @@ export const VariableResolutionValidator: Validator = {
                 }
               }
               let resolvedTargetType =
-                (typeSymbols.find(
-                  (s: ApexSymbol) =>
-                    s.kind === SymbolKind.Class ||
-                    s.kind === SymbolKind.Interface,
-                ) as TypeSymbol | undefined) ?? null;
+                typeSymbols.find(isClassOrInterfaceSymbol) ?? null;
               resolvedTargetType = yield* resolveTargetTypeWithArrayAccess(
                 resolvedTargetType,
                 fullTypeStr,
@@ -836,15 +830,10 @@ export const VariableResolutionValidator: Validator = {
                     typeSymbols = symbolManager.findSymbolByName(lastPart);
                 }
                 const resolvedTargetType =
-                  (typeSymbols.find(
-                    (s: ApexSymbol) =>
-                      s.kind === SymbolKind.Class ||
-                      s.kind === SymbolKind.Interface,
-                  ) as TypeSymbol | undefined) ?? null;
+                  typeSymbols.find(isClassOrInterfaceSymbol) ?? null;
                 if (resolvedTargetType) {
                   targetType = resolvedTargetType;
                 } else {
-                  // Type not in symbol manager (e.g. ContentVersion) - suppress false positive
                   suppressDueToUnresolvedDeclaredType = true;
                 }
                 break;
@@ -993,11 +982,7 @@ function resolveChainTargetType(
         const lastPart = typeName.split('.').pop();
         if (lastPart) typeSymbols = symbolManager.findSymbolByName(lastPart);
       }
-      currentType =
-        (typeSymbols.find(
-          (s: ApexSymbol) =>
-            s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-        ) as TypeSymbol | undefined) ?? null;
+      currentType = typeSymbols.find(isClassOrInterfaceSymbol) ?? null;
     }
     // When first node is a class name (e.g. EncodingUtil), resolve via symbol manager
     if (!currentType && !firstVar) {
@@ -1018,11 +1003,7 @@ function resolveChainTargetType(
         const lastPart = firstNode.name.split('.').pop();
         if (lastPart) typeSymbols = symbolManager.findSymbolByName(lastPart);
       }
-      currentType =
-        (typeSymbols.find(
-          (s: ApexSymbol) =>
-            s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-        ) as TypeSymbol | undefined) ?? null;
+      currentType = typeSymbols.find(isClassOrInterfaceSymbol) ?? null;
     }
     if (!currentType) return null;
 
@@ -1039,10 +1020,7 @@ function resolveChainTargetType(
       if (!method?.returnType?.name) return null;
       const returnTypeName = method.returnType.name;
       const typeSymbols = symbolManager.findSymbolByName(returnTypeName);
-      const nextType = typeSymbols.find(
-        (s: ApexSymbol) =>
-          s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-      ) as TypeSymbol | undefined;
+      const nextType = typeSymbols.find(isClassOrInterfaceSymbol);
       if (!nextType) return null;
       currentType = nextType;
     }
@@ -1072,7 +1050,7 @@ function findMethodInClassHierarchy(
 
     const isMethodInClass = (method: ApexSymbol): boolean => {
       if (
-        method.kind !== SymbolKind.Method ||
+        !isMethodSymbol(method) ||
         method.name?.toLowerCase() !== methodName.toLowerCase()
       )
         return false;
@@ -1092,10 +1070,7 @@ function findMethodInClassHierarchy(
       const superSymbols = symbolManager.findSymbolByName(
         classSymbol.superClass,
       );
-      const superClass = superSymbols.find(
-        (s: ApexSymbol) =>
-          s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-      ) as TypeSymbol | undefined;
+      const superClass = superSymbols.find(isClassOrInterfaceSymbol);
       if (superClass)
         return yield* findMethodInClassHierarchy(
           symbolManager,
@@ -1133,10 +1108,7 @@ function resolveTargetTypeWithArrayAccess(
     const elementType = extractElementTypeFromCollection(variableTypeName);
     if (!elementType) return targetType;
     const elementSymbols = symbolManager.findSymbolByName(elementType);
-    const elementTypeSymbol = elementSymbols.find(
-      (s: ApexSymbol) =>
-        s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-    ) as TypeSymbol | undefined;
+    const elementTypeSymbol = elementSymbols.find(isClassOrInterfaceSymbol);
     return elementTypeSymbol ?? targetType;
   });
 }
@@ -1245,11 +1217,9 @@ function findVariableInScope(
   // misses parameters since they live in method block scope, not file scope)
   if (parentContext) {
     const methodSymbol = allSymbols.find(
-      (s) =>
-        s.kind === SymbolKind.Method &&
-        'parameters' in s &&
-        s.name === parentContext,
-    ) as MethodSymbol | undefined;
+      (s): s is MethodSymbol =>
+        isMethodSymbol(s) && 'parameters' in s && s.name === parentContext,
+    );
     if (methodSymbol?.parameters) {
       const param = methodSymbol.parameters.find(
         (p) => p.name?.toLowerCase() === variableName.toLowerCase(),
@@ -1262,12 +1232,8 @@ function findVariableInScope(
   // (not in symbolArray). Search all methods in the file.
   if (!parentContext) {
     for (const s of allSymbols) {
-      if (
-        s.kind === SymbolKind.Method &&
-        'parameters' in s &&
-        (s as MethodSymbol).parameters
-      ) {
-        const param = (s as MethodSymbol).parameters.find(
+      if (isMethodSymbol(s) && 'parameters' in s && s.parameters) {
+        const param = s.parameters.find(
           (p) => p.name?.toLowerCase() === variableName.toLowerCase(),
         );
         if (param) return param;
@@ -1360,11 +1326,10 @@ function findFieldsInClass(
   // Get fields and properties directly in this class (properties use get; set;)
   for (const symbol of allSymbols) {
     if (
-      (symbol.kind === SymbolKind.Field ||
-        symbol.kind === SymbolKind.Property) &&
+      (isFieldSymbol(symbol) || isPropertySymbol(symbol)) &&
       (symbol.parentId === classBlock?.id || symbol.parentId === classSymbol.id)
     ) {
-      fields.push(symbol as VariableSymbol);
+      fields.push(symbol);
     }
   }
 
@@ -1382,17 +1347,12 @@ function findFieldInSuperclass(
   return Effect.gen(function* () {
     // Find the superclass type symbol
     const superClassSymbols = symbolManager.findSymbolByName(superClassName);
-    const superClassSymbol = superClassSymbols.find(
-      (s: ApexSymbol) =>
-        s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-    ) as TypeSymbol | undefined;
+    const superClassSymbol = superClassSymbols.find(isClassOrInterfaceSymbol);
 
     if (!superClassSymbol) {
-      // Superclass not found - might need artifact loading
       return null;
     }
 
-    // Get all symbols for completion to find fields
     const allSymbols = symbolManager.getAllSymbolsForCompletion();
 
     // Find fields in the superclass
@@ -1523,30 +1483,18 @@ function findDeclaringClassForVariable(
 
   let current: ApexSymbol | null = variable;
   while (current) {
-    if (
-      current.kind === SymbolKind.Class ||
-      current.kind === SymbolKind.Interface
-    ) {
-      return current as TypeSymbol;
+    if (isClassOrInterfaceSymbol(current)) {
+      return current;
     }
     if (current.parentId) {
       const parent = resolveParent(current.parentId);
-      if (
-        parent &&
-        (parent.kind === SymbolKind.Class ||
-          parent.kind === SymbolKind.Interface)
-      ) {
-        return parent as TypeSymbol;
+      if (isClassOrInterfaceSymbol(parent)) {
+        return parent;
       }
-      // If parent is a block, check its parent
       if (parent && isBlockSymbol(parent) && parent.parentId) {
         const grandParent = resolveParent(parent.parentId);
-        if (
-          grandParent &&
-          (grandParent.kind === SymbolKind.Class ||
-            grandParent.kind === SymbolKind.Interface)
-        ) {
-          return grandParent as TypeSymbol;
+        if (isClassOrInterfaceSymbol(grandParent)) {
+          return grandParent;
         }
       }
       current = parent ?? null;
@@ -1577,10 +1525,7 @@ function isSubclassOf(
     const superClassSymbols = symbolManager.findSymbolByName(
       childClass.superClass,
     );
-    const superClassSymbol = superClassSymbols.find(
-      (s: ApexSymbol) =>
-        s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
-    ) as TypeSymbol | undefined;
+    const superClassSymbol = superClassSymbols.find(isClassOrInterfaceSymbol);
 
     if (superClassSymbol) {
       return isSubclassOf(

--- a/packages/apex-parser-ast/src/semantics/validation/validators/VariableShadowingValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/VariableShadowingValidator.ts
@@ -9,6 +9,13 @@
 import { Effect } from 'effect';
 import type { SymbolTable, ApexSymbol } from '../../../types/symbol';
 import { SymbolKind } from '../../../types/symbol';
+import {
+  isMethodSymbol,
+  isConstructorSymbol,
+  isClassOrInterfaceSymbol,
+  isFieldSymbol,
+  isBlockSymbol,
+} from '../../../utils/symbolNarrowing';
 import type {
   ValidationResult,
   ValidationErrorInfo,
@@ -86,9 +93,7 @@ export const VariableShadowingValidator: Validator = {
       );
 
       // Get all fields for shadowing checks
-      const fields = allSymbols.filter(
-        (symbol) => symbol.kind === SymbolKind.Field,
-      );
+      const fields = allSymbols.filter((symbol) => isFieldSymbol(symbol));
 
       // Check each variable for cross-scope shadowing (WARNINGS only)
       for (const variable of variables) {
@@ -156,21 +161,14 @@ function findContainingMethod(
 
   while (current) {
     // Check if current is a method/constructor
-    if (
-      current.kind === SymbolKind.Method ||
-      current.kind === SymbolKind.Constructor
-    ) {
+    if (isMethodSymbol(current) || isConstructorSymbol(current)) {
       return current;
     }
 
     // Check if current's parent is a method/constructor
     if (current.parentId) {
       const parent = allSymbols.find((s) => s.id === current!.parentId);
-      if (
-        parent &&
-        (parent.kind === SymbolKind.Method ||
-          parent.kind === SymbolKind.Constructor)
-      ) {
+      if (parent && (isMethodSymbol(parent) || isConstructorSymbol(parent))) {
         return parent;
       }
       current = parent ?? null;
@@ -193,21 +191,14 @@ function findContainingClass(
 
   while (current) {
     // Check if current is a class/interface
-    if (
-      current.kind === SymbolKind.Class ||
-      current.kind === SymbolKind.Interface
-    ) {
+    if (isClassOrInterfaceSymbol(current)) {
       return current;
     }
 
     // Check if current's parent is a class/interface
     if (current.parentId) {
       const parent = allSymbols.find((s) => s.id === current!.parentId);
-      if (
-        parent &&
-        (parent.kind === SymbolKind.Class ||
-          parent.kind === SymbolKind.Interface)
-      ) {
+      if (parent && isClassOrInterfaceSymbol(parent)) {
         return parent;
       }
       current = parent ?? null;
@@ -242,7 +233,7 @@ function findShadowedSymbol(
     // Fields might be direct children of class or children of class block
     // Find all blocks that are children of the class
     const classBlocks = allSymbols.filter(
-      (s) => s.kind === SymbolKind.Block && s.parentId === containingClass.id,
+      (s) => isBlockSymbol(s) && s.parentId === containingClass.id,
     );
 
     // Check fields that are children of the class or class blocks

--- a/packages/apex-parser-ast/src/utils/contextTypeGuards.ts
+++ b/packages/apex-parser-ast/src/utils/contextTypeGuards.ts
@@ -33,6 +33,7 @@ import {
   UpsertStatementContext,
   ExpressionListContext,
   MethodCallContext,
+  CreatedNameContext,
 } from '@apexdevtools/apex-parser';
 
 /**
@@ -218,4 +219,21 @@ export function isMethodCallContext(
     ctx instanceof MethodCallContext ||
     ctx instanceof DotMethodCallContext
   );
+}
+
+/**
+ * Build a dot-separated type name from a CreatedNameContext.
+ *
+ * Grammar: createdName : idCreatedNamePair (DOT idCreatedNamePair)*
+ *
+ * Returns `null` when no idCreatedNamePair children exist.
+ */
+export function getTypeNameFromCreatedName(
+  createdName: CreatedNameContext,
+): string | null {
+  const pairs = createdName.idCreatedNamePair();
+  if (!pairs || pairs.length === 0) {
+    return null;
+  }
+  return pairs.map((pair) => pair.anyId().text).join('.');
 }

--- a/packages/apex-parser-ast/src/utils/symbolNarrowing.ts
+++ b/packages/apex-parser-ast/src/utils/symbolNarrowing.ts
@@ -73,6 +73,15 @@ export const isInterfaceSymbol = (
 ): symbol is TypeSymbol => !!symbol && symbol.kind === SymbolKind.Interface;
 
 /**
+ * Type predicate to check if a symbol is a Class or Interface
+ */
+export const isClassOrInterfaceSymbol = (
+  symbol: ApexSymbol | undefined | null,
+): symbol is TypeSymbol =>
+  !!symbol &&
+  (symbol.kind === SymbolKind.Class || symbol.kind === SymbolKind.Interface);
+
+/**
  * Type predicate to check if a symbol is a TriggerSymbol
  */
 export const isTriggerSymbol = (


### PR DESCRIPTION
### What does this PR do?

Replaces all `as any` casts and `: any` type annotations across 21 semantic validator files with specific TypeScript types. This eliminates unsafe type coercions and improves type safety throughout the validation layer.

**Changes by pattern:**
- **ANTLR context types:** Replaced `any` with `MethodCallExpressionContext`, `DotMethodCallContext`, `TypeRefContext`, `ParserRuleContext`, etc. Removed dead code accessing non-existent methods (`typeName()`, `typeArguments()` on `CreatedNameContext`/`IdCreatedNamePairContext`)
- **Symbol type guards:** Replaced `(s as any).scopeType` with `isBlockSymbol` type guard + direct property access
- **Symbol interfaces:** Replaced `(ref as any).literalType` / `.literalValue` / `.accessValidationState` with direct property access on `SymbolReference`
- **Error codes:** Replaced `code as any` with `ErrorCodeKey` type for `localizeTyped` calls
- **Service types:** Replaced `symbolManager?: any` with `ISymbolManagerInterface`
- **Variable narrowing:** Replaced `receiverSymbol as any` with `isVariableSymbol` type guard

**Files changed:** 21 validator files in `packages/apex-parser-ast/src/semantics/validation/validators/`

### What issues does this PR fix or reference?

@W-21324737@


Made with [Cursor](https://cursor.com)