### PR TITLE
ci: switch Dependabot automerge to svc-idee-bot scheduled workflow - W-22106427

### DIFF
--- a/.github/SECURITY_AUTHENTICATION.md
+++ b/.github/SECURITY_AUTHENTICATION.md
@@ -108,11 +108,10 @@ permissions:
 
 ### **Automerge Workflow** (`automerge.yml`)
 
-- **Token**: `GITHUB_TOKEN`
-- **Operations**: Enables auto-merge for eligible Dependabot PRs
-- **Permissions**: `contents: write`, `pull-requests: write`, `actions: read`
-- **Guards**: Only same-repo `dependabot[bot]` PRs are eligible; fork-origin PRs are excluded
-- **Prerequisite**: Repository auto-merge must be enabled in GitHub settings
+- **Token**: `IDEE_GH_TOKEN` (`svc-idee-bot` service account)
+- **Operations**: Directly merges eligible Dependabot PRs via `salesforcecli/github-workflows` reusable workflow; does **not** use GitHub's repo-level auto-merge toggle
+- **Permissions**: `contents: write`, `pull-requests: write`, `checks: read`, `actions: read`
+- **Guards**: Only minor/patch version bumps are merged; major bumps are skipped; `svc-idee-bot` is in the branch-protection bypass list so no human review is required for bot merges
 
 ### **Validate PR Workflow** (`validatePR.yml`)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -313,19 +313,18 @@ graph LR
 
 **Triggers:**
 
-- Pull request events
-- Check suite completion
-- Status events
+- Scheduled (four times daily during off-hours UTC: 02:42, 05:42, 08:42, 11:42)
+- Manual dispatch (`workflow_dispatch`)
 
-**Purpose:** Enable GitHub auto-merge for eligible Dependabot PRs.
+**Purpose:** Merge eligible Dependabot PRs using `svc-idee-bot` via the shared `salesforcecli/github-workflows` reusable workflow.
 
 **Features:**
 
-- Only applies to PRs opened by `dependabot[bot]`
-- Only applies to same-repository PRs (fork-origin PRs are excluded)
+- Uses `IDEE_GH_TOKEN` (svc-idee-bot), which is in the branch-protection bypass list — no human review required for bot merges
+- Does **not** use GitHub's repo-level auto-merge toggle (which cannot be restricted to Dependabot only)
+- Only merges minor and patch version bumps (`maxVersionBump: minor`); major bumps are skipped
 - Uses squash merge method
-- Skips major version bumps
-- Requires repository-level auto-merge to be enabled in GitHub settings
+- `skipCI` input available on manual dispatch for emergency use
 
 #### Stale (`stale.yml`)
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,71 +1,40 @@
 name: Dependabot Automerge
 
+# Merges eligible Dependabot PRs using svc-idee-bot via the shared Salesforce CLI
+# reusable workflow. This avoids GitHub's repo-level auto-merge toggle (which cannot
+# be restricted to Dependabot only) and instead uses a bot token that is already in
+# the branch-protection bypass list, so no human review is required for bot merges.
+#
+# Eligible PRs: same-repo Dependabot PRs with minor or patch version bumps where all
+# required status checks have passed.
+
 on:
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - ready_for_review
-      - reopened
+  # Scheduled runs sweep up any PRs whose checks finished between manual triggers.
+  # Timing mirrors salesforcedx-vscode: four windows per day during off-hours (UTC).
+  schedule:
+    - cron: '42 2,5,8,11 * * *'
+
+  # Manual trigger for ad-hoc runs or debugging (skipCI available for emergencies).
+  workflow_dispatch:
+    inputs:
+      skipCI:
+        description: 'Skip CI check requirement and merge immediately'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
   pull-requests: write
+  checks: read
+  actions: read
 
 jobs:
-  enable-automerge:
-    runs-on: ubuntu-latest
-    if: |
-      github.event.pull_request.user.login == 'dependabot[bot]' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false
-    steps:
-      - name: Enable auto-merge for Dependabot PR
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const pullRequest = context.payload.pull_request;
-            const title = context.payload.pull_request.title ?? "";
-            const pull_number = context.payload.pull_request.number;
-            const headRepoFullName = pullRequest.head?.repo?.full_name ?? "";
-            const baseRepoFullName = pullRequest.base?.repo?.full_name ?? "";
-
-            if (headRepoFullName !== baseRepoFullName) {
-              core.info(
-                `Skipping auto-merge for PR #${pull_number}: fork-origin PR detected (${headRepoFullName} -> ${baseRepoFullName}).`
-              );
-              return;
-            }
-
-            // Dependabot titles generally look like:
-            // "Bump <dep> from <old> to <new>".
-            // Skip auto-merge if this is a major version bump.
-            const bumpMatch = title.match(/ from v?(\d+)(?:\.[\w.-]+)? to v?(\d+)(?:\.[\w.-]+)?$/i);
-            if (bumpMatch) {
-              const fromMajor = Number.parseInt(bumpMatch[1], 10);
-              const toMajor = Number.parseInt(bumpMatch[2], 10);
-              if (Number.isFinite(fromMajor) && Number.isFinite(toMajor) && toMajor > fromMajor) {
-                core.info(`Skipping auto-merge for PR #${pull_number}: major version bump detected in title "${title}".`);
-                return;
-              }
-            }
-
-            await github.graphql(`
-              mutation($pullRequestId: ID!) {
-                enablePullRequestAutoMerge(input: {
-                  pullRequestId: $pullRequestId,
-                  mergeMethod: SQUASH
-                }) {
-                  pullRequest {
-                    number
-                    autoMergeRequest {
-                      enabledAt
-                    }
-                  }
-                }
-              }
-            `, {
-              pullRequestId: context.payload.pull_request.node_id
-            });
-            core.info(`Enabled auto-merge for PR #${pull_number}`);
+  automerge:
+    uses: salesforcecli/github-workflows/.github/workflows/automerge.yml@main
+    secrets:
+      SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+    with:
+      mergeMethod: squash
+      maxVersionBump: minor
+      skipCI: ${{ github.event.inputs.skipCI == 'true' }}


### PR DESCRIPTION
### What does this PR do?

Replaces the `pull_request_target` automerge workflow (which called the GitHub GraphQL `enablePullRequestAutoMerge` mutation and required the repo-level auto-merge setting to be enabled) with a scheduled workflow that uses `svc-idee-bot` via the shared `salesforcecli/github-workflows` reusable automerge workflow.

The old approach failed on every Dependabot PR because the repo-level auto-merge setting is off — and that setting can't be scoped to Dependabot only, so turning it on would allow any maintainer to use it on any PR. The new approach avoids that setting entirely.

Key changes:
- Trigger: schedule (4× daily at off-hours UTC) + `workflow_dispatch` with optional `skipCI`
- Token: `IDEE_GH_TOKEN` (`svc-idee-bot`), which is already in the branch-protection bypass list — no human review required for bot merges
- Merges minor/patch bumps only (`maxVersionBump: minor`); major bumps skipped
- Mirrors the pattern used in `salesforcedx-vscode`

### What issues does this PR fix or reference?

@W-22106427@

Made with [Cursor](https://cursor.com)