### PR TITLE
build(deps): co-locate playwright and @playwright/test in e2e-tests

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -219,7 +219,8 @@
     }
   },
   "devDependencies": {
-    "@playwright/test": "^1.55.0",
+    "@playwright/test": "^1.58.2",
+    "playwright": "^1.58.2",
     "@types/node": "^20.19.39",
     "@vscode/test-electron": "2.5.2",
     "typescript": "^5.8.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.4.4",
-        "@playwright/test": "^1.55.0",
         "@salesforce/apex-lsp-compliant-services": "1.0.0",
         "@salesforce/apex-lsp-parser-ast": "1.0.0",
         "@semantic-release/changelog": "^6.0.3",
@@ -54,7 +53,6 @@
         "jscpd": "^4.0.9",
         "jsonc-eslint-parser": "^2.4.0",
         "knip": "^6.4.1",
-        "playwright": "^1.58.2",
         "prettier": "^3.8.1",
         "rimraf": "^5.0.5",
         "semantic-release": "^25.0.3",
@@ -79,9 +77,10 @@
     "e2e-tests": {
       "version": "1.0.0",
       "devDependencies": {
-        "@playwright/test": "^1.55.0",
+        "@playwright/test": "^1.58.2",
         "@types/node": "^20.19.39",
         "@vscode/test-electron": "2.5.2",
+        "playwright": "^1.58.2",
         "typescript": "^5.8.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.4.4",
-    "@playwright/test": "^1.55.0",
     "@salesforce/apex-lsp-compliant-services": "1.0.0",
     "@salesforce/apex-lsp-parser-ast": "1.0.0",
     "@semantic-release/changelog": "^6.0.3",
@@ -102,7 +101,6 @@
     "jscpd": "^4.0.9",
     "jsonc-eslint-parser": "^2.4.0",
     "knip": "^6.4.1",
-    "playwright": "^1.58.2",
     "prettier": "^3.8.1",
     "rimraf": "^5.0.5",
     "semantic-release": "^25.0.3",


### PR DESCRIPTION
### What does this PR do?

Moves `playwright` and `@playwright/test` out of the root `package.json` and into `e2e-tests/package.json`, pinning both at the same `^1.58.2` constraint.

**Why:** `node_modules/.bin/playwright` is always owned by `@playwright/test/cli.js` (alphabetical npm resolution). When `playwright` lived only in the root, Dependabot bumped it in isolation — `@playwright/test` stayed at an older version, so `npx playwright install` installed the wrong Chromium revision while `@vscode/test-web` resolved a different playwright version from the root and expected a different browser build. This caused every E2E web test to crash at browser launch with `Executable doesn't exist`.

Co-locating both packages in `e2e-tests/package.json` ensures:
- Dependabot bumps them in a single PR, keeping versions in sync.
- The binary and browser revision always match.
- Root `package.json` is no longer responsible for E2E-only tooling.

### What issues does this PR fix or reference?

[skip-validate-pr]

Made with [Cursor](https://cursor.com)