### PR TITLE
fix(ci): remove gitignored build artifact path from generate-stubs git add - W-22243795

### DIFF
--- a/.github/workflows/generate-stubs.yml
+++ b/.github/workflows/generate-stubs.yml
@@ -128,7 +128,6 @@ jobs:
         id: changes
         run: |
           git add packages/apex-parser-ast/src/resources/StandardApexLibrary/ \
-                  packages/apex-parser-ast/resources/ \
                   packages/apex-parser-ast/test/generator/__snapshots__/emptyStubDetection.snapshot.test.ts.snap
           if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -150,7 +149,6 @@ jobs:
 
             **Changes:**
             - Updated `.cls` stub files in `packages/apex-parser-ast/src/resources/StandardApexLibrary/`
-            - Rebuilt `StandardApexLibrary.zip` and protobuf artifacts
             - Updated `manifest.json` with current namespace/class counts
             - Updated empty-stub snapshot baseline (`emptyStubDetection.snapshot.test.ts.snap`)
 


### PR DESCRIPTION
## Summary

- The `generate-stubs.yml` "Check for changes" step was running `git add packages/apex-parser-ast/resources/` which is gitignored (build artifacts: `StandardApexLibrary.zip` + `.md5`), causing the step to fail with exit code 1
- Removed that path from the `git add`; only source stubs and snapshot need staging
- Updated the auto-generated PR body to stop claiming zip artifacts are committed

### What issues does this PR fix or reference?
@W-22243795@

Made with [Cursor](https://cursor.com)