### PR TITLE
feat(infra): add worker-topology settings type extensions - W-22201102

### DIFF
--- a/packages/apex-lsp-shared/src/server/ApexLanguageServerSettings.ts
+++ b/packages/apex-lsp-shared/src/server/ApexLanguageServerSettings.ts
@@ -63,6 +63,12 @@ export interface EnvironmentSettings {
   /** Current environment (node, browser, web-worker) */
   runtimePlatform: RuntimePlatform;
 
+  /**
+   * Absolute URL of worker.platform.web.js, injected by the VS Code extension
+   * when running as a web worker (blob: origins cannot be used as URL bases).
+   */
+  workerPlatformWebUrl?: string;
+
   /** Current server mode */
   serverMode: ServerMode;
 
@@ -221,6 +227,9 @@ export interface DeferredReferenceProcessingSettings {
 
   /** Time threshold in milliseconds - if batch processing exceeds this, yield more frequently (default: 50) */
   yieldTimeThresholdMs?: number;
+
+  /** Enable deferred processing of cross-file references during workspace load (default: false) */
+  enableCrossFileDeferral?: boolean;
 }
 
 /**

--- a/packages/apex-lsp-shared/src/settings/ApexSettingsUtilities.ts
+++ b/packages/apex-lsp-shared/src/settings/ApexSettingsUtilities.ts
@@ -111,6 +111,7 @@ export const DEFAULT_APEX_SETTINGS: ApexLanguageServerSettings = {
       circuitBreakerResetThreshold: 50,
       maxDeferredTasksPerSecond: 5,
       yieldTimeThresholdMs: 50,
+      enableCrossFileDeferral: false,
     },
 
     symbolGraph: {

--- a/packages/apex-lsp-shared/test/settings/ApexLanguageServerSettings.test.ts
+++ b/packages/apex-lsp-shared/test/settings/ApexLanguageServerSettings.test.ts
@@ -193,6 +193,48 @@ describe('ApexLanguageServerSettings Validation', () => {
       expect(result.isValid).toBe(true);
       expect(result.details).toHaveLength(0);
     });
+
+    it('should accept workerPlatformWebUrl in environment settings', () => {
+      const configWithUrl = {
+        environment: {
+          profilingMode: 'none',
+          profilingType: 'cpu',
+          workerPlatformWebUrl:
+            'https://example.salesforce.com/dist/worker.platform.web.js',
+        },
+      };
+
+      const result = validateApexSettings(configWithUrl);
+
+      expect(result.isValid).toBe(true);
+      expect(result.details).toHaveLength(0);
+    });
+
+    it('should accept maxFileCount in loadWorkspace settings', () => {
+      const configWithMaxFiles = {
+        loadWorkspace: {
+          maxFileCount: 500,
+        },
+      };
+
+      const result = validateApexSettings(configWithMaxFiles);
+
+      expect(result.isValid).toBe(true);
+      expect(result.details).toHaveLength(0);
+    });
+
+    it('should accept enableCrossFileDeferral in deferredReferenceProcessing', () => {
+      const configWithDeferral = {
+        deferredReferenceProcessing: {
+          enableCrossFileDeferral: true,
+        },
+      };
+
+      const result = validateApexSettings(configWithDeferral);
+
+      expect(result.isValid).toBe(true);
+      expect(result.details).toHaveLength(0);
+    });
   });
 
   describe('isValidApexSettings', () => {
@@ -238,6 +280,30 @@ describe('ApexLanguageServerSettings Validation', () => {
 
       expect(result.apex.environment.runtimePlatform).toBe('web');
       expect(result.apex.performance.commentCollectionMaxFileSize).toBe(51200); // Browser default
+    });
+
+    it('should default enableCrossFileDeferral to false', () => {
+      const result = mergeWithDefaults({}, 'desktop');
+
+      expect(
+        result.apex.deferredReferenceProcessing.enableCrossFileDeferral,
+      ).toBe(false);
+    });
+
+    it('should preserve user-supplied enableCrossFileDeferral=true', () => {
+      const partialConfig = {
+        apex: {
+          deferredReferenceProcessing: {
+            enableCrossFileDeferral: true,
+          },
+        },
+      } as Partial<ApexLanguageServerSettings>;
+
+      const result = mergeWithDefaults(partialConfig, 'desktop');
+
+      expect(
+        result.apex.deferredReferenceProcessing.enableCrossFileDeferral,
+      ).toBe(true);
     });
   });
 

--- a/packages/apex-lsp-vscode-extension/test/configuration.test.ts
+++ b/packages/apex-lsp-vscode-extension/test/configuration.test.ts
@@ -118,6 +118,7 @@ describe('Configuration Module', () => {
             circuitBreakerResetThreshold: 50,
             maxDeferredTasksPerSecond: 5,
             yieldTimeThresholdMs: 50,
+            enableCrossFileDeferral: false,
           },
           performance: {
             commentCollectionMaxFileSize: 102400,
@@ -145,6 +146,7 @@ describe('Configuration Module', () => {
             profilingMode: 'none',
             profilingType: 'cpu',
             commentCollectionLogLevel: 'info',
+            jsHeapSizeGB: undefined,
           },
           resources: {
             standardApexLibraryPath: undefined,


### PR DESCRIPTION
### What does this PR do?

**Phase 1 (additive, no behavior change)** type extensions for the upcoming worker-topology feature. All additions are optional fields, default values, and tests — no existing call sites are modified and no new runtime behavior is enabled.

#### Settings interface additions (`apex-lsp-shared`)

- `EnvironmentSettings.workerPlatformWebUrl?: string` — absolute URL of `worker.platform.web.js`, injected by the VS Code extension when running as a web worker (blob: origins cannot be used as URL bases).
- `DeferredReferenceProcessingSettings.enableCrossFileDeferral?: boolean` — gate for deferred cross-file reference resolution during workspace load.

(`LoadWorkspaceSettings.maxFileCount` was originally part of this story but landed on main from a predecessor branch.)

#### Defaults

- `DEFAULT_APEX_SETTINGS.deferredReferenceProcessing.enableCrossFileDeferral = false` so `mergeWithDefaults` returns an explicit value when callers don't supply one.

#### Tests

- New `validateApexSettings` cases for `workerPlatformWebUrl`, `maxFileCount`, and `enableCrossFileDeferral`.
- New `mergeWithDefaults` cases covering the `enableCrossFileDeferral` default and user-supplied override.
- Updated `apex-lsp-vscode-extension/test/configuration.test.ts` to include `enableCrossFileDeferral: false` and `jsHeapSizeGB: undefined` in the expected default settings shape (the latter was a pre-existing failure on main, surfaced when the wireit cache was invalidated).

#### Notes on the VS Code extension config block

The `apex.experimental.workers` configuration block, the `apex.loadWorkspace.maxFileCount` config, and the matching NLS strings are already present on main from a predecessor branch — this PR does not duplicate them.

### Verification (from repo root)

- `npm run compile` — clean
- `npm run lint` — clean
- `npm run test` — 4145 passing (was 4140; +5 new tests), 0 failing
- `npm run bundle` — clean
- `npx knip` — only pre-existing \`playwright\` unlisted-deps in \`apex-stubs-generator\` (unrelated)
- \`npm run check:dupes\` — no duplicates flagged for any modified file

### What issues does this PR fix or reference?

@W-22201102@


Made with [Cursor](https://cursor.com)