### PR TITLE
feat(apex-lsp-parser-ast): add Effect ops and services for symbol management - W-22201103

### DIFF
--- a/packages/apex-parser-ast/src/index.ts
+++ b/packages/apex-parser-ast/src/index.ts
@@ -77,6 +77,101 @@ export * from './utils/UnifiedCache';
 export * from './symbols/ApexSymbolManager';
 export * from './symbols/ApexSymbolProcessingManager';
 
+// Export Effect data services for symbol management
+export {
+  SymbolIndexStore,
+  symbolIndexStoreShim,
+  type SymbolIndexStoreShape,
+} from './symbols/services/symbolIndexStore';
+export {
+  ReferenceStore,
+  referenceStoreShim,
+  type ReferenceStoreShape,
+} from './symbols/services/referenceStore';
+export {
+  CacheStore,
+  cacheStoreShim,
+  type CacheStoreShape,
+} from './symbols/services/cacheStore';
+export {
+  FileStateStore,
+  fileStateStoreShim,
+  type FileStateStoreShape,
+  type FileMetadata,
+} from './symbols/services/fileStateStore';
+export {
+  ConcurrencyGuards,
+  concurrencyGuardsShim,
+  type ConcurrencyGuardsShape,
+} from './symbols/services/concurrencyGuards';
+export {
+  IEffectSymbolManager,
+  iEffectSymbolManagerFromLegacy,
+  type IEffectSymbolManagerShape,
+} from './symbols/services/symbolManagerFacade';
+export { SymbolIndexStoreLive } from './symbols/services/symbolIndexStoreLive';
+
+// Export standalone symbol management functions
+export {
+  getSymbol as getSymbolOp,
+  findByName as findByNameOp,
+  findByFQN as findByFQNOp,
+  findSymbolsByFQN as findSymbolsByFQNOp,
+  findInFile as findInFileOp,
+  findFilesForSymbol as findFilesForSymbolOp,
+  getAllSymbolsForCompletion as getAllSymbolsForCompletionOp,
+  getSymbolTableForFile as getSymbolTableForFileOp,
+  findFQNForStandardClass as findFQNForStandardClassOp,
+  isStandardLibraryType as isStandardLibraryTypeOp,
+  getBlockCommentsForSymbol as getBlockCommentsForSymbolOp,
+} from './symbols/ops/symbolLookup';
+export {
+  getContainingType as getContainingTypeOp,
+  getAncestorChain as getAncestorChainOp,
+  constructFQN as constructFQNOp,
+} from './symbols/ops/typeHierarchy';
+export {
+  findReferencesTo as findReferencesToOp,
+  findReferencesFrom as findReferencesFromOp,
+  findRelatedSymbols as findRelatedSymbolsOp,
+  getReferencesAtPosition as getReferencesAtPositionOp,
+  getAllReferencesInFile as getAllReferencesInFileOp,
+} from './symbols/ops/referenceOps';
+export {
+  analyzeDependencies as analyzeDependenciesOp,
+  detectCircularDependencies as detectCircularDependenciesOp,
+  getGraphData as getGraphDataOp,
+  getGraphDataForFile as getGraphDataForFileOp,
+  getGraphDataByType as getGraphDataByTypeOp,
+} from './symbols/ops/graphAnalysis';
+export {
+  find as findOp,
+  findScalarKeywordType as findScalarKeywordTypeOp,
+  findSObjectType as findSObjectTypeOp,
+  findExternalType as findExternalTypeOp,
+  findInDefaultNamespaceOrder as findInDefaultNamespaceOrderOp,
+  findInImplicitFileNamespaceSlot as findInImplicitFileNamespaceSlotOp,
+  findInExplicitNamespace as findInExplicitNamespaceOp,
+  isBuiltInNamespace as isBuiltInNamespaceOp,
+  isSObjectContainerNamespace as isSObjectContainerNamespaceOp,
+} from './symbols/ops/symbolProvider';
+export {
+  removeFile as removeFileOp,
+  clear as clearOp,
+  optimizeMemory as optimizeMemoryOp,
+  setCommentAssociations as setCommentAssociationsOp,
+} from './symbols/ops/symbolMutation';
+export {
+  resolveSymbol as resolveSymbolOp,
+  createResolutionContext as createResolutionContextOp,
+  createResolutionContextWithRequestType as createResolutionContextWithRequestTypeOp,
+  getDetailLevelForFile as getDetailLevelForFileOp,
+} from './symbols/ops/symbolResolution';
+export {
+  isStandardApexClass as isStandardApexClassOp,
+  resolveStandardApexClass as resolveStandardApexClassOp,
+} from './symbols/ops/stdlibLoading';
+
 // Export resolution framework types
 export * from './symbols/resolution/types';
 
@@ -89,6 +184,9 @@ export * from './symbols/ApexSymbolProcessingManager';
 
 // Export GlobalTypeRegistry Effect service
 export * from './services/GlobalTypeRegistryService';
+
+// Export ResourceLoaderService Effect service
+export * from './symbols/services/ResourceLoaderService';
 
 // Export i18n support
 export * from './i18n/messageInstance';

--- a/packages/apex-parser-ast/src/symbols/ops/chainResolution.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/chainResolution.ts
@@ -1,0 +1,3553 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { HashMap, Stack } from 'data-structure-typed';
+import { Effect } from 'effect';
+import type {
+  ApexSymbol,
+  SymbolLocation,
+  SymbolTable,
+  TypeSymbol,
+  VariableSymbol,
+} from '../../types/symbol';
+import { SymbolKind } from '../../types/symbol';
+import {
+  type SymbolReference,
+  ReferenceContext,
+  EnhancedSymbolReference,
+} from '../../types/symbolReference';
+import {
+  isChainedSymbolReference,
+  isBlockSymbol,
+  isMethodSymbol as isMethodSymbolNarrowing,
+} from '../../utils/symbolNarrowing';
+import {
+  createFileUri,
+  isStandardApexUri,
+  extractApexLibPath,
+} from '../../types/ProtocolHandler';
+import { extractFilePathFromUri } from '../../types/UriBasedIdGenerator';
+import { STANDARD_APEX_LIBRARY_URI } from '../../utils/ResourceUtils';
+import { getImplicitQualifiedCandidates } from '../../namespace/NamespaceResolutionPolicy';
+import { BUILTIN_TYPE_NAMES } from '../../utils/ApexKeywords';
+import {
+  applyMethodTypeSubstitutions,
+  createGenericTypeSubstitutionMap,
+  type GenericTypeSubstitutionMap,
+} from '../../utils/genericTypeSubstitution';
+import {
+  GlobalTypeRegistry,
+  GlobalTypeRegistryLive,
+} from '../../services/GlobalTypeRegistryService';
+import {
+  findChainMemberAtPosition as findChainMember,
+  isPositionOnFirstNode as posOnFirstNode,
+} from './positionUtils';
+import {
+  extractQualifierFromChain as extractQualFromChainOp,
+  isValidNamespace as isValidNsOp,
+  findSymbolsInNamespace as findSymsInNsOp,
+  resolveUnqualifiedReferenceByScope as resolveUnqualRefByScopeOp,
+  resolvePreferredTypeSymbolForLookup as resolvePreferredTypeOp,
+  isSymbolAccessibleFromFile as isSymAccessibleOp,
+  selectMostSpecificSymbol as selectMostSpecificOp,
+} from './symbolRefResolution';
+import type {
+  ChainResolutionContext,
+  SymbolManagerOps,
+} from '../services/symbolResolver';
+
+// ---------------------------------------------------------------------------
+// resolveChainedSymbolReference
+// ---------------------------------------------------------------------------
+
+export async function resolveChainedSymbolReference(
+  self: SymbolManagerOps,
+  typeReference: SymbolReference,
+  position?: { line: number; character: number },
+  fileUri?: string,
+): Promise<ApexSymbol | null> {
+  // Fast path: if already resolved by listener second-pass, use the ID directly
+  // BUT: Skip fast path when position is on any chain member
+  // This ensures we resolve the correct chain member (e.g., "numbers" or "size" in "numbers.size()")
+  if (typeReference.resolvedSymbolId) {
+    // Check if this is a chained reference and position is on a chain member
+    let shouldSkipFastPath = false;
+    if (position && isChainedSymbolReference(typeReference)) {
+      const chainMember = findChainMember(typeReference, position);
+      // Skip fast path if position is on any chain member (first node = variable, later = method)
+      if (chainMember) {
+        shouldSkipFastPath = true;
+      }
+    }
+
+    if (!shouldSkipFastPath) {
+      const resolvedSymbol = await self.getSymbol(
+        typeReference.resolvedSymbolId,
+      );
+      if (resolvedSymbol) {
+        self.logger.debug(
+          () =>
+            `Using pre-resolved symbol ID "${typeReference.resolvedSymbolId}" ` +
+            `for chained reference "${typeReference.name}"`,
+        );
+        return resolvedSymbol;
+      }
+      // If symbol not found, fall through to normal resolution
+    }
+  }
+
+  if (isChainedSymbolReference(typeReference)) {
+    let resolvedContext: ChainResolutionContext | null = null;
+    try {
+      const chainNodes = typeReference.chainNodes;
+
+      if (!chainNodes?.length) {
+        self.logger.warn(
+          () => 'Chained expression reference missing chainNodes property',
+        );
+        return null;
+      }
+
+      // If position is provided, try to resolve the specific chain member first
+      // This handles cases where resolveEntireChain might fail (e.g., 'this.method()' chains)
+      if (position) {
+        const firstNode = chainNodes[0];
+
+        // Check if position is on the first node (at start, within, or at chained ref start)
+        if (posOnFirstNode(typeReference, firstNode, position)) {
+          // Fast path: if first node already has resolvedSymbolId, use it directly
+          if (firstNode.resolvedSymbolId) {
+            const resolvedSymbol = await self.getSymbol(
+              firstNode.resolvedSymbolId,
+            );
+            if (resolvedSymbol) {
+              self.logger.debug(
+                () =>
+                  'Using pre-resolved symbol ID ' +
+                  `"${firstNode.resolvedSymbolId}" for first node "${firstNode.name}"`,
+              );
+              return resolvedSymbol;
+            }
+          }
+
+          // Special handling for method calls in 'this' chains
+          // For 'this.method().anotherMethod()', the first node is a method call,
+          // not a class, so we should resolve it as a method in the current class
+          if (firstNode.context === ReferenceContext.METHOD_CALL && fileUri) {
+            // Try to resolve as a method in the current class
+            const symbolTable =
+              self.symbolRefManager.getSymbolTableForFile(fileUri);
+            if (symbolTable) {
+              const allSymbols = symbolTable.getAllSymbols();
+              const methodSymbols = allSymbols.filter(
+                (s) =>
+                  s.kind === SymbolKind.Method && s.name === firstNode.name,
+              );
+              if (methodSymbols.length > 0) {
+                // Prefer non-static methods for 'this.method()' chains
+                const instanceMethod = methodSymbols.find(
+                  (s) => !s.modifiers?.isStatic,
+                );
+                if (instanceMethod) {
+                  return instanceMethod;
+                }
+                // Fall back to any method if no instance method found
+                return methodSymbols[0];
+              }
+            }
+          }
+
+          const firstNodeSymbol = await resolveFirstNodeAsClass(
+            self,
+            firstNode.name,
+            true,
+          );
+          if (firstNodeSymbol) {
+            return firstNodeSymbol;
+          }
+          // If first node resolution failed, fall through to chain member resolution
+        }
+
+        // Find the chain member at the position
+        const chainMember = findChainMember(typeReference, position);
+
+        // If position matches a specific chain member (not the first node), resolve that member
+        if (chainMember && chainMember.index > 0) {
+          // Position is on a method/field call in the chain (e.g., "size" in "numbers.size()")
+          // Resolve the specific chain member, not the whole chain
+          if (chainMember.member.resolvedSymbolId) {
+            const resolvedSymbol = await self.getSymbol(
+              chainMember.member.resolvedSymbolId,
+            );
+            if (resolvedSymbol) {
+              self.logger.debug(
+                () =>
+                  `Resolved chain member "${chainMember.member.name}" at index ${chainMember.index}`,
+              );
+              return resolvedSymbol;
+            }
+          }
+          // If chain member not pre-resolved, it will be handled by the code below
+          // that resolves the entire chain and then finds the chain member at the position
+        }
+
+        if (chainMember && chainMember.index === 0) {
+          // We already tried resolving the first node above, but if it failed,
+          // try one more time here with the chain member context
+          const firstNode = chainNodes[0];
+          if (firstNode.context === ReferenceContext.METHOD_CALL && fileUri) {
+            const symbolTable =
+              self.symbolRefManager.getSymbolTableForFile(fileUri);
+            if (symbolTable) {
+              const allSymbols = symbolTable.getAllSymbols();
+              const methodSymbols = allSymbols.filter(
+                (s) =>
+                  s.kind === SymbolKind.Method && s.name === firstNode.name,
+              );
+              if (methodSymbols.length > 0) {
+                const instanceMethod = methodSymbols.find(
+                  (s) => !s.modifiers?.isStatic,
+                );
+                if (instanceMethod) {
+                  return instanceMethod;
+                }
+                return methodSymbols[0];
+              }
+            }
+          }
+        }
+      }
+
+      // Resolve the entire chain
+      // Note: For 'this.method()' chains, resolveEntireChain might return null
+      // if the first method call can't be resolved through normal chain resolution.
+      // We handle this case above by resolving the first node directly.
+      const resolvedChain = await resolveEntireChain(self, chainNodes, fileUri);
+
+      self.logger.debug(
+        () =>
+          `resolveEntireChain for "${typeReference.name}" returned: ${
+            resolvedChain
+              ? `chain with ${resolvedChain.length} members`
+              : 'null'
+          }`,
+      );
+      if (resolvedChain) {
+        resolvedChain.forEach((ctx, idx) => {
+          if (ctx) {
+            const name =
+              ctx.type === 'symbol'
+                ? ctx.symbol?.name || 'N/A'
+                : ctx.type === 'namespace'
+                  ? ctx.name
+                  : 'N/A';
+            self.logger.debug(
+              () => `  Chain member ${idx}: type=${ctx.type}, name=${name}`,
+            );
+          }
+        });
+      }
+
+      // If position is provided, find the specific chain member and return its resolved symbol
+      if (position) {
+        // Find the chain member at the position (if not already found above)
+        const chainMember = findChainMember(typeReference, position);
+
+        self.logger.debug(
+          () =>
+            `Chain member at position ${position.line}:${position.character}: ${
+              chainMember
+                ? `index=${chainMember.index}, name=${chainMember.member.name}`
+                : 'null'
+            }`,
+        );
+
+        if (chainMember) {
+          // If position is on the first node, we already tried resolving it above
+          // Skip to resolving other chain members
+          if (chainMember.index === 0) {
+            // We already handled the first node above, but if it failed,
+            // try one more time here
+            const firstNode = chainNodes[0];
+            if (firstNode.context === ReferenceContext.METHOD_CALL && fileUri) {
+              const symbolTable =
+                self.symbolRefManager.getSymbolTableForFile(fileUri);
+              if (symbolTable) {
+                const allSymbols = symbolTable.getAllSymbols();
+                const methodSymbols = allSymbols.filter(
+                  (s) =>
+                    s.kind === SymbolKind.Method && s.name === firstNode.name,
+                );
+                if (methodSymbols.length > 0) {
+                  const instanceMethod = methodSymbols.find(
+                    (s) => !s.modifiers?.isStatic,
+                  );
+                  if (instanceMethod) {
+                    return instanceMethod;
+                  }
+                  return methodSymbols[0];
+                }
+              }
+            }
+            // If we get here, first node resolution failed - try class resolution
+            const firstNodeSymbol = await resolveFirstNodeAsClass(
+              self,
+              chainNodes[0].name,
+              false,
+            );
+            if (firstNodeSymbol) {
+              return firstNodeSymbol;
+            }
+          }
+
+          // Resolve the chain member from the resolved chain context
+          // Only use resolvedChain if it exists and has the member at this index
+          if (resolvedChain && resolvedChain.length > chainMember.index) {
+            resolvedContext = resolvedChain[chainMember.index];
+            if (resolvedContext?.type === 'symbol') {
+              return resolvedContext.symbol || null;
+            }
+          }
+
+          // If the resolved context is not a symbol (e.g., namespace or global), and we're on the first node,
+          // try to resolve the qualifier as a class symbol
+          if (
+            chainMember.index === 0 &&
+            resolvedContext &&
+            (resolvedContext.type === 'namespace' ||
+              resolvedContext.type === 'global')
+          ) {
+            const qualifierName = chainNodes[0].name;
+            const qualifierSymbols = await self.findSymbolByName(qualifierName);
+
+            // Filter for class symbols
+            const classSymbols = qualifierSymbols.filter(
+              (s) =>
+                s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
+            );
+
+            if (classSymbols.length > 0) {
+              // Prefer standard Apex classes for qualified references
+              const standardClass = classSymbols.find(
+                (s) =>
+                  s.fileUri?.includes('apexlib://') ||
+                  s.fileUri?.includes('StandardApexLibrary'),
+              );
+              return standardClass || classSymbols[0];
+            }
+
+            // If no class found, try standard Apex class resolution
+            const standardClass =
+              await self.resolveStandardApexClass(qualifierName);
+            if (standardClass) {
+              return standardClass;
+            }
+          }
+        }
+      }
+
+      // Return the final resolved symbol (last in the chain)
+      // Only if resolvedChain exists
+      if (resolvedChain && resolvedChain.length > 0) {
+        resolvedContext = resolvedChain[resolvedChain.length - 1];
+        return resolvedContext?.type === 'symbol'
+          ? resolvedContext.symbol
+          : null;
+      }
+
+      // If resolvedChain is null and we have a position, we might have already
+      // resolved the first node above, so return null here
+      return null;
+    } catch (error) {
+      self.logger.error(
+        () => `Error resolving chained expression reference: ${error}`,
+      );
+      return null;
+    }
+  } else {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// resolveEntireChain
+// ---------------------------------------------------------------------------
+
+export async function resolveEntireChain(
+  self: SymbolManagerOps,
+  chainNodes: SymbolReference[],
+  fileUri?: string,
+): Promise<ChainResolutionContext[] | null> {
+  if (!chainNodes?.length) {
+    return null;
+  }
+
+  // Find all possible resolution paths
+  const resolutionPaths = await findAllPossibleResolutionPaths(
+    self,
+    chainNodes,
+    fileUri,
+  );
+
+  if (resolutionPaths.length === 0) {
+    self.logger.debug(
+      () =>
+        `No resolution paths found for chain: ${chainNodes.map((n) => n.name).join('.')} ` +
+        `(fileUri: ${fileUri})`,
+    );
+    return null;
+  }
+
+  if (resolutionPaths.length === 1) {
+    return resolutionPaths[0];
+  }
+
+  // Multiple valid paths - need to disambiguate
+  const bestPath = disambiguateResolutionPaths(
+    self,
+    resolutionPaths,
+    chainNodes,
+  );
+
+  return bestPath;
+}
+
+// ---------------------------------------------------------------------------
+// findAllPossibleResolutionPaths
+// ---------------------------------------------------------------------------
+
+export async function findAllPossibleResolutionPaths(
+  self: SymbolManagerOps,
+  chainNodes: SymbolReference[],
+  fileUri?: string,
+): Promise<ChainResolutionContext[][]> {
+  const paths: ChainResolutionContext[][] = [];
+  const pathStack = new Stack<ChainResolutionContext>();
+
+  await exploreResolutionPaths(
+    self,
+    chainNodes,
+    0,
+    undefined,
+    pathStack,
+    paths,
+    fileUri,
+  );
+
+  paths.forEach((_path, _index) => {
+    // Debug logging removed for performance
+  });
+
+  return paths;
+}
+
+// ---------------------------------------------------------------------------
+// exploreResolutionPaths
+// ---------------------------------------------------------------------------
+
+export async function exploreResolutionPaths(
+  self: SymbolManagerOps,
+  chainNodes: SymbolReference[],
+  stepIndex: number,
+  currentContext: ChainResolutionContext,
+  pathStack: Stack<ChainResolutionContext>,
+  allPaths: ChainResolutionContext[][],
+  fileUri?: string,
+): Promise<void> {
+  if (stepIndex >= chainNodes.length) {
+    // Complete path found - add to results
+    const completePath = pathStack.toArray();
+    allPaths.push(completePath);
+    return;
+  }
+
+  const step = chainNodes[stepIndex];
+  const nextStep =
+    stepIndex + 1 < chainNodes.length ? chainNodes[stepIndex + 1] : undefined;
+
+  // Get ALL possible resolutions for this step
+  const possibleResolutions = await getAllPossibleResolutions(
+    self,
+    step,
+    currentContext,
+    nextStep,
+    fileUri,
+  );
+
+  if (possibleResolutions.length === 0 && stepIndex === 0) {
+    self.logger.debug(
+      () =>
+        `No resolutions found for first step "${step.name}" ` +
+        `(context: ${ReferenceContext[step.context] || step.context}, ` +
+        `fileUri: ${fileUri})`,
+    );
+  }
+
+  for (const resolution of possibleResolutions) {
+    pathStack.push(resolution);
+    await exploreResolutionPaths(
+      self,
+      chainNodes,
+      stepIndex + 1,
+      resolution,
+      pathStack,
+      allPaths,
+      fileUri,
+    );
+    pathStack.pop(); // Backtrack
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getAllPossibleResolutions
+// ---------------------------------------------------------------------------
+
+export async function getAllPossibleResolutions(
+  self: SymbolManagerOps,
+  step: SymbolReference,
+  currentContext: ChainResolutionContext,
+  nextStep?: SymbolReference,
+  fileUri?: string,
+): Promise<ChainResolutionContext[]> {
+  const resolutions: ChainResolutionContext[] = [];
+  const stepName = step.name;
+
+  // Strategy 1: Try namespace resolution
+  if (canResolveAsNamespace(step, currentContext)) {
+    if (await isValidNsOp(self, stepName)) {
+      const namespaceContext: ChainResolutionContext = {
+        type: 'namespace',
+        name: stepName,
+      };
+      resolutions.push(namespaceContext);
+    }
+  }
+
+  // Strategy 1.5: Try variable resolution FIRST when there's no current context
+  // This is important for chained calls like "base64Data.toString()"
+  // We prioritize variables over classes when resolving the first step of a chain
+  if (
+    !currentContext &&
+    (step.context === ReferenceContext.VARIABLE_USAGE ||
+      step.context === ReferenceContext.CHAIN_STEP ||
+      step.context === ReferenceContext.CLASS_REFERENCE)
+  ) {
+    let variableSymbol: ApexSymbol | undefined;
+
+    // Fast path: if the step has a resolvedSymbolId, use it directly
+    if (step.resolvedSymbolId) {
+      const resolvedSymbol = await self.getSymbol(step.resolvedSymbolId);
+      if (
+        resolvedSymbol &&
+        (resolvedSymbol.kind === 'variable' ||
+          resolvedSymbol.kind === 'field' ||
+          resolvedSymbol.kind === 'parameter' ||
+          resolvedSymbol.kind === 'property')
+      ) {
+        variableSymbol = resolvedSymbol;
+      }
+    }
+
+    // If still not found and we have fileUri, try scope-based lookup for local variables FIRST
+    // (before global lookup, as local variables take precedence)
+    if (!variableSymbol && fileUri && step.location) {
+      const position = {
+        line:
+          step.location.identifierRange?.startLine ??
+          step.location.symbolRange.startLine,
+        character:
+          step.location.identifierRange?.startColumn ??
+          step.location.symbolRange.startColumn,
+      };
+      const scopeBasedSymbol = resolveUnqualRefByScopeOp(
+        self,
+        step,
+        fileUri,
+        position,
+      );
+      if (
+        scopeBasedSymbol &&
+        (scopeBasedSymbol.kind === 'variable' ||
+          scopeBasedSymbol.kind === 'parameter' ||
+          scopeBasedSymbol.kind === 'field' ||
+          scopeBasedSymbol.kind === 'property')
+      ) {
+        variableSymbol = scopeBasedSymbol;
+      }
+    }
+
+    // If not found via resolvedSymbolId or scope, try global lookup (works for fields and global variables)
+    if (!variableSymbol) {
+      const variableSymbols = await self.findSymbolByName(stepName);
+      variableSymbol = variableSymbols.find(
+        (s) =>
+          s.kind === 'variable' ||
+          s.kind === 'field' ||
+          s.kind === 'parameter' ||
+          s.kind === 'property',
+      );
+    }
+
+    if (variableSymbol) {
+      resolutions.push({ type: 'symbol', symbol: variableSymbol });
+    }
+  }
+
+  // Strategy 1.6: Try method resolution in current class when there's no current context
+  // This handles 'this.method()' chains where the first node is a method call
+  // and should resolve to a method in the current class
+  if (
+    !currentContext &&
+    step.context === ReferenceContext.METHOD_CALL &&
+    fileUri &&
+    step.location
+  ) {
+    // Try to find the method in the current class using scope-based resolution
+    const position = {
+      line:
+        step.location.identifierRange?.startLine ??
+        step.location.symbolRange.startLine,
+      character:
+        step.location.identifierRange?.startColumn ??
+        step.location.symbolRange.startColumn,
+    };
+    const scopeBasedSymbol = resolveUnqualRefByScopeOp(
+      self,
+      step,
+      fileUri,
+      position,
+    );
+    if (
+      scopeBasedSymbol &&
+      scopeBasedSymbol.kind === SymbolKind.Method &&
+      scopeBasedSymbol.name === stepName
+    ) {
+      resolutions.push({ type: 'symbol', symbol: scopeBasedSymbol });
+    } else {
+      // Fallback: Try to find the method in the current class via symbol table
+      const symbolTable = self.symbolRefManager.getSymbolTableForFile(fileUri);
+      if (symbolTable) {
+        const allSymbols = symbolTable.getAllSymbols();
+        // Find methods in the current class that match the step name
+        const methodSymbols = allSymbols.filter(
+          (s) => s.kind === SymbolKind.Method && s.name === stepName,
+        );
+        if (methodSymbols.length > 0) {
+          // Prefer non-static methods for 'this.method()' chains
+          const instanceMethod = methodSymbols.find(
+            (s) => !s.modifiers?.isStatic,
+          );
+          if (instanceMethod) {
+            resolutions.push({ type: 'symbol', symbol: instanceMethod });
+          } else {
+            // Fall back to any method if no instance method found
+            resolutions.push({ type: 'symbol', symbol: methodSymbols[0] });
+          }
+        }
+      }
+    }
+  }
+
+  // Strategy 2: Try class resolution
+  const classSymbol = await tryResolveAsClass(
+    self,
+    stepName,
+    currentContext,
+    step.context,
+  );
+  if (classSymbol) {
+    resolutions.push({ type: 'symbol', symbol: classSymbol });
+  }
+
+  // Strategy 2.5: Try instance resolution (for variables that are treated as class references)
+  // This works both when currentContext is defined (for nested chains) and undefined (for first step)
+  // Skip this strategy if the step context indicates a method call - methods should be resolved
+  // via tryResolveAsMember, not as instance properties
+  if (step.context !== ReferenceContext.METHOD_CALL) {
+    const instanceSymbol = await tryResolveAsInstance(
+      self,
+      stepName,
+      currentContext,
+    );
+    if (instanceSymbol) {
+      resolutions.push({ type: 'symbol', symbol: instanceSymbol });
+    }
+  }
+
+  // Strategy 3: Try property/method resolution
+  const memberSymbol = await tryResolveAsMember(
+    self,
+    step,
+    currentContext,
+    nextStep,
+  );
+  if (memberSymbol) {
+    resolutions.push({ type: 'symbol', symbol: memberSymbol });
+  }
+
+  // Strategy 4: Try built-in type resolution
+  const builtInSymbol = await self.resolveStandardLibraryType(step);
+  if (builtInSymbol) {
+    resolutions.push({ type: 'symbol', symbol: builtInSymbol });
+  }
+
+  // Strategy 5: Try VARIABLE_USAGE/CHAIN_STEP/CLASS_REFERENCE resolution (for variables, fields, parameters)
+  // This is important for chained calls like "base64Data.toString()"
+  // When there's no current context and the step could be a variable, try to resolve it
+  // Note: CLASS_REFERENCE context is sometimes used for variables in chain nodes
+  if (
+    !currentContext &&
+    (step.context === ReferenceContext.VARIABLE_USAGE ||
+      step.context === ReferenceContext.CHAIN_STEP ||
+      step.context === ReferenceContext.CLASS_REFERENCE)
+  ) {
+    // First try global lookup (works for fields and global variables)
+    const variableSymbols = await self.findSymbolByName(stepName);
+    let variableSymbol = variableSymbols.find(
+      (s) =>
+        s.kind === 'variable' ||
+        s.kind === 'field' ||
+        s.kind === 'parameter' ||
+        s.kind === 'property',
+    );
+
+    // If not found and we have fileUri, try scope-based lookup for local variables
+    if (!variableSymbol && fileUri && step.location) {
+      const position = {
+        line: step.location.symbolRange.startLine,
+        character: step.location.symbolRange.startColumn,
+      };
+      const scopeBasedSymbol = resolveUnqualRefByScopeOp(
+        self,
+        step,
+        fileUri,
+        position,
+      );
+      if (
+        scopeBasedSymbol &&
+        (scopeBasedSymbol.kind === 'variable' ||
+          scopeBasedSymbol.kind === 'parameter' ||
+          scopeBasedSymbol.kind === 'field' ||
+          scopeBasedSymbol.kind === 'property')
+      ) {
+        variableSymbol = scopeBasedSymbol;
+      }
+    }
+
+    if (variableSymbol) {
+      resolutions.push({ type: 'symbol', symbol: variableSymbol });
+    }
+  }
+
+  // Strategy 6: Try global symbol resolution
+  const globalSymbols = await self.findSymbolByName(stepName);
+  const matchingGlobalSymbol = globalSymbols.find(
+    (s) => s.kind === 'class' || s.kind === 'property' || s.kind === 'method',
+  );
+  if (matchingGlobalSymbol) {
+    resolutions.push({ type: 'symbol', symbol: matchingGlobalSymbol });
+  }
+
+  // Strategy 6.5: Final fallback for method calls in current class when no context
+  // This handles 'this.method()' chains where other strategies failed
+  if (
+    !currentContext &&
+    step.context === ReferenceContext.METHOD_CALL &&
+    fileUri &&
+    resolutions.length === 0
+  ) {
+    // Try to find the method in the current class via symbol table
+    const symbolTable = self.symbolRefManager.getSymbolTableForFile(fileUri);
+    if (symbolTable) {
+      const allSymbols = symbolTable.getAllSymbols();
+      // Find methods in the current class that match the step name
+      const methodSymbols = allSymbols.filter(
+        (s) => s.kind === SymbolKind.Method && s.name === stepName,
+      );
+      if (methodSymbols.length > 0) {
+        // Prefer non-static methods for 'this.method()' chains
+        const instanceMethod = methodSymbols.find(
+          (s) => !s.modifiers?.isStatic,
+        );
+        if (instanceMethod) {
+          resolutions.push({ type: 'symbol', symbol: instanceMethod });
+        } else {
+          // Fall back to any method if no instance method found
+          resolutions.push({ type: 'symbol', symbol: methodSymbols[0] });
+        }
+      }
+    }
+  }
+
+  // Strategy 7: Try standard Apex class resolution (for cases like URL without namespace)
+  if (
+    currentContext?.type === 'namespace' &&
+    step.context !== ReferenceContext.METHOD_CALL &&
+    step.context !== ReferenceContext.FIELD_ACCESS &&
+    step.context !== ReferenceContext.VARIABLE_USAGE
+  ) {
+    const fqn = `${currentContext.name}.${stepName}`;
+    const standardClass = await self.resolveStandardApexClass(fqn);
+    if (standardClass) {
+      resolutions.push({ type: 'symbol', symbol: standardClass });
+    }
+  }
+
+  return resolutions;
+}
+
+// ---------------------------------------------------------------------------
+// disambiguateResolutionPaths
+// ---------------------------------------------------------------------------
+
+export function disambiguateResolutionPaths(
+  self: SymbolManagerOps,
+  paths: ChainResolutionContext[][],
+  chainNodes: SymbolReference[],
+): ChainResolutionContext[] {
+  // Strategy 1: Prefer namespace paths over class paths when both exist
+  const namespacePaths = paths.filter((path) =>
+    path.some((ctx) => ctx && ctx.type === 'namespace'),
+  );
+
+  if (namespacePaths.length > 0) {
+    return selectBestNamespacePath(namespacePaths, chainNodes);
+  }
+
+  // Strategy 2: Prefer most specific resolution (fewer global lookups)
+  const mostSpecificPath = paths.reduce((best, current) => {
+    const bestSpecificity = getPathSpecificity(best);
+    const currentSpecificity = getPathSpecificity(current);
+
+    if (currentSpecificity > bestSpecificity) {
+      return current;
+    }
+    return best;
+  });
+
+  // Strategy 3: Use static analysis of the next step if available
+  if (chainNodes.length > 1) {
+    const nextStep = chainNodes[1];
+    const contextAwarePath = choosePathBasedOnNextStep(paths, nextStep);
+    if (contextAwarePath) {
+      return contextAwarePath;
+    }
+  }
+
+  // Strategy 4: Prefer paths with method calls over property access
+  const methodPaths = paths.filter((path) =>
+    path.some(
+      (ctx) =>
+        ctx &&
+        ctx.type === 'symbol' &&
+        (ctx.symbol.kind === 'method' || isMethodSymbol(ctx.symbol)),
+    ),
+  );
+
+  if (methodPaths.length > 0) {
+    return methodPaths[0];
+  }
+
+  return mostSpecificPath;
+}
+
+// ---------------------------------------------------------------------------
+// selectBestNamespacePath
+// ---------------------------------------------------------------------------
+
+export function selectBestNamespacePath(
+  namespacePaths: ChainResolutionContext[][],
+  _chainNodes: SymbolReference[],
+): ChainResolutionContext[] {
+  // Prefer paths where the namespace is used earlier in the chain
+  return namespacePaths.reduce((best, current) => {
+    const bestNamespaceIndex = getFirstNamespaceIndex(best);
+    const currentNamespaceIndex = getFirstNamespaceIndex(current);
+
+    // Prefer earlier namespace usage
+    if (currentNamespaceIndex < bestNamespaceIndex) {
+      return current;
+    }
+
+    // If same position, prefer shorter paths (more direct)
+    if (
+      currentNamespaceIndex === bestNamespaceIndex &&
+      current.length < best.length
+    ) {
+      return current;
+    }
+
+    return best;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// getFirstNamespaceIndex
+// ---------------------------------------------------------------------------
+
+export function getFirstNamespaceIndex(path: ChainResolutionContext[]): number {
+  return path.findIndex((ctx) => ctx && ctx.type === 'namespace');
+}
+
+// ---------------------------------------------------------------------------
+// getPathSpecificity
+// ---------------------------------------------------------------------------
+
+export function getPathSpecificity(path: ChainResolutionContext[]): number {
+  let score = 0;
+
+  for (const ctx of path) {
+    if (ctx && ctx.type === 'namespace') {
+      score += 10; // Namespace resolution is very specific
+    } else if (ctx && ctx.type === 'symbol') {
+      const symbol = ctx.symbol;
+
+      // Prefer more specific symbol types
+      switch (symbol.kind) {
+        case 'method':
+          score += 8;
+          break;
+        case 'property':
+          score += 6;
+          break;
+        case 'class':
+          score += 4;
+          break;
+        default:
+          score += 2;
+      }
+
+      // Bonus for static symbols
+      if ((symbol as any).isStatic) {
+        score += 1;
+      }
+    }
+  }
+
+  return score;
+}
+
+// ---------------------------------------------------------------------------
+// choosePathBasedOnNextStep
+// ---------------------------------------------------------------------------
+
+export function choosePathBasedOnNextStep(
+  paths: ChainResolutionContext[][],
+  nextStep: SymbolReference,
+): ChainResolutionContext[] | null {
+  const nextStepContext = nextStep.context;
+
+  // If next step is a method call, prefer paths that can resolve to a class
+  if (nextStepContext === ReferenceContext.METHOD_CALL) {
+    const classPaths = paths.filter((path) => {
+      const lastContext = path[path.length - 1];
+      return (
+        lastContext?.type === 'symbol' &&
+        (lastContext.symbol.kind === 'class' ||
+          isClassSymbol(lastContext.symbol))
+      );
+    });
+
+    if (classPaths.length > 0) {
+      return classPaths[0];
+    }
+  }
+
+  // If next step is field access, prefer paths that can resolve to an instance
+  if (nextStepContext === ReferenceContext.FIELD_ACCESS) {
+    const instancePaths = paths.filter((path) => {
+      const lastContext = path[path.length - 1];
+      return (
+        lastContext?.type === 'symbol' &&
+        (lastContext.symbol.kind === 'property' ||
+          lastContext.symbol.kind === 'class' ||
+          isInstanceSymbol(lastContext.symbol))
+      );
+    });
+
+    if (instancePaths.length > 0) {
+      return instancePaths[0];
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// isMethodSymbol / isClassSymbol / isInstanceSymbol
+// ---------------------------------------------------------------------------
+
+export function isMethodSymbol(symbol: ApexSymbol): boolean {
+  return (
+    symbol.kind === 'method' ||
+    (symbol.kind === 'property' && symbol.name?.includes('()'))
+  );
+}
+
+export function isClassSymbol(symbol: ApexSymbol): boolean {
+  return (
+    symbol.kind === 'class' ||
+    symbol.kind === 'interface' ||
+    symbol.kind === 'enum'
+  );
+}
+
+export function isInstanceSymbol(symbol: ApexSymbol): boolean {
+  return (
+    !(symbol as any).isStatic &&
+    (symbol.kind === 'property' || symbol.kind === 'method')
+  );
+}
+
+// ---------------------------------------------------------------------------
+// resolveFirstNodeAsClass
+// ---------------------------------------------------------------------------
+
+export async function resolveFirstNodeAsClass(
+  self: SymbolManagerOps,
+  firstNodeName: string,
+  includeRetry: boolean = true,
+): Promise<ApexSymbol | null> {
+  // Try standard Apex class resolution first (for System, Database, etc.)
+  // If it's a standard namespace, try both "Namespace" and "Namespace.Namespace"
+  let standardClass = await self.resolveStandardApexClass(firstNodeName);
+  if (!standardClass && self.stdlibProvider.isStdApexNamespace(firstNodeName)) {
+    // Try resolving as "Namespace.Namespace" (e.g., "System.System")
+    standardClass = await self.resolveStandardApexClass(
+      `${firstNodeName}.${firstNodeName}`,
+    );
+  }
+  if (standardClass) {
+    self.logger.debug(
+      () =>
+        `Resolved first node "${firstNodeName}" as standard class: ${standardClass?.name}`,
+    );
+    return standardClass;
+  }
+
+  // Try built-in type resolution
+  // Create a minimal SymbolReference from the string name
+  // Since resolveStandardLibraryType only uses typeRef.name, we can use dummy ranges
+  const dummyLocation: SymbolLocation = {
+    symbolRange: { startLine: 0, startColumn: 0, endLine: 0, endColumn: 0 },
+    identifierRange: {
+      startLine: 0,
+      startColumn: 0,
+      endLine: 0,
+      endColumn: 0,
+    },
+  };
+  const typeRef: SymbolReference = new EnhancedSymbolReference(
+    firstNodeName,
+    dummyLocation,
+    ReferenceContext.CLASS_REFERENCE,
+    undefined, // resolvedSymbolId - will be set during second-pass resolution
+  );
+  const builtInSymbol = await self.resolveStandardLibraryType(typeRef);
+  if (builtInSymbol) {
+    self.logger.debug(
+      () =>
+        `Resolved first node "${firstNodeName}" as built-in type: ${builtInSymbol.name}`,
+    );
+    return builtInSymbol;
+  }
+
+  // Try finding by name (prefer class symbols)
+  const qualifierSymbols = await self.findSymbolByName(firstNodeName);
+  const classSymbols = qualifierSymbols.filter(
+    (s) => s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
+  );
+  if (classSymbols.length > 0) {
+    // Prefer standard Apex classes
+    const stdClass = classSymbols.find(
+      (s) =>
+        s.fileUri?.includes('apexlib://') ||
+        s.fileUri?.includes('StandardApexLibrary'),
+    );
+    if (stdClass) {
+      self.logger.debug(
+        () =>
+          `Resolved first node "${firstNodeName}" from name lookup as standard class: ${stdClass.name}`,
+      );
+      return stdClass;
+    }
+    return classSymbols[0];
+  }
+
+  // If no class found but it's a standard namespace, try to resolve the namespace class
+  // Some namespaces have a class with the same name (e.g., System.System)
+  if (self.stdlibProvider.isStdApexNamespace(firstNodeName)) {
+    // Try resolving as "Namespace.Namespace" (e.g., "System.System")
+    const namespaceClass = await self.resolveStandardApexClass(
+      `${firstNodeName}.${firstNodeName}`,
+    );
+    if (namespaceClass) {
+      self.logger.debug(
+        () =>
+          `Resolved first node "${firstNodeName}" as namespace class: ${namespaceClass.name}`,
+      );
+      return namespaceClass;
+    }
+
+    // If namespace class resolution failed, try finding by name with namespace prefix
+    const namespaceQualifierSymbols = await self.findSymbolByName(
+      `${firstNodeName}.${firstNodeName}`,
+    );
+    const namespaceClassSymbols = namespaceQualifierSymbols.filter(
+      (s) => s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
+    );
+    if (namespaceClassSymbols.length > 0) {
+      const nsStdClass = namespaceClassSymbols.find(
+        (s) =>
+          s.fileUri?.includes('apexlib://') ||
+          s.fileUri?.includes('StandardApexLibrary'),
+      );
+      if (nsStdClass) {
+        self.logger.debug(
+          () =>
+            `Resolved first node "${firstNodeName}" as namespace class from name lookup: ${nsStdClass.name}`,
+        );
+        return nsStdClass;
+      }
+      return namespaceClassSymbols[0];
+    }
+  }
+
+  // If we couldn't resolve the first node, try one more time with findSymbolByName
+  // after potential async loading. This handles cases where resolveStandardApexClass
+  // triggered async loading but the symbol wasn't immediately available
+  if (includeRetry) {
+    const retrySymbols = await self.findSymbolByName(firstNodeName);
+    const retryClassSymbols = retrySymbols.filter(
+      (s) => s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
+    );
+    if (retryClassSymbols.length > 0) {
+      const retryStdClass = retryClassSymbols.find(
+        (s) =>
+          s.fileUri?.includes('apexlib://') ||
+          s.fileUri?.includes('StandardApexLibrary'),
+      );
+      if (retryStdClass) {
+        self.logger.debug(
+          () =>
+            `Resolved first node "${firstNodeName}" from retry name lookup as standard class: ${retryStdClass.name}`,
+        );
+        return retryStdClass;
+      }
+      return retryClassSymbols[0];
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// tryResolveAsInstance
+// ---------------------------------------------------------------------------
+
+export async function tryResolveAsInstance(
+  self: SymbolManagerOps,
+  stepName: string,
+  currentContext: ChainResolutionContext | undefined,
+): Promise<ApexSymbol | null> {
+  // If we have a current context, try to find as a property in that context
+  // BUT: Don't try property resolution if the context is a Class/Interface/Enum
+  // (those should use tryResolveAsMember instead, which handles methods properly)
+  if (
+    currentContext &&
+    currentContext.type === 'symbol' &&
+    currentContext.symbol.kind !== SymbolKind.Class &&
+    currentContext.symbol.kind !== SymbolKind.Interface &&
+    currentContext.symbol.kind !== SymbolKind.Enum
+  ) {
+    const propertySymbol = await self.resolveMemberInContext(
+      currentContext,
+      stepName,
+      'property',
+    );
+    if (propertySymbol) {
+      return propertySymbol;
+    }
+  }
+
+  // Try to find as a global variable (works when currentContext is undefined or property lookup failed)
+  const globalSymbols = await self.findSymbolByName(stepName);
+  const globalVariableSymbol = globalSymbols.find(
+    (s) => s.kind === 'variable' || s.kind === 'field' || s.kind === 'property',
+  );
+  if (globalVariableSymbol) {
+    return globalVariableSymbol;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// tryResolveAsClass
+// ---------------------------------------------------------------------------
+
+export async function tryResolveAsClass(
+  self: SymbolManagerOps,
+  stepName: string,
+  currentContext: ChainResolutionContext,
+  stepContext?: ReferenceContext,
+): Promise<ApexSymbol | null> {
+  if (
+    stepContext === ReferenceContext.METHOD_CALL ||
+    stepContext === ReferenceContext.FIELD_ACCESS ||
+    stepContext === ReferenceContext.VARIABLE_USAGE
+  ) {
+    return null;
+  }
+
+  if (currentContext?.type === 'namespace') {
+    // Look for class in the namespace
+    const namespaceSymbols = await findSymsInNsOp(self, currentContext.name);
+
+    let classSymbol = namespaceSymbols.find(
+      (s) => s.name === stepName && s.kind === 'class',
+    );
+
+    // If not found in loaded symbols, try to resolve as standard Apex class
+    if (!classSymbol) {
+      const fqn = `${currentContext.name}.${stepName}`;
+
+      classSymbol = (await self.resolveStandardApexClass(fqn)) || undefined;
+    }
+
+    return classSymbol || null;
+  }
+
+  if (currentContext?.type === 'symbol') {
+    // Look for nested class in the current symbol
+    const nestedClasses = await findSymsInNsOp(
+      self,
+      currentContext.symbol.name,
+    );
+    return (
+      nestedClasses.find((s) => s.name === stepName && s.kind === 'class') ||
+      null
+    );
+  }
+
+  // Look in global scope
+  const globalSymbols = await self.findSymbolByName(stepName);
+  let classSymbol = globalSymbols.find((s) => s.kind === 'class');
+
+  // If not found in global symbols, try to resolve as standard Apex class
+  if (!classSymbol) {
+    classSymbol = (await self.resolveStandardApexClass(stepName)) || undefined;
+  }
+
+  return classSymbol || null;
+}
+
+// ---------------------------------------------------------------------------
+// tryResolveAsMember
+// ---------------------------------------------------------------------------
+
+export async function tryResolveAsMember(
+  self: SymbolManagerOps,
+  step: SymbolReference,
+  currentContext: ChainResolutionContext,
+  _nextStep?: SymbolReference,
+): Promise<ApexSymbol | null> {
+  if (!currentContext || currentContext.type !== 'symbol') {
+    return null;
+  }
+
+  const stepName = step.name;
+  const stepContext = step.context;
+
+  // Try as method if context suggests it
+  if (stepContext === ReferenceContext.METHOD_CALL) {
+    const methodSymbol = await self.resolveMemberInContext(
+      currentContext,
+      stepName,
+      'method',
+    );
+    if (methodSymbol) {
+      return methodSymbol;
+    }
+  }
+
+  // Try as property if context suggests it
+  if (stepContext === ReferenceContext.FIELD_ACCESS) {
+    const propertySymbol = await self.resolveMemberInContext(
+      currentContext,
+      stepName,
+      'property',
+    );
+    if (propertySymbol) {
+      return propertySymbol;
+    }
+  }
+
+  // Try both if context is ambiguous
+  if (stepContext === ReferenceContext.CHAIN_STEP) {
+    const methodSymbol = await self.resolveMemberInContext(
+      currentContext,
+      stepName,
+      'method',
+    );
+    if (methodSymbol) {
+      return methodSymbol;
+    }
+
+    const propertySymbol = await self.resolveMemberInContext(
+      currentContext,
+      stepName,
+      'property',
+    );
+    if (propertySymbol) {
+      return propertySymbol;
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// canResolveAsNamespace
+// ---------------------------------------------------------------------------
+
+export function canResolveAsNamespace(
+  step: SymbolReference,
+  currentContext: ChainResolutionContext,
+): boolean {
+  // Can resolve as namespace if:
+  // 1. It's explicitly marked as NAMESPACE context
+  // 2. It's a CHAIN_STEP that could be a namespace
+  // 3. It's in a global context (no current context)
+  return (
+    step.context === ReferenceContext.NAMESPACE ||
+    step.context === ReferenceContext.CHAIN_STEP ||
+    !currentContext
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ResolverStats (local to this module, mirrors the ASM-internal interface)
+// ---------------------------------------------------------------------------
+
+interface ResolverStats {
+  resolverCalls: number;
+  resolverQualifiedCalls: number;
+  resolverQualifiedMs: number;
+  resolverScopeHierarchyMs: number;
+  resolverScopeSearchMs: number;
+  resolverDirectLookupMs: number;
+  resolverBuiltInMs: number;
+  resolverPreResolvedHits: number;
+  resolverQualifiedThisCalls: number;
+  resolverQualifiedThisLookupMs: number;
+  resolverQualifiedGlobalLookupMs: number;
+  resolverQualifiedResolveMemberMs: number;
+  resolverQualifiedStandardClassMs: number;
+  resolverQualifiedCacheHits: number;
+  resolverQualifiedCacheMisses: number;
+  resolverQualifiedTypeContextPromotions: number;
+  resolverMemberContextCacheHits: number;
+  resolverMemberContextCacheMisses: number;
+}
+
+// ---------------------------------------------------------------------------
+// convertToStandardLibraryUri (private helper)
+// ---------------------------------------------------------------------------
+
+function convertToStandardLibraryUri(
+  self: SymbolManagerOps,
+  classPath: string,
+): string {
+  if (
+    !classPath.includes('://') &&
+    classPath.includes('/') &&
+    classPath.endsWith('.cls')
+  ) {
+    const namespace = classPath.split('/')[0];
+    if (self.stdlibProvider.isStdApexNamespace(namespace)) {
+      return `${STANDARD_APEX_LIBRARY_URI}/${classPath}`;
+    }
+  }
+  return classPath;
+}
+
+// ---------------------------------------------------------------------------
+// evolveContextAfterResolution
+// ---------------------------------------------------------------------------
+
+export function evolveContextAfterResolution(
+  _self: SymbolManagerOps,
+  step: any,
+  newContext: string,
+  _resolutionStrategy: string,
+): void {
+  try {
+    let newReferenceContext: ReferenceContext;
+    switch (newContext) {
+      case 'NAMESPACE':
+        newReferenceContext = ReferenceContext.NAMESPACE;
+        break;
+      case 'CLASS_REFERENCE':
+        newReferenceContext = ReferenceContext.CLASS_REFERENCE;
+        break;
+      case 'METHOD_CALL':
+        newReferenceContext = ReferenceContext.METHOD_CALL;
+        break;
+      case 'FIELD_ACCESS':
+        newReferenceContext = ReferenceContext.FIELD_ACCESS;
+        break;
+      default:
+        return;
+    }
+
+    step.context = newReferenceContext;
+  } catch (_error) {
+    // Error evolving context, continue
+  }
+}
+
+// ---------------------------------------------------------------------------
+// selectBestMemberCandidate
+// ---------------------------------------------------------------------------
+
+export function selectBestMemberCandidate(
+  _self: SymbolManagerOps,
+  candidates: ApexSymbol[],
+  context: ReferenceContext,
+): ApexSymbol | null {
+  if (candidates.length === 0) return null;
+  if (candidates.length === 1) return candidates[0];
+
+  if (context === ReferenceContext.METHOD_CALL) {
+    const methods = candidates.filter((s) => s.kind === SymbolKind.Method);
+    if (methods.length > 0) {
+      const nonStatic = methods.find((s) => s.modifiers?.isStatic === false);
+      return nonStatic || methods[0];
+    }
+  }
+
+  if (context === ReferenceContext.FIELD_ACCESS) {
+    const fields = candidates.filter(
+      (s) => s.kind === SymbolKind.Field || s.kind === SymbolKind.Property,
+    );
+    if (fields.length > 0) {
+      const nonStatic = fields.find((s) => s.modifiers?.isStatic === false);
+      return nonStatic || fields[0];
+    }
+  }
+
+  return candidates[0];
+}
+
+// ---------------------------------------------------------------------------
+// ensureClassSymbolsLoaded
+// ---------------------------------------------------------------------------
+
+export async function ensureClassSymbolsLoaded(
+  self: SymbolManagerOps,
+  classSymbol: ApexSymbol,
+): Promise<void> {
+  if (!classSymbol.fileUri?.endsWith('.cls')) {
+    return;
+  }
+
+  try {
+    let classPath = classSymbol.fileUri;
+    if (isStandardApexUri(classPath)) {
+      classPath = extractApexLibPath(classPath);
+    }
+
+    const symbolTable = await self.stdlibProvider.getSymbolTable(classPath);
+    if (symbolTable) {
+      const fileUri = convertToStandardLibraryUri(self, classPath);
+      await self.addSymbolTableAsync(symbolTable, fileUri);
+      classSymbol.fileUri = fileUri;
+    }
+  } catch (_error) {
+    // Error loading class symbols, continue
+  }
+}
+
+// ---------------------------------------------------------------------------
+// selectBestQualifier
+// ---------------------------------------------------------------------------
+
+export function selectBestQualifier(
+  self: SymbolManagerOps,
+  candidates: ApexSymbol[],
+  sourceFile: string,
+): ApexSymbol | null {
+  const classLikeCandidates = candidates.filter(
+    (symbol) =>
+      symbol.kind === SymbolKind.Class &&
+      typeof symbol.fileUri === 'string' &&
+      symbol.fileUri.endsWith(`/${symbol.name}.cls`),
+  );
+  if (classLikeCandidates.length > 0) {
+    candidates = classLikeCandidates;
+  }
+
+  const sameFile = candidates.find((symbol) => symbol.fileUri === sourceFile);
+  if (sameFile) return sameFile;
+
+  const accessible = candidates.filter((symbol) =>
+    isSymAccessibleOp(symbol, sourceFile),
+  );
+  if (accessible.length === 1) return accessible[0];
+  if (accessible.length > 1) return accessible[0];
+
+  return candidates[0] || null;
+}
+
+// ---------------------------------------------------------------------------
+// getSymbolById
+// ---------------------------------------------------------------------------
+
+export function getSymbolById(
+  self: SymbolManagerOps,
+  symbolId: string,
+): ApexSymbol | null {
+  try {
+    const allFiles: string[] = Array.from(
+      (self.symbolRefManager as any)['fileToSymbolTable']?.keys() || [],
+    );
+
+    for (const fileUri of allFiles) {
+      const symbolTable = self.symbolRefManager.getSymbolTableForFile(fileUri);
+      if (symbolTable) {
+        const symbols = symbolTable.getAllSymbols();
+        const found = symbols.find((s: ApexSymbol) => s.id === symbolId);
+        if (found) {
+          return found;
+        }
+      }
+    }
+
+    return null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// resolveSuperclassSymbol
+// ---------------------------------------------------------------------------
+
+export async function resolveSuperclassSymbol(
+  self: SymbolManagerOps,
+  typeSymbol: TypeSymbol,
+): Promise<TypeSymbol | null> {
+  if (!typeSymbol.superClass) {
+    return null;
+  }
+
+  const superclassName = typeSymbol.superClass;
+
+  const superclassSymbols = await self.findSymbolByName(superclassName);
+  const superclassTypeSymbol = superclassSymbols.find(
+    (s) => s.kind === SymbolKind.Class,
+  ) as TypeSymbol | undefined;
+
+  if (superclassTypeSymbol) {
+    if (superclassTypeSymbol.fileUri) {
+      let symbolTable = self.symbolRefManager.getSymbolTableForFile(
+        superclassTypeSymbol.fileUri,
+      );
+
+      if (
+        !symbolTable &&
+        superclassTypeSymbol.fileUri &&
+        isStandardApexUri(superclassTypeSymbol.fileUri)
+      ) {
+        const classPath = extractApexLibPath(superclassTypeSymbol.fileUri);
+        if (classPath) {
+          try {
+            const normalizedUri = extractFilePathFromUri(
+              superclassTypeSymbol.fileUri,
+            );
+            if (!self.loadingSymbolTables.has(normalizedUri)) {
+              self.loadingSymbolTables.add(normalizedUri);
+              try {
+                const loadedSymbolTable =
+                  await self.stdlibProvider.getSymbolTable(classPath);
+                if (loadedSymbolTable) {
+                  await self.addSymbolTableAsync(
+                    loadedSymbolTable,
+                    superclassTypeSymbol.fileUri,
+                  );
+                  symbolTable = self.symbolRefManager.getSymbolTableForFile(
+                    superclassTypeSymbol.fileUri,
+                  );
+                }
+              } finally {
+                self.loadingSymbolTables.delete(normalizedUri);
+              }
+            }
+          } catch (_error) {
+            // Error loading, continue
+          }
+        }
+      }
+    }
+
+    return superclassTypeSymbol;
+  }
+
+  {
+    const standardClass = await self.resolveStandardApexClass(superclassName);
+    if (standardClass && standardClass.kind === SymbolKind.Class) {
+      return standardClass as TypeSymbol;
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// resolveObjectClass
+// ---------------------------------------------------------------------------
+
+export async function resolveObjectClass(
+  self: SymbolManagerOps,
+): Promise<TypeSymbol | null> {
+  const objectSymbols = await self.findSymbolByName('Object');
+  const objectTypeSymbol = objectSymbols.find(
+    (s) =>
+      s.kind === SymbolKind.Class &&
+      (s.fileUri?.includes('StandardApexLibrary') ||
+        s.fileUri?.includes('apexlib://') ||
+        s.fileUri?.includes('builtins')),
+  ) as TypeSymbol | undefined;
+
+  if (objectTypeSymbol) {
+    if (objectTypeSymbol.fileUri) {
+      let symbolTable = self.symbolRefManager.getSymbolTableForFile(
+        objectTypeSymbol.fileUri,
+      );
+
+      if (!symbolTable) {
+        const classPath = extractApexLibPath(objectTypeSymbol.fileUri);
+        if (classPath) {
+          try {
+            const normalizedUri = extractFilePathFromUri(
+              objectTypeSymbol.fileUri,
+            );
+            if (!self.loadingSymbolTables.has(normalizedUri)) {
+              self.loadingSymbolTables.add(normalizedUri);
+              try {
+                const loadedSymbolTable =
+                  await self.stdlibProvider.getSymbolTable(classPath);
+                if (loadedSymbolTable) {
+                  await self.addSymbolTableAsync(
+                    loadedSymbolTable,
+                    objectTypeSymbol.fileUri,
+                  );
+                  symbolTable = self.symbolRefManager.getSymbolTableForFile(
+                    objectTypeSymbol.fileUri,
+                  );
+                }
+              } finally {
+                self.loadingSymbolTables.delete(normalizedUri);
+              }
+            }
+          } catch (_error) {
+            // Error loading, continue
+          }
+        }
+      }
+    }
+
+    return objectTypeSymbol;
+  }
+
+  {
+    let standardClass: ApexSymbol | null =
+      await self.resolveStandardApexClass('Object');
+    for (const candidate of getImplicitQualifiedCandidates('Object')) {
+      if (standardClass) break;
+      standardClass = await self.resolveStandardApexClass(candidate);
+      if (standardClass) {
+        break;
+      }
+    }
+
+    if (standardClass && standardClass.kind === SymbolKind.Class) {
+      return standardClass as TypeSymbol;
+    }
+  }
+
+  self.logger.warn(
+    () => 'Object class not found - inheritance chain traversal may fail',
+  );
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// resolveMemberInContext
+// ---------------------------------------------------------------------------
+
+export async function resolveMemberInContext(
+  self: SymbolManagerOps,
+  context: ChainResolutionContext,
+  memberName: string,
+  memberType: 'property' | 'method' | 'class',
+  typeSubstitutions: GenericTypeSubstitutionMap | null = null,
+): Promise<ApexSymbol | null> {
+  if (context?.type === 'symbol') {
+    const contextSymbol = context.symbol;
+    const contextFile = contextSymbol.fileUri;
+    if (contextFile) {
+      let symbolTable =
+        self.symbolRefManager.getSymbolTableForFile(contextFile);
+      self.logger.debug(
+        () =>
+          `resolveMemberInContext: Symbol table for "${contextSymbol.name}": ${symbolTable ? 'found' : 'not found'}`,
+      );
+
+      if (!symbolTable) {
+        const properUri = createFileUri(contextFile);
+        if (properUri !== contextFile) {
+          symbolTable = self.symbolRefManager.getSymbolTableForFile(properUri);
+        }
+      }
+
+      if (!symbolTable && isStandardApexUri(contextFile)) {
+        const normalizedUri = extractFilePathFromUri(
+          createFileUri(contextFile),
+        );
+
+        if (self.loadingSymbolTables.has(normalizedUri)) {
+          self.logger.debug(
+            () =>
+              `Skipping recursive load attempt for ${contextFile} (normalized: ${normalizedUri}) - already loading`,
+          );
+          symbolTable =
+            self.symbolRefManager.getSymbolTableForFile(contextFile);
+          if (!symbolTable) {
+            return null;
+          }
+        } else {
+          const normalizedUri2 = extractFilePathFromUri(
+            createFileUri(contextFile),
+          );
+          if (self.loadingSymbolTables.has(normalizedUri2)) {
+            self.logger.debug(
+              () =>
+                `Skipping recursive load attempt for ${contextFile} (normalized: ${normalizedUri2}) - already loading`,
+            );
+            symbolTable =
+              self.symbolRefManager.getSymbolTableForFile(contextFile);
+            if (!symbolTable) {
+              return null;
+            }
+          } else {
+            try {
+              self.loadingSymbolTables.add(normalizedUri2);
+
+              const classPath = extractApexLibPath(contextFile);
+
+              const loadedSymbolTable =
+                await self.stdlibProvider.getSymbolTable(classPath);
+              if (loadedSymbolTable) {
+                symbolTable = loadedSymbolTable;
+
+                await self.addSymbolTableAsync(symbolTable, contextFile);
+
+                symbolTable =
+                  self.symbolRefManager.getSymbolTableForFile(contextFile);
+              }
+            } catch (_error) {
+            } finally {
+              self.loadingSymbolTables.delete(normalizedUri2);
+            }
+          }
+        }
+      }
+
+      if (symbolTable) {
+        if (
+          contextSymbol.kind === SymbolKind.Variable ||
+          contextSymbol.kind === SymbolKind.Field ||
+          contextSymbol.kind === SymbolKind.Parameter ||
+          contextSymbol.kind === SymbolKind.Property
+        ) {
+          const variableSymbol = contextSymbol as VariableSymbol;
+          const typeInfo = variableSymbol.type;
+
+          if (typeInfo) {
+            if (typeInfo.resolvedSymbol) {
+              const typeSymbol = typeInfo.resolvedSymbol;
+              const resolvedMember = await resolveMemberInContext(
+                self,
+                { type: 'symbol', symbol: typeSymbol },
+                memberName,
+                memberType,
+              );
+              if (resolvedMember) {
+                return resolvedMember;
+              }
+              if (
+                typeInfo.isBuiltIn ||
+                (typeSymbol.fileUri && isStandardApexUri(typeSymbol.fileUri))
+              ) {
+                const classPath = extractApexLibPath(typeSymbol.fileUri);
+                if (classPath) {
+                  try {
+                    const st =
+                      await self.stdlibProvider.getSymbolTable(classPath);
+                    if (st) {
+                      await self.addSymbolTableAsync(st, typeSymbol.fileUri);
+                      const retryResult = await resolveMemberInContext(
+                        self,
+                        { type: 'symbol', symbol: typeSymbol },
+                        memberName,
+                        memberType,
+                      );
+                      if (retryResult) {
+                        return retryResult;
+                      }
+                    }
+                  } catch (_error) {
+                    // Error loading, continue to other strategies
+                  }
+                }
+              }
+            }
+
+            const typeName = typeInfo.name;
+            if (typeName) {
+              const baseTypeName = typeName.replace(/\[\]$/, '');
+
+              if (typeInfo.isBuiltIn) {
+                self.logger.debug(
+                  () =>
+                    `Attempting to resolve built-in type "${baseTypeName}" as standard Apex class`,
+                );
+                const standardClassSymbol =
+                  await self.resolveStandardApexClass(baseTypeName);
+                if (standardClassSymbol) {
+                  self.logger.debug(
+                    () =>
+                      `Resolved built-in type "${baseTypeName}" to class symbol: ` +
+                      `${standardClassSymbol.name} (fileUri: ${standardClassSymbol.fileUri})`,
+                  );
+                  const resolvedMember = await resolveMemberInContext(
+                    self,
+                    { type: 'symbol', symbol: standardClassSymbol },
+                    memberName,
+                    memberType,
+                  );
+                  if (resolvedMember) {
+                    self.logger.debug(
+                      () =>
+                        `Resolved member "${memberName}" on built-in type "${baseTypeName}": ${resolvedMember.name}`,
+                    );
+                    return resolvedMember;
+                  }
+                  self.logger.debug(
+                    () =>
+                      `Member "${memberName}" not found on "${baseTypeName}" ` +
+                      'class symbol, trying to load class and retry',
+                  );
+                  if (
+                    standardClassSymbol.fileUri &&
+                    isStandardApexUri(standardClassSymbol.fileUri)
+                  ) {
+                    const classPath = extractApexLibPath(
+                      standardClassSymbol.fileUri,
+                    );
+                    if (classPath) {
+                      try {
+                        self.logger.debug(
+                          () =>
+                            `Loading class from path: ${classPath} for member resolution`,
+                        );
+                        const st =
+                          await self.stdlibProvider.getSymbolTable(classPath);
+                        if (st) {
+                          await self.addSymbolTableAsync(
+                            st,
+                            standardClassSymbol.fileUri,
+                          );
+                          self.logger.debug(
+                            () =>
+                              `Class loaded, retrying member resolution for "${memberName}"`,
+                          );
+                          const retryResult = await resolveMemberInContext(
+                            self,
+                            { type: 'symbol', symbol: standardClassSymbol },
+                            memberName,
+                            memberType,
+                          );
+                          if (retryResult) {
+                            self.logger.debug(
+                              () =>
+                                `Successfully resolved member "${memberName}" after loading class`,
+                            );
+                            return retryResult;
+                          } else {
+                            self.logger.debug(
+                              () =>
+                                `Member "${memberName}" still not found after loading class`,
+                            );
+                          }
+                        } else {
+                          self.logger.debug(
+                            () =>
+                              `Failed to load class from path: ${classPath}`,
+                          );
+                        }
+                      } catch (error) {
+                        self.logger.debug(
+                          () => `Error loading class ${classPath}: ${error}`,
+                        );
+                      }
+                    } else {
+                      self.logger.debug(
+                        () =>
+                          `Could not extract class path from fileUri: ${standardClassSymbol.fileUri}`,
+                      );
+                    }
+                  } else {
+                    self.logger.debug(
+                      () =>
+                        `Cannot load class: fileUri=${standardClassSymbol.fileUri}, ` +
+                        `isStandardApexUri=${
+                          standardClassSymbol.fileUri
+                            ? isStandardApexUri(standardClassSymbol.fileUri)
+                            : false
+                        }`,
+                    );
+                  }
+                } else {
+                  self.logger.debug(
+                    () =>
+                      `Could not resolve built-in type "${baseTypeName}" ` +
+                      'as standard Apex class - resolveStandardApexClass returned null',
+                  );
+                }
+              }
+
+              const typeSymbols = await self.findSymbolByName(baseTypeName);
+              const typeClassSymbol = typeSymbols.find(
+                (s) =>
+                  s.kind === SymbolKind.Class ||
+                  s.kind === SymbolKind.Interface ||
+                  s.kind === SymbolKind.Enum,
+              );
+
+              if (typeClassSymbol) {
+                const resolvedMember = await resolveMemberInContext(
+                  self,
+                  { type: 'symbol', symbol: typeClassSymbol },
+                  memberName,
+                  memberType,
+                );
+                if (resolvedMember) {
+                  return resolvedMember;
+                }
+                if (
+                  typeClassSymbol.fileUri &&
+                  isStandardApexUri(typeClassSymbol.fileUri)
+                ) {
+                  const classPath = extractApexLibPath(typeClassSymbol.fileUri);
+                  if (classPath) {
+                    try {
+                      const st =
+                        await self.stdlibProvider.getSymbolTable(classPath);
+                      if (st) {
+                        await self.addSymbolTableAsync(
+                          st,
+                          typeClassSymbol.fileUri,
+                        );
+                        const retryResult = await resolveMemberInContext(
+                          self,
+                          { type: 'symbol', symbol: typeClassSymbol },
+                          memberName,
+                          memberType,
+                        );
+                        if (retryResult) {
+                          return retryResult;
+                        }
+                      }
+                    } catch (_error) {
+                      // Error loading, continue to other strategies
+                    }
+                  }
+                }
+              }
+
+              const typeRef: SymbolReference = {
+                name: baseTypeName,
+                context: ReferenceContext.CLASS_REFERENCE,
+                location: {
+                  symbolRange: {
+                    startLine: 0,
+                    startColumn: 0,
+                    endLine: 0,
+                    endColumn: 0,
+                  },
+                  identifierRange: {
+                    startLine: 0,
+                    startColumn: 0,
+                    endLine: 0,
+                    endColumn: 0,
+                  },
+                },
+                resolvedSymbolId: undefined,
+              };
+
+              const builtInTypeSymbol =
+                await self.resolveStandardLibraryType(typeRef);
+              if (builtInTypeSymbol) {
+                const resolvedMember = await resolveMemberInContext(
+                  self,
+                  { type: 'symbol', symbol: builtInTypeSymbol },
+                  memberName,
+                  memberType,
+                );
+                if (resolvedMember) {
+                  return resolvedMember;
+                }
+              }
+
+              const standardClassSymbol2 =
+                await self.resolveStandardApexClass(baseTypeName);
+              if (standardClassSymbol2) {
+                const resolvedMember = await resolveMemberInContext(
+                  self,
+                  { type: 'symbol', symbol: standardClassSymbol2 },
+                  memberName,
+                  memberType,
+                );
+                if (resolvedMember) {
+                  return resolvedMember;
+                }
+                if (
+                  standardClassSymbol2.fileUri &&
+                  isStandardApexUri(standardClassSymbol2.fileUri)
+                ) {
+                  const classPath = extractApexLibPath(
+                    standardClassSymbol2.fileUri,
+                  );
+                  if (classPath) {
+                    try {
+                      const st =
+                        await self.stdlibProvider.getSymbolTable(classPath);
+                      if (st) {
+                        await self.addSymbolTableAsync(
+                          st,
+                          standardClassSymbol2.fileUri,
+                        );
+                        const retryResult = await resolveMemberInContext(
+                          self,
+                          { type: 'symbol', symbol: standardClassSymbol2 },
+                          memberName,
+                          memberType,
+                        );
+                        if (retryResult) {
+                          return retryResult;
+                        }
+                      }
+                    } catch (_error) {
+                      // Error loading, continue to other strategies
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          return null;
+        }
+
+        if (isMethodSymbolNarrowing(contextSymbol)) {
+          const returnType = contextSymbol.returnType;
+
+          if (returnType) {
+            if (returnType.resolvedSymbol) {
+              const returnTypeSymbol = returnType.resolvedSymbol;
+              const resolvedMember = await resolveMemberInContext(
+                self,
+                { type: 'symbol', symbol: returnTypeSymbol },
+                memberName,
+                memberType,
+              );
+              if (resolvedMember) {
+                return resolvedMember;
+              }
+            }
+
+            const returnTypeName = returnType.name;
+            if (returnTypeName) {
+              const baseTypeName = returnTypeName.replace(/\[\]$/, '');
+
+              const typeRef: SymbolReference = {
+                name: baseTypeName,
+                context: ReferenceContext.CLASS_REFERENCE,
+                location: {
+                  symbolRange: {
+                    startLine: 0,
+                    startColumn: 0,
+                    endLine: 0,
+                    endColumn: 0,
+                  },
+                  identifierRange: {
+                    startLine: 0,
+                    startColumn: 0,
+                    endLine: 0,
+                    endColumn: 0,
+                  },
+                },
+                resolvedSymbolId: undefined,
+              };
+
+              const builtInTypeSymbol =
+                await self.resolveStandardLibraryType(typeRef);
+              if (builtInTypeSymbol) {
+                const resolvedMember = await resolveMemberInContext(
+                  self,
+                  { type: 'symbol', symbol: builtInTypeSymbol },
+                  memberName,
+                  memberType,
+                );
+                if (resolvedMember) {
+                  return resolvedMember;
+                }
+              }
+
+              const standardClassSymbol =
+                await self.resolveStandardApexClass(baseTypeName);
+              if (standardClassSymbol) {
+                const resolvedMember = await resolveMemberInContext(
+                  self,
+                  { type: 'symbol', symbol: standardClassSymbol },
+                  memberName,
+                  memberType,
+                );
+                if (resolvedMember) {
+                  return resolvedMember;
+                }
+              }
+
+              const typeClassSymbols =
+                await self.findSymbolByName(baseTypeName);
+              const typeClassSymbol = typeClassSymbols.find(
+                (s) =>
+                  s.kind === SymbolKind.Class ||
+                  s.kind === SymbolKind.Interface ||
+                  s.kind === SymbolKind.Enum,
+              );
+
+              if (typeClassSymbol) {
+                const resolvedMember = await resolveMemberInContext(
+                  self,
+                  { type: 'symbol', symbol: typeClassSymbol },
+                  memberName,
+                  memberType,
+                );
+                if (resolvedMember) {
+                  return resolvedMember;
+                }
+              }
+            }
+          }
+
+          return null;
+        }
+
+        if (
+          contextSymbol.kind === SymbolKind.Class ||
+          contextSymbol.kind === SymbolKind.Interface ||
+          contextSymbol.kind === SymbolKind.Enum
+        ) {
+          const allSymbols = symbolTable.getAllSymbols();
+          const classSymbolInTable = allSymbols.find(
+            (s) =>
+              s.kind === SymbolKind.Class &&
+              s.name === contextSymbol.name &&
+              s.fileUri === contextSymbol.fileUri,
+          );
+          const classSymbolId = classSymbolInTable?.id || contextSymbol.id;
+          let classBlock = allSymbols.find(
+            (s) =>
+              isBlockSymbol(s) &&
+              s.scopeType === 'class' &&
+              (s.parentId === classSymbolId || s.parentId === contextSymbol.id),
+          );
+          if (!classBlock && classSymbolInTable) {
+            classBlock = allSymbols.find(
+              (s) =>
+                isBlockSymbol(s) &&
+                s.scopeType === 'class' &&
+                s.fileUri === contextSymbol.fileUri &&
+                (!s.parentId ||
+                  s.parentId === '' ||
+                  s.parentId === classSymbolId),
+            );
+          }
+          if (!classBlock) {
+            const allClassBlocks = allSymbols.filter(
+              (s) => isBlockSymbol(s) && s.scopeType === 'class',
+            );
+            const classSymbols = allSymbols.filter(
+              (s) =>
+                s.kind === SymbolKind.Class && s.name === contextSymbol.name,
+            );
+            self.logger.debug(
+              () =>
+                `Class block lookup for "${contextSymbol.name}": not found. ` +
+                `contextSymbol.id: "${contextSymbol.id}", ` +
+                `Found ${allClassBlocks.length} class blocks, ` +
+                `Found ${classSymbols.length} class symbols with name "${contextSymbol.name}". ` +
+                `Class block parentIds: ${allClassBlocks.map((b) => b.parentId).join(', ')}. ` +
+                `Class symbol IDs: ${classSymbols.map((s) => s.id).join(', ')}`,
+            );
+
+            const fallbackMembers = allSymbols.filter((s) => {
+              if (
+                isBlockSymbol(s) ||
+                s.fileUri !== contextSymbol.fileUri ||
+                s.name !== memberName ||
+                s.kind !== memberType
+              ) {
+                return false;
+              }
+              const directParent = allSymbols.find(
+                (sym) => sym.id === s.parentId && isBlockSymbol(sym),
+              );
+              if (
+                directParent &&
+                (directParent as any).scopeType === 'class' &&
+                directParent.fileUri === contextSymbol.fileUri
+              ) {
+                return true;
+              }
+              let currentParentId = s.parentId;
+              const visited = new Set<string>();
+              while (currentParentId && !visited.has(currentParentId)) {
+                if (
+                  currentParentId === classSymbolId ||
+                  currentParentId === contextSymbol.id
+                ) {
+                  return true;
+                }
+                visited.add(currentParentId);
+                const parent = allSymbols.find(
+                  (sym) => sym.id === currentParentId,
+                );
+                if (!parent) {
+                  break;
+                }
+                currentParentId = parent.parentId;
+              }
+              return false;
+            });
+            if (fallbackMembers.length > 0) {
+              const fallbackMember = fallbackMembers[0];
+              if (fallbackMember.kind === SymbolKind.Method) {
+                return applyMethodTypeSubstitutions(
+                  fallbackMember as any,
+                  typeSubstitutions,
+                );
+              }
+              return fallbackMember;
+            }
+          } else {
+            const resolvedClassBlock = classBlock;
+            self.logger.debug(
+              () =>
+                `Class block lookup for "${contextSymbol.name}": found (id: ${resolvedClassBlock.id})`,
+            );
+          }
+
+          if (classBlock) {
+            const resolvedClassBlock = classBlock;
+
+            const directScopeMembers = symbolTable.getSymbolsInScope(
+              resolvedClassBlock.id,
+            );
+            const allSyms = symbolTable.getAllSymbols();
+            const classMembers = allSyms.filter(
+              (s) =>
+                !isBlockSymbol(s) &&
+                s.fileUri === contextSymbol.fileUri &&
+                (s.parentId === resolvedClassBlock.id ||
+                  directScopeMembers.some((ds) => ds.id === s.parentId) ||
+                  (() => {
+                    let currentParentId = s.parentId;
+                    const visited = new Set<string>();
+                    while (currentParentId && !visited.has(currentParentId)) {
+                      visited.add(currentParentId);
+                      if (currentParentId === resolvedClassBlock.id) {
+                        return true;
+                      }
+                      const parent = allSyms.find(
+                        (sym) => sym.id === currentParentId,
+                      );
+                      if (!parent) break;
+                      currentParentId = parent.parentId;
+                    }
+                    return false;
+                  })()),
+            );
+            self.logger.debug(
+              () =>
+                `Looking for member "${memberName}" (${memberType}) in class ` +
+                `"${contextSymbol.name}" (fileUri: ${contextSymbol.fileUri}), ` +
+                `classBlock.id: ${resolvedClassBlock.id}, found ${classMembers.length} ` +
+                `class members (direct scope: ${directScopeMembers.length}). ` +
+                `Sample members: ${classMembers
+                  .slice(0, 5)
+                  .map((s) => `${s.name || 'unnamed'} (${s.kind})`)
+                  .join(', ')}`,
+            );
+            const matchingMembers = classMembers.filter(
+              (s) =>
+                !isBlockSymbol(s) &&
+                s.name === memberName &&
+                s.kind === memberType &&
+                s.fileUri === contextSymbol.fileUri,
+            );
+            self.logger.debug(
+              () =>
+                `After filtering: found ${matchingMembers.length} matching members. ` +
+                `Filter criteria: name=${memberName}, kind=${memberType}, ` +
+                `fileUri=${contextSymbol.fileUri}, parentId=${resolvedClassBlock.id}`,
+            );
+            if (matchingMembers.length === 0) {
+              const methodsWithName = classMembers.filter(
+                (s) => !isBlockSymbol(s) && s.name === memberName,
+              );
+              const methodsWithKind = classMembers.filter(
+                (s) => !isBlockSymbol(s) && s.kind === memberType,
+              );
+              const allMethods = classMembers.filter(
+                (s) => !isBlockSymbol(s) && s.kind === 'method',
+              );
+              const membersWithSizeName = classMembers.filter(
+                (s) => !isBlockSymbol(s) && s.name === 'size',
+              );
+              self.logger.debug(
+                () =>
+                  `No matching members found. Methods with name "${memberName}": ` +
+                  `${methodsWithName.length}, Methods with kind "${memberType}": ` +
+                  `${methodsWithKind.length}, All methods: ${allMethods
+                    .map((m) => m.name)
+                    .join(', ')}, Members named "size": ${membersWithSizeName
+                    .map((m) => `${m.name} (${m.kind})`)
+                    .join(', ')}`,
+              );
+              if (methodsWithName.length > 0) {
+                methodsWithName.forEach((m, idx) => {
+                  self.logger.debug(
+                    () =>
+                      `  Method ${idx}: name=${m.name}, kind=${m.kind}, ` +
+                      `fileUri=${m.fileUri}, parentId=${m.parentId}, ` +
+                      `contextSymbol.fileUri=${contextSymbol.fileUri}, ` +
+                      `classBlock.id=${resolvedClassBlock.id}`,
+                  );
+                });
+              }
+            }
+
+            if (matchingMembers.length > 0) {
+              const method = matchingMembers[0];
+              if (method.kind === SymbolKind.Method) {
+                const methodParentBlock = symbolTable
+                  .getAllSymbols()
+                  .find((s) => s.id === method.parentId && isBlockSymbol(s));
+                const parentChainMatches =
+                  methodParentBlock &&
+                  (methodParentBlock.parentId === contextSymbol.id ||
+                    methodParentBlock.parentId === classSymbolId);
+                if (parentChainMatches) {
+                  return applyMethodTypeSubstitutions(
+                    method as any,
+                    typeSubstitutions,
+                  );
+                }
+                self.logger.debug(
+                  () =>
+                    `Method ${memberName} found but parent chain doesn't match context class ${contextSymbol.name}`,
+                );
+              } else {
+                return method;
+              }
+            }
+          }
+          if (
+            contextSymbol.fileUri &&
+            isStandardApexUri(contextSymbol.fileUri)
+          ) {
+            const classPath = extractApexLibPath(contextSymbol.fileUri);
+            if (classPath) {
+              try {
+                const normalizedUri = extractFilePathFromUri(
+                  contextSymbol.fileUri,
+                );
+                if (!self.loadingSymbolTables.has(normalizedUri)) {
+                  self.loadingSymbolTables.add(normalizedUri);
+                  try {
+                    const st =
+                      await self.stdlibProvider.getSymbolTable(classPath);
+                    if (st) {
+                      await self.addSymbolTableAsync(st, contextSymbol.fileUri);
+                      const reloadedSymbolTable =
+                        self.symbolRefManager.getSymbolTableForFile(
+                          contextSymbol.fileUri,
+                        );
+                      if (reloadedSymbolTable) {
+                        const allSymbols2 = reloadedSymbolTable.getAllSymbols();
+                        const classBlock2 = allSymbols2.find(
+                          (s) =>
+                            isBlockSymbol(s) &&
+                            s.scopeType === 'class' &&
+                            s.parentId === contextSymbol.id,
+                        );
+
+                        if (classBlock2) {
+                          const classMembers2 =
+                            reloadedSymbolTable.getSymbolsInScope(
+                              classBlock2.id,
+                            );
+                          const matchingMembers2 = classMembers2.filter(
+                            (s) =>
+                              !isBlockSymbol(s) &&
+                              s.name === memberName &&
+                              s.kind === memberType &&
+                              s.fileUri === contextSymbol.fileUri &&
+                              s.parentId === classBlock2.id,
+                          );
+
+                          if (matchingMembers2.length > 0) {
+                            const method = matchingMembers2[0];
+                            if (method.kind === SymbolKind.Method) {
+                              const methodParentBlock = allSymbols2.find(
+                                (s) =>
+                                  s.id === method.parentId && isBlockSymbol(s),
+                              );
+                              if (
+                                methodParentBlock &&
+                                methodParentBlock.parentId === contextSymbol.id
+                              ) {
+                                return applyMethodTypeSubstitutions(
+                                  method as any,
+                                  typeSubstitutions,
+                                );
+                              }
+                            } else {
+                              return method;
+                            }
+                          }
+                        }
+                      }
+                    }
+                  } finally {
+                    self.loadingSymbolTables.delete(normalizedUri);
+                  }
+                }
+              } catch (_error) {
+                // Error loading, continue to return null
+              }
+            }
+          }
+
+          if (contextSymbol.kind === SymbolKind.Class) {
+            const classTypeSymbol = contextSymbol as TypeSymbol;
+
+            if (classTypeSymbol.superClass) {
+              const superclassSymbolResult = await resolveSuperclassSymbol(
+                self,
+                classTypeSymbol,
+              );
+              if (superclassSymbolResult) {
+                const superclassMember = await resolveMemberInContext(
+                  self,
+                  { type: 'symbol', symbol: superclassSymbolResult },
+                  memberName,
+                  memberType,
+                );
+                if (superclassMember) {
+                  return superclassMember;
+                }
+              }
+            }
+
+            if (classTypeSymbol.name?.toLowerCase() !== 'object') {
+              const objectClassResult = await resolveObjectClass(self);
+              if (objectClassResult) {
+                const objectMember = await resolveMemberInContext(
+                  self,
+                  { type: 'symbol', symbol: objectClassResult },
+                  memberName,
+                  memberType,
+                );
+                if (objectMember) {
+                  return objectMember;
+                }
+              }
+            }
+          }
+
+          return null;
+        }
+
+        const allSymbols = symbolTable.getAllSymbols();
+
+        const contextMembers = allSymbols.filter(
+          (s) => s.name === memberName && s.kind === memberType,
+        );
+
+        if (contextMembers.length > 0) {
+          const contextMember = contextMembers[0];
+          if (contextMember.kind === SymbolKind.Method) {
+            return applyMethodTypeSubstitutions(
+              contextMember as any,
+              typeSubstitutions,
+            );
+          }
+          return contextMember;
+        } else {
+          const _sameNameSymbols = allSymbols.filter(
+            (s) => s.name === memberName,
+          );
+        }
+      }
+    }
+  } else if (context?.type === 'namespace') {
+    const namespaceSymbols = await findSymsInNsOp(self, context.name);
+    const matchingSymbol = namespaceSymbols.find(
+      (s) => s.kind === memberType && s.name === memberName,
+    );
+
+    if (matchingSymbol) {
+      return matchingSymbol;
+    }
+  }
+
+  const isResolvingMethodOnClass =
+    context?.type === 'symbol' &&
+    (context.symbol.kind === SymbolKind.Class ||
+      context.symbol.kind === SymbolKind.Interface ||
+      context.symbol.kind === SymbolKind.Enum) &&
+    memberType === 'method';
+
+  const isResolvingMethodOnVariableType =
+    memberType === 'method' &&
+    context?.type === 'symbol' &&
+    (context.symbol.kind === SymbolKind.Variable ||
+      context.symbol.kind === SymbolKind.Field ||
+      context.symbol.kind === SymbolKind.Parameter ||
+      context.symbol.kind === SymbolKind.Property);
+
+  const isBuiltInOrStandardClass =
+    context?.type === 'symbol' &&
+    context.symbol.kind === SymbolKind.Class &&
+    memberType === 'method' &&
+    context.symbol.fileUri &&
+    (isStandardApexUri(context.symbol.fileUri) ||
+      BUILTIN_TYPE_NAMES.has(context.symbol.name.toLowerCase()));
+
+  if (
+    !isResolvingMethodOnClass &&
+    !isResolvingMethodOnVariableType &&
+    !isBuiltInOrStandardClass
+  ) {
+    const globalSymbols = await self.findSymbolByName(memberName);
+    const matchingSymbol = globalSymbols.find((s) => s.kind === memberType);
+
+    if (matchingSymbol) {
+      return matchingSymbol;
+    }
+  }
+
+  if (memberType === 'class') {
+    const memberRef: SymbolReference = {
+      name: memberName,
+      context: ReferenceContext.CLASS_REFERENCE,
+      location: {
+        symbolRange: {
+          startLine: 0,
+          startColumn: 0,
+          endLine: 0,
+          endColumn: 0,
+        },
+        identifierRange: {
+          startLine: 0,
+          startColumn: 0,
+          endLine: 0,
+          endColumn: 0,
+        },
+      },
+      resolvedSymbolId: undefined,
+    };
+    const builtInSymbol = await self.resolveStandardLibraryType(memberRef);
+    if (builtInSymbol) {
+      return builtInSymbol;
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// resolveQualifiedReferenceFromChain
+// ---------------------------------------------------------------------------
+
+export async function resolveQualifiedReferenceFromChain(
+  self: SymbolManagerOps,
+  qualifier: string,
+  member: string,
+  context: ReferenceContext,
+  fileUri?: string,
+  sourceSymbol?: ApexSymbol | null,
+  originalTypeRef?: SymbolReference,
+  symbolTable?: SymbolTable,
+  qualifiedResolutionCache?: HashMap<string, ApexSymbol | null>,
+  memberResolutionCache?: HashMap<string, ApexSymbol | null>,
+  resolverStats?: ResolverStats,
+): Promise<ApexSymbol | null> {
+  try {
+    if (qualifier.toLowerCase() === 'this') {
+      if (resolverStats) {
+        resolverStats.resolverQualifiedThisCalls += 1;
+      }
+      let containingClass: ApexSymbol | null = null;
+      if (sourceSymbol) {
+        containingClass = await self.getContainingType(sourceSymbol);
+      }
+
+      if (containingClass && fileUri) {
+        const thisLookupStart = Date.now();
+        const normalizedUri = extractFilePathFromUri(createFileUri(fileUri));
+        const localSymbols = symbolTable?.getAllSymbols();
+
+        const allSymbolsWithName = localSymbols
+          ? localSymbols.filter((s) => s.name === member)
+          : await self.findSymbolByName(member);
+
+        const classMembers = allSymbolsWithName.filter((s) => {
+          if (s.parentId === containingClass?.id) {
+            return true;
+          }
+          if (
+            s.fileUri === normalizedUri &&
+            containingClass?.location &&
+            s.location
+          ) {
+            const classStart = containingClass?.location.symbolRange.startLine;
+            const classEnd = containingClass?.location.symbolRange.endLine;
+            const symbolStart = s.location.symbolRange.startLine;
+            const symbolEnd = s.location.symbolRange.endLine;
+            return symbolStart >= classStart && symbolEnd <= classEnd;
+          }
+          return false;
+        });
+
+        if (classMembers.length > 0) {
+          if (resolverStats) {
+            resolverStats.resolverQualifiedThisLookupMs +=
+              Date.now() - thisLookupStart;
+          }
+          return classMembers[0];
+        }
+        if (resolverStats) {
+          resolverStats.resolverQualifiedThisLookupMs +=
+            Date.now() - thisLookupStart;
+        }
+      }
+
+      const thisGlobalLookupStart = Date.now();
+      const symbols = symbolTable
+        ? symbolTable
+            .getAllSymbols()
+            .filter((s) => s.name?.toLowerCase() === member.toLowerCase())
+        : await self.findSymbolByName(member);
+      if (resolverStats) {
+        resolverStats.resolverQualifiedGlobalLookupMs +=
+          Date.now() - thisGlobalLookupStart;
+      }
+      if (symbols.length > 0) {
+        if (fileUri) {
+          const normalizedUri = extractFilePathFromUri(createFileUri(fileUri));
+          const sameFileSymbol = symbols.find(
+            (s) => s.fileUri === normalizedUri,
+          );
+          if (sameFileSymbol) {
+            return sameFileSymbol;
+          }
+        }
+        return symbols[0];
+      }
+      return null;
+    }
+
+    const qualifiedCacheKey = `${qualifier}|${member}|${context}|${fileUri ?? ''}`;
+    if (qualifiedResolutionCache?.has(qualifiedCacheKey)) {
+      if (resolverStats) {
+        resolverStats.resolverQualifiedCacheHits += 1;
+      }
+      return qualifiedResolutionCache.get(qualifiedCacheKey) ?? null;
+    }
+    if (resolverStats) {
+      resolverStats.resolverQualifiedCacheMisses += 1;
+    }
+
+    let qualifierSymbols = await self.findSymbolByName(qualifier);
+
+    if (qualifierSymbols.length === 0) {
+      let qualifierRef: SymbolReference;
+      if (
+        originalTypeRef &&
+        isChainedSymbolReference(originalTypeRef) &&
+        originalTypeRef.chainNodes.length >= 2
+      ) {
+        qualifierRef = originalTypeRef.chainNodes[0];
+      } else {
+        qualifierRef = {
+          name: qualifier,
+          context: ReferenceContext.NAMESPACE,
+          location: originalTypeRef?.location || {
+            symbolRange: {
+              startLine: 0,
+              startColumn: 0,
+              endLine: 0,
+              endColumn: 0,
+            },
+            identifierRange: {
+              startLine: 0,
+              startColumn: 0,
+              endLine: 0,
+              endColumn: 0,
+            },
+          },
+          resolvedSymbolId: undefined,
+        };
+      }
+      const builtInQualifier =
+        await self.resolveStandardLibraryType(qualifierRef);
+      if (builtInQualifier) {
+        qualifierSymbols = [builtInQualifier];
+      }
+    }
+
+    if (qualifierSymbols.length === 0) {
+      const stdClassStart = Date.now();
+      const standardClass = await self.resolveStandardApexClass(qualifier);
+      if (resolverStats) {
+        resolverStats.resolverQualifiedStandardClassMs +=
+          Date.now() - stdClassStart;
+      }
+      if (standardClass) {
+        qualifierSymbols = [standardClass];
+      }
+    }
+
+    if (qualifierSymbols.length === 0) {
+      qualifiedResolutionCache?.set(qualifiedCacheKey, null);
+      return null;
+    }
+
+    if (qualifierSymbols.length > 1) {
+      const preferredFileUri =
+        sourceSymbol?.fileUri ??
+        (fileUri ? extractFilePathFromUri(createFileUri(fileUri)) : null);
+      const sourceLine = sourceSymbol?.location?.identifierRange?.startLine;
+      const kindRank = (kind: string): number => {
+        if (
+          kind === SymbolKind.Variable ||
+          kind === SymbolKind.Parameter ||
+          kind === SymbolKind.Field ||
+          kind === SymbolKind.Property
+        ) {
+          return 0;
+        }
+        return 1;
+      };
+
+      qualifierSymbols = [...qualifierSymbols].sort((a, b) => {
+        const aSameFile =
+          preferredFileUri && a.fileUri === preferredFileUri ? 0 : 1;
+        const bSameFile =
+          preferredFileUri && b.fileUri === preferredFileUri ? 0 : 1;
+        if (aSameFile !== bSameFile) {
+          return aSameFile - bSameFile;
+        }
+
+        const aKind = kindRank(a.kind);
+        const bKind = kindRank(b.kind);
+        if (aKind !== bKind) {
+          return aKind - bKind;
+        }
+
+        if (sourceLine !== undefined) {
+          const aLine = a.location?.identifierRange?.startLine;
+          const bLine = b.location?.identifierRange?.startLine;
+          const aDist =
+            aLine !== undefined
+              ? Math.abs(aLine - sourceLine)
+              : Number.MAX_SAFE_INTEGER;
+          const bDist =
+            bLine !== undefined
+              ? Math.abs(bLine - sourceLine)
+              : Number.MAX_SAFE_INTEGER;
+          if (aDist !== bDist) {
+            return aDist - bDist;
+          }
+        }
+
+        return 0;
+      });
+    }
+
+    const qualifierSymbol = qualifierSymbols[0];
+
+    let memberResolutionContext: { type: 'symbol'; symbol: ApexSymbol } = {
+      type: 'symbol',
+      symbol: qualifierSymbol,
+    };
+    let memberTypeSubstitutions: GenericTypeSubstitutionMap | null = null;
+    let qualifierRawTypeName: string | null = null;
+    let collectionElementType: string | null = null;
+    let promotedFromCollectionType = false;
+    if (
+      (qualifierSymbol.kind === SymbolKind.Variable ||
+        qualifierSymbol.kind === SymbolKind.Parameter ||
+        qualifierSymbol.kind === SymbolKind.Field ||
+        qualifierSymbol.kind === SymbolKind.Property) &&
+      (qualifierSymbol as any)?.type?.name
+    ) {
+      const qualifierTypeObj = (qualifierSymbol as any)?.type;
+      memberTypeSubstitutions =
+        createGenericTypeSubstitutionMap(qualifierTypeObj);
+      const rawTypeName = ((qualifierSymbol as any).type.name as string).trim();
+      qualifierRawTypeName = rawTypeName;
+      collectionElementType =
+        rawTypeName === 'List' || rawTypeName === 'Set'
+          ? ((qualifierTypeObj?.typeParameters?.[0]?.originalTypeString as
+              | string
+              | undefined) ??
+            (qualifierTypeObj?.typeParameters?.[0]?.name as
+              | string
+              | undefined) ??
+            null)
+          : null;
+      let collectionTypeSymbol = await resolvePreferredTypeOp(
+        self,
+        rawTypeName,
+        fileUri,
+        symbolTable,
+      );
+      if (
+        !collectionTypeSymbol &&
+        (rawTypeName === 'List' ||
+          rawTypeName === 'Set' ||
+          rawTypeName === 'Map')
+      ) {
+        collectionTypeSymbol = await self.resolveStandardApexClass(rawTypeName);
+      }
+      const elementTypeSymbol = collectionElementType
+        ? await resolvePreferredTypeOp(
+            self,
+            collectionElementType,
+            fileUri,
+            symbolTable,
+          )
+        : null;
+      const typeSymbol = collectionTypeSymbol ?? elementTypeSymbol;
+      promotedFromCollectionType = !!collectionTypeSymbol;
+      if (typeSymbol) {
+        memberResolutionContext = { type: 'symbol', symbol: typeSymbol };
+        if (resolverStats) {
+          resolverStats.resolverQualifiedTypeContextPromotions += 1;
+        }
+      }
+    }
+    const chainIndicatesMethod =
+      !!originalTypeRef &&
+      isChainedSymbolReference(originalTypeRef) &&
+      originalTypeRef.chainNodes?.some(
+        (node) =>
+          node.name === member && node.context === ReferenceContext.METHOD_CALL,
+      );
+    const memberTypeForLookup =
+      context === ReferenceContext.METHOD_CALL || chainIndicatesMethod
+        ? 'method'
+        : 'property';
+    const memberCacheKey = `${memberResolutionContext.symbol.id}|${memberTypeForLookup}|${member.toLowerCase()}`;
+    const cachedMember = memberResolutionCache?.get(memberCacheKey);
+    if (cachedMember !== undefined) {
+      if (resolverStats) {
+        resolverStats.resolverMemberContextCacheHits += 1;
+      }
+      qualifiedResolutionCache?.set(qualifiedCacheKey, cachedMember);
+      return cachedMember;
+    }
+    if (resolverStats) {
+      resolverStats.resolverMemberContextCacheMisses += 1;
+    }
+    const resolveMemberStart = Date.now();
+    const memberSymbol = await resolveMemberInContext(
+      self,
+      memberResolutionContext,
+      member,
+      memberTypeForLookup,
+      memberTypeSubstitutions,
+    );
+    let finalMemberSymbol = memberSymbol;
+    if (
+      !finalMemberSymbol &&
+      collectionElementType &&
+      promotedFromCollectionType &&
+      qualifierRawTypeName &&
+      memberResolutionContext.symbol.name.toLowerCase() ===
+        qualifierRawTypeName.toLowerCase()
+    ) {
+      const elementTypeSymbol = await resolvePreferredTypeOp(
+        self,
+        collectionElementType,
+        fileUri,
+        symbolTable,
+      );
+      if (elementTypeSymbol) {
+        finalMemberSymbol = await resolveMemberInContext(
+          self,
+          { type: 'symbol', symbol: elementTypeSymbol },
+          member,
+          memberTypeForLookup,
+          null,
+        );
+      }
+    }
+    const resolveMemberMs = Date.now() - resolveMemberStart;
+    if (resolverStats) {
+      resolverStats.resolverQualifiedResolveMemberMs += resolveMemberMs;
+    }
+    if (finalMemberSymbol) {
+      memberResolutionCache?.set(memberCacheKey, finalMemberSymbol);
+      qualifiedResolutionCache?.set(qualifiedCacheKey, finalMemberSymbol);
+      return finalMemberSymbol;
+    }
+
+    if (context === ReferenceContext.METHOD_CALL) {
+      memberResolutionCache?.set(memberCacheKey, qualifierSymbol);
+      qualifiedResolutionCache?.set(qualifiedCacheKey, qualifierSymbol);
+      return qualifierSymbol;
+    }
+
+    memberResolutionCache?.set(memberCacheKey, null);
+    qualifiedResolutionCache?.set(qualifiedCacheKey, null);
+    return null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// findTargetSymbolForReference
+// ---------------------------------------------------------------------------
+
+export async function findTargetSymbolForReference(
+  self: SymbolManagerOps,
+  typeRef: SymbolReference,
+  fileUri?: string,
+  sourceSymbol?: ApexSymbol | null,
+  symbolTable?: SymbolTable,
+  qualifiedResolutionCache?: HashMap<string, ApexSymbol | null>,
+  memberResolutionCache?: HashMap<string, ApexSymbol | null>,
+  resolverStats?: ResolverStats,
+): Promise<ApexSymbol | null> {
+  if (resolverStats) {
+    resolverStats.resolverCalls += 1;
+  }
+  if (typeRef.resolvedSymbolId) {
+    const resolvedSymbol = await self.getSymbol(typeRef.resolvedSymbolId);
+    if (resolvedSymbol) {
+      if (resolverStats) {
+        resolverStats.resolverPreResolvedHits += 1;
+      }
+      self.logger.debug(
+        () =>
+          `Using pre-resolved symbol ID "${typeRef.resolvedSymbolId}" in findTargetSymbolForReference`,
+      );
+      return resolvedSymbol;
+    }
+    self.logger.debug(
+      () =>
+        'Pre-resolved symbol ID "' +
+        typeRef.resolvedSymbolId +
+        '" not found ' +
+        'in findTargetSymbolForReference, falling back to normal resolution',
+    );
+  }
+
+  const qualifierInfo = extractQualFromChainOp(typeRef);
+
+  if (qualifierInfo && qualifierInfo.isQualified) {
+    const qualifiedStart = Date.now();
+    const qualifiedSymbol = await resolveQualifiedReferenceFromChain(
+      self,
+      qualifierInfo.qualifier,
+      qualifierInfo.member,
+      typeRef.context,
+      fileUri,
+      sourceSymbol,
+      typeRef,
+      symbolTable,
+      qualifiedResolutionCache,
+      memberResolutionCache,
+      resolverStats,
+    );
+    if (resolverStats) {
+      resolverStats.resolverQualifiedCalls += 1;
+      resolverStats.resolverQualifiedMs += Date.now() - qualifiedStart;
+    }
+
+    if (qualifiedSymbol) {
+      return qualifiedSymbol;
+    }
+  }
+
+  if (symbolTable && fileUri) {
+    const scopeHierarchyStart = Date.now();
+    const position = {
+      line: typeRef.location.identifierRange.startLine,
+      character: typeRef.location.identifierRange.startColumn,
+    };
+    const scopeHierarchy = symbolTable.getScopeHierarchy(position);
+    if (resolverStats) {
+      resolverStats.resolverScopeHierarchyMs +=
+        Date.now() - scopeHierarchyStart;
+    }
+
+    const allFileSymbols = symbolTable.getAllSymbols();
+    const scopeSearchStart = Date.now();
+
+    const innermostToOutermost = [...scopeHierarchy].reverse();
+    for (const blockSymbol of innermostToOutermost) {
+      const directChildren = allFileSymbols.filter(
+        (symbol) =>
+          symbol.name === typeRef.name && symbol.parentId === blockSymbol.id,
+      );
+
+      const nestedBlocks = allFileSymbols.filter((s) => {
+        if (s.kind !== SymbolKind.Block || s.parentId !== blockSymbol.id) {
+          return false;
+        }
+        return scopeHierarchy.some(
+          (hierarchyBlock) => hierarchyBlock.id === s.id,
+        );
+      });
+      const symbolsInNestedBlocks: ApexSymbol[] = [];
+      for (const nestedBlock of nestedBlocks) {
+        const isInHierarchy = scopeHierarchy.some(
+          (hierarchyBlock) => hierarchyBlock.id === nestedBlock.id,
+        );
+        if (!isInHierarchy) {
+          continue;
+        }
+        const nestedSymbols = allFileSymbols.filter(
+          (symbol) =>
+            symbol.name?.toLowerCase() === typeRef.name.toLowerCase() &&
+            symbol.parentId === nestedBlock.id,
+        );
+        symbolsInNestedBlocks.push(...nestedSymbols);
+      }
+
+      const symbolsInScope = [...directChildren, ...symbolsInNestedBlocks];
+
+      if (symbolsInScope.length > 0) {
+        const prioritized = symbolsInScope.sort((a, b) => {
+          const aIsVar =
+            a.kind === SymbolKind.Variable || a.kind === SymbolKind.Parameter;
+          const bIsVar =
+            b.kind === SymbolKind.Variable || b.kind === SymbolKind.Parameter;
+          if (aIsVar && !bIsVar) return -1;
+          if (!aIsVar && bIsVar) return 1;
+          return 0;
+        });
+        if (resolverStats) {
+          resolverStats.resolverScopeSearchMs += Date.now() - scopeSearchStart;
+        }
+        return prioritized[0];
+      }
+    }
+
+    const parentScopeSearchOrder = [...scopeHierarchy].reverse();
+    for (const blockSymbol of parentScopeSearchOrder) {
+      if (!isBlockSymbol(blockSymbol)) {
+        continue;
+      }
+
+      const isClassOrFileLevel =
+        blockSymbol.scopeType === 'class' || blockSymbol.scopeType === 'file';
+      const isMethodLevel = blockSymbol.scopeType === 'method';
+
+      if (isClassOrFileLevel) {
+        const classFields = allFileSymbols.filter(
+          (s) =>
+            s.name === typeRef.name &&
+            s.parentId === blockSymbol.id &&
+            s.kind === SymbolKind.Field,
+        );
+        if (classFields.length > 0) {
+          if (resolverStats) {
+            resolverStats.resolverScopeSearchMs +=
+              Date.now() - scopeSearchStart;
+          }
+          return classFields[0];
+        }
+        const classMethods = allFileSymbols.filter(
+          (s) =>
+            s.name === typeRef.name &&
+            s.parentId === blockSymbol.id &&
+            s.kind === SymbolKind.Method,
+        );
+        if (classMethods.length > 0) {
+          if (resolverStats) {
+            resolverStats.resolverScopeSearchMs +=
+              Date.now() - scopeSearchStart;
+          }
+          return classMethods[0];
+        }
+      }
+
+      if (isMethodLevel) {
+        const parameters = allFileSymbols.filter(
+          (s) =>
+            s.name === typeRef.name &&
+            s.parentId === blockSymbol.id &&
+            s.kind === SymbolKind.Parameter,
+        );
+        if (parameters.length > 0) {
+          if (resolverStats) {
+            resolverStats.resolverScopeSearchMs +=
+              Date.now() - scopeSearchStart;
+          }
+          return parameters[0];
+        }
+      }
+    }
+    if (resolverStats) {
+      resolverStats.resolverScopeSearchMs += Date.now() - scopeSearchStart;
+    }
+  }
+
+  if (symbolTable) {
+    const directLookupStart = Date.now();
+    const allFileSymbols = symbolTable.getAllSymbols();
+    const directMatch = allFileSymbols.find(
+      (s) => s.name?.toLowerCase() === typeRef.name.toLowerCase(),
+    );
+    if (resolverStats) {
+      resolverStats.resolverDirectLookupMs += Date.now() - directLookupStart;
+    }
+    if (directMatch) {
+      return directMatch;
+    }
+  }
+
+  const builtInStart = Date.now();
+  const builtInSymbol = await self.resolveStandardLibraryType(typeRef);
+  if (resolverStats) {
+    resolverStats.resolverBuiltInMs += Date.now() - builtInStart;
+  }
+  if (builtInSymbol) {
+    return builtInSymbol;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// resolveSymbolReferenceToSymbol
+// ---------------------------------------------------------------------------
+
+export async function resolveSymbolReferenceToSymbol(
+  self: SymbolManagerOps,
+  typeReference: SymbolReference,
+  sourceFile: string,
+  position?: { line: number; character: number },
+): Promise<ApexSymbol | null> {
+  self.logger.debug(
+    () =>
+      '[Resolution] resolveSymbolReferenceToSymbol called for ' +
+      `"${typeReference.name}" (context: ${typeReference.context})`,
+  );
+
+  try {
+    if (typeReference.context === ReferenceContext.LITERAL) {
+      if (!typeReference.literalType || typeReference.literalType === 'Null') {
+        return null;
+      }
+
+      const builtInTypeRef: SymbolReference = {
+        name: typeReference.literalType,
+        location: typeReference.location,
+        context: ReferenceContext.CLASS_REFERENCE,
+      };
+
+      const builtInSymbol =
+        await self.resolveStandardLibraryType(builtInTypeRef);
+      if (builtInSymbol) {
+        typeReference.resolvedSymbolId = builtInSymbol.id;
+        self.logger.debug(
+          () =>
+            `Resolved LITERAL reference "${typeReference.name}" ` +
+            `(type: ${typeReference.literalType}) to built-in type: ${builtInSymbol.name}`,
+        );
+        return builtInSymbol;
+      }
+
+      return null;
+    }
+
+    if (typeReference.resolvedSymbolId) {
+      let shouldSkipFastPath = false;
+      if (position && isChainedSymbolReference(typeReference)) {
+        const chainMember = findChainMember(typeReference, position);
+        if (chainMember) {
+          shouldSkipFastPath = true;
+        }
+      }
+
+      if (!shouldSkipFastPath) {
+        const resolvedSymbol = await self.getSymbol(
+          typeReference.resolvedSymbolId,
+        );
+        if (resolvedSymbol) {
+          self.logger.debug(
+            () =>
+              `Using pre-resolved symbol ID "${typeReference.resolvedSymbolId}" ` +
+              `for reference "${typeReference.name}"`,
+          );
+          return resolvedSymbol;
+        }
+        self.logger.debug(
+          () =>
+            `Pre-resolved symbol ID "${typeReference.resolvedSymbolId}" not found, falling back to normal resolution`,
+        );
+      }
+    }
+
+    const syntheticRef = typeReference as any;
+    if (syntheticRef._originalChainedRef && syntheticRef._chainNode) {
+      if (syntheticRef._chainNode.resolvedSymbolId) {
+        const resolvedSymbol = await self.getSymbol(
+          syntheticRef._chainNode.resolvedSymbolId,
+        );
+        if (resolvedSymbol) {
+          self.logger.debug(
+            () =>
+              `Resolved synthetic reference "${typeReference.name}" through chain node`,
+          );
+          return resolvedSymbol;
+        }
+      }
+      const chainedRef = syntheticRef._originalChainedRef;
+      if (position) {
+        const chainMember = findChainMember(chainedRef, position);
+        if (chainMember && chainMember.member.resolvedSymbolId) {
+          const resolvedSymbol = await self.getSymbol(
+            chainMember.member.resolvedSymbolId,
+          );
+          if (resolvedSymbol) {
+            self.logger.debug(
+              () =>
+                `Resolved synthetic reference "${typeReference.name}" through chain member at position`,
+            );
+            return resolvedSymbol;
+          }
+        }
+      }
+      return resolveChainedSymbolReference(
+        self,
+        chainedRef,
+        position,
+        sourceFile,
+      );
+    }
+
+    if (isChainedSymbolReference(typeReference)) {
+      return resolveChainedSymbolReference(
+        self,
+        typeReference,
+        position,
+        sourceFile,
+      );
+    }
+
+    const qualifierInfo = extractQualFromChainOp(typeReference);
+    if (qualifierInfo && qualifierInfo.isQualified) {
+      const qualifiedSymbol = await resolveQualifiedReferenceFromChain(
+        self,
+        qualifierInfo.qualifier,
+        qualifierInfo.member,
+        typeReference.context,
+        sourceFile,
+        undefined,
+        typeReference,
+      );
+
+      if (qualifiedSymbol) {
+        return qualifiedSymbol;
+      }
+    }
+
+    if (typeReference.context !== ReferenceContext.VARIABLE_DECLARATION) {
+      const builtInSymbol =
+        await self.resolveStandardLibraryType(typeReference);
+      if (builtInSymbol) {
+        self.logger.debug(
+          () =>
+            `Resolved built-in type "${typeReference.name}" to symbol: ${builtInSymbol.name}`,
+        );
+        return builtInSymbol;
+      } else {
+        self.logger.debug(
+          () =>
+            `Built-in type resolution failed for "${typeReference.name}" in ${sourceFile}`,
+        );
+      }
+
+      const standardClass = await self.resolveStandardApexClass(
+        typeReference.name,
+      );
+      if (standardClass) {
+        self.logger.debug(
+          () =>
+            `Resolved standard Apex class "${typeReference.name}" to symbol: ${standardClass.name}`,
+        );
+        return standardClass;
+      } else {
+        self.logger.debug(
+          () =>
+            `Standard Apex class resolution failed for "${typeReference.name}" in ${sourceFile}`,
+        );
+      }
+    }
+
+    const isStandardNamespace = self.stdlibProvider.isStdApexNamespace(
+      typeReference.name,
+    );
+    if (isStandardNamespace) {
+      // Let it continue to scope resolution
+    }
+
+    let variableUsageLooksLikeClass = false;
+    if (typeReference.context === ReferenceContext.VARIABLE_USAGE) {
+      const candidates = await self.findSymbolByName(typeReference.name);
+      const hasClassMatch = candidates.some(
+        (s) => s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
+      );
+      variableUsageLooksLikeClass = hasClassMatch || candidates.length === 0;
+    }
+    const isClassReferenceContext =
+      typeReference.context === ReferenceContext.CLASS_REFERENCE ||
+      typeReference.context === ReferenceContext.CONSTRUCTOR_CALL ||
+      typeReference.context === ReferenceContext.GENERIC_PARAMETER_TYPE ||
+      (typeReference.context === ReferenceContext.VARIABLE_USAGE &&
+        variableUsageLooksLikeClass);
+    if (isClassReferenceContext) {
+      const candidates = await self.findSymbolByName(typeReference.name);
+
+      let classCandidates = candidates.filter(
+        (s) => s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface,
+      );
+
+      if (classCandidates.length === 0) {
+        const sourceSymbolTable =
+          self.symbolRefManager.getSymbolTableForFile(sourceFile);
+        if (sourceSymbolTable) {
+          const allSymbols = sourceSymbolTable.getAllSymbols();
+          classCandidates = allSymbols.filter(
+            (s) =>
+              s.name === typeReference.name &&
+              (s.kind === SymbolKind.Class || s.kind === SymbolKind.Interface),
+          );
+        }
+
+        if (classCandidates.length === 0) {
+          self.logger.debug(
+            () =>
+              `[Resolution] Type "${typeReference.name}" not in source file, checking GlobalTypeRegistry`,
+          );
+
+          const sourceSymbolTable2 =
+            self.symbolRefManager.getSymbolTableForFile(sourceFile);
+
+          const registryLookup = Effect.gen(function* () {
+            const registry = yield* GlobalTypeRegistry;
+
+            const sourceSymbolForNs = sourceSymbolTable2
+              ?.getAllSymbols()
+              .find((s) => s.parentId === null);
+            const currentNs = sourceSymbolForNs?.namespace
+              ? String(sourceSymbolForNs.namespace)
+              : undefined;
+
+            return yield* registry.resolveType(typeReference.name, {
+              currentNamespace: currentNs,
+            });
+          });
+
+          try {
+            const registryEntry = await Effect.runPromise(
+              registryLookup.pipe(Effect.provide(GlobalTypeRegistryLive)),
+            );
+
+            if (registryEntry) {
+              let symbol = self.symbolRefManager.getSymbol(
+                registryEntry.symbolId,
+              );
+
+              self.logger.debug(
+                () =>
+                  `[Resolution] Registry entry found for "${typeReference.name}" ` +
+                  `(symbolId="${registryEntry.symbolId}"), symbol in graph: ${symbol ? 'YES' : 'NO'}`,
+              );
+
+              if (!symbol && registryEntry.isStdlib) {
+                self.logger.debug(
+                  () =>
+                    `[Resolution] Loading stdlib class on-demand: ${registryEntry.fileUri}`,
+                );
+
+                const match = registryEntry.fileUri.match(
+                  /apexlib:\/\/resources\/StandardApexLibrary\/(.+\.cls)$/,
+                );
+                if (match) {
+                  const classPath = match[1];
+                  const st =
+                    await self.stdlibProvider.getSymbolTable(classPath);
+                  if (st) {
+                    await self.addSymbolTableAsync(st, registryEntry.fileUri);
+                    symbol = self.symbolRefManager.getSymbol(
+                      registryEntry.symbolId,
+                    );
+                    self.logger.debug(
+                      () =>
+                        `[Resolution] After loading, symbol in graph: ${symbol ? 'YES' : 'NO'}`,
+                    );
+                  }
+                }
+              }
+
+              if (symbol) {
+                classCandidates = [symbol];
+                self.logger.debug(
+                  () =>
+                    `[GlobalTypeRegistry] Resolved "${typeReference.name}" to ` +
+                    `"${registryEntry.fqn}" via Effect service (O(1))`,
+                );
+              } else {
+                self.logger.debug(
+                  () =>
+                    `[Resolution] Registry entry found but symbol not available for "${typeReference.name}"`,
+                );
+              }
+            } else {
+              self.logger.debug(
+                () =>
+                  `[GlobalTypeRegistry] Type "${typeReference.name}" not found in registry. ` +
+                  'Type may not exist or file not yet loaded.',
+              );
+            }
+          } catch (error) {
+            self.logger.error(
+              () =>
+                `[GlobalTypeRegistry] Effect service error: ${error}. ` +
+                'Type resolution failed.',
+            );
+          }
+        }
+      }
+
+      if (classCandidates.length > 0) {
+        const sameFileClass = classCandidates.find(
+          (s) => s.fileUri === sourceFile || s.key.path[0] === sourceFile,
+        );
+        if (sameFileClass) {
+          return sameFileClass;
+        }
+        const accessibleClass = classCandidates.find((s) =>
+          isSymAccessibleOp(s, sourceFile),
+        );
+        if (accessibleClass) {
+          return accessibleClass;
+        }
+        return classCandidates[0];
+      }
+
+      const builtInSymbol2 =
+        await self.resolveStandardLibraryType(typeReference);
+      if (builtInSymbol2) {
+        self.logger.debug(
+          () =>
+            `Resolved GENERIC_PARAMETER_TYPE "${typeReference.name}" to built-in type: ${builtInSymbol2.name}`,
+        );
+        return builtInSymbol2;
+      }
+
+      const standardClass2 = await self.resolveStandardApexClass(
+        typeReference.name,
+      );
+      if (standardClass2) {
+        self.logger.debug(
+          () =>
+            `Resolved GENERIC_PARAMETER_TYPE "${typeReference.name}" to standard Apex class: ${standardClass2.name}`,
+        );
+        return standardClass2;
+      }
+
+      return null;
+    }
+
+    if (position) {
+      const scopeResolvedSymbol = resolveUnqualRefByScopeOp(
+        self,
+        typeReference,
+        sourceFile,
+        position,
+      );
+      if (scopeResolvedSymbol !== null) {
+        return scopeResolvedSymbol;
+      }
+    }
+
+    const candidates2 = await self.findSymbolByName(typeReference.name);
+
+    if (candidates2.length === 0) {
+      return null;
+    }
+
+    const sameFileCandidates = candidates2.filter(
+      (symbol) =>
+        symbol.fileUri === sourceFile || symbol.key.path[0] === sourceFile,
+    );
+
+    if (sameFileCandidates.length > 0) {
+      return selectMostSpecificOp(sameFileCandidates, sourceFile);
+    }
+
+    const accessibleCandidates = candidates2.filter((symbol) =>
+      isSymAccessibleOp(symbol, sourceFile),
+    );
+
+    if (accessibleCandidates.length > 0) {
+      return selectMostSpecificOp(accessibleCandidates, sourceFile);
+    }
+
+    return candidates2[0];
+  } catch (_error) {
+    return null;
+  }
+}

--- a/packages/apex-parser-ast/src/symbols/ops/graphAnalysis.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/graphAnalysis.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Effect } from 'effect';
+import type { ApexSymbol } from '../../types/symbol';
+import type { DependencyAnalysis } from '../ApexSymbolRefManager';
+import type {
+  GraphData,
+  FileGraphData,
+  TypeGraphData,
+} from '../../types/graph';
+import { ReferenceStore } from '../services/referenceStore';
+import { CacheStore } from '../services/cacheStore';
+
+/** Analyze dependencies for a symbol, with cache */
+export const analyzeDependencies = (
+  symbol: ApexSymbol,
+): Effect.Effect<DependencyAnalysis, never, ReferenceStore | CacheStore> =>
+  Effect.gen(function* () {
+    const cache = yield* CacheStore;
+    const cacheKey = `deps_${symbol.name}`;
+    const cached = yield* cache.get<DependencyAnalysis>(cacheKey);
+    if (cached) return cached;
+
+    const refs = yield* ReferenceStore;
+    const analysis = yield* refs.analyzeDependencies(symbol);
+    yield* cache.set(cacheKey, analysis, 'analysis');
+    return analysis;
+  });
+
+/** Detect all circular dependencies in the graph */
+export const detectCircularDependencies = (): Effect.Effect<
+  string[][],
+  never,
+  ReferenceStore
+> =>
+  Effect.gen(function* () {
+    const refs = yield* ReferenceStore;
+    return yield* refs.detectCircularDependencies();
+  });
+
+/** Get graph data as JSON-serializable data */
+export const getGraphData = (): Effect.Effect<
+  GraphData,
+  never,
+  ReferenceStore
+> =>
+  Effect.gen(function* () {
+    const refs = yield* ReferenceStore;
+    return yield* refs.getGraphData();
+  });
+
+/** Get graph data filtered by file */
+export const getGraphDataForFile = (
+  fileUri: string,
+): Effect.Effect<FileGraphData, never, ReferenceStore> =>
+  Effect.gen(function* () {
+    const refs = yield* ReferenceStore;
+    return yield* refs.getGraphDataForFile(fileUri);
+  });
+
+/** Get graph data filtered by symbol type */
+export const getGraphDataByType = (
+  symbolType: string,
+): Effect.Effect<TypeGraphData, never, ReferenceStore> =>
+  Effect.gen(function* () {
+    const refs = yield* ReferenceStore;
+    return yield* refs.getGraphDataByType(symbolType);
+  });

--- a/packages/apex-parser-ast/src/symbols/ops/positionUtils.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/positionUtils.ts
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import type {
+  ApexSymbol,
+  SymbolLocation,
+  Position,
+  Range,
+  SymbolTable,
+} from '../../types/symbol';
+import { SymbolKind } from '../../types/symbol';
+import type {
+  SymbolReference,
+  ChainedSymbolReference,
+} from '../../types/symbolReference';
+import {
+  isChainedSymbolReference,
+  isBlockSymbol,
+  inTypeSymbolGroup,
+} from '../../utils/symbolNarrowing';
+
+/** Check if a position falls within a symbol's symbolRange */
+export function isPositionWithinSymbol(
+  symbol: ApexSymbol,
+  position: Position,
+): boolean {
+  if (!symbol.location) return false;
+
+  const { startLine, startColumn, endLine, endColumn } =
+    symbol.location.symbolRange;
+
+  if (position.line < startLine || position.line > endLine) {
+    return false;
+  }
+  if (position.line === startLine && position.character < startColumn) {
+    return false;
+  }
+  if (position.line === endLine && position.character > endColumn) {
+    return false;
+  }
+
+  return true;
+}
+
+/** Check if a position is within a symbol's identifierRange */
+export function isPositionInIdentifierRange(
+  position: { line: number; character: number },
+  identifierRange: {
+    startLine: number;
+    startColumn: number;
+    endLine: number;
+    endColumn: number;
+  },
+): boolean {
+  return (
+    position.line >= identifierRange.startLine &&
+    position.line <= identifierRange.endLine &&
+    position.character >= identifierRange.startColumn &&
+    position.character <= identifierRange.endColumn
+  );
+}
+
+/** Check if a Range is contained within a SymbolLocation's symbolRange */
+export function isPositionContainedInSymbol(
+  position: Range,
+  symbolLocation: SymbolLocation,
+): boolean {
+  const { startLine, startColumn, endLine, endColumn } =
+    symbolLocation.symbolRange;
+
+  if (position.startLine < startLine || position.endLine > endLine) {
+    return false;
+  }
+  if (position.startLine === startLine && position.startColumn < startColumn) {
+    return false;
+  }
+  if (position.endLine === endLine && position.endColumn > endColumn) {
+    return false;
+  }
+
+  return true;
+}
+
+/** Check if one symbol's range is entirely contained within another */
+export function isSymbolContainedWithin(
+  innerSymbol: ApexSymbol,
+  outerSymbol: ApexSymbol,
+): boolean {
+  const inner = innerSymbol.location;
+  const outer = outerSymbol.location;
+
+  if (inner.symbolRange.startLine < outer.symbolRange.startLine) return false;
+  if (
+    inner.symbolRange.startLine === outer.symbolRange.startLine &&
+    inner.symbolRange.startColumn < outer.symbolRange.startColumn
+  ) {
+    return false;
+  }
+  if (inner.symbolRange.endLine > outer.symbolRange.endLine) return false;
+  if (
+    inner.symbolRange.endLine === outer.symbolRange.endLine &&
+    inner.symbolRange.endColumn > outer.symbolRange.endColumn
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+/** Check if a position is within a location's identifierRange */
+export function isPositionWithinLocation(
+  location: { identifierRange: Range },
+  position: { line: number; character: number },
+): boolean {
+  const { startLine, startColumn, endLine, endColumn } =
+    location.identifierRange;
+
+  if (position.line < startLine || position.line > endLine) {
+    return false;
+  }
+  if (position.line === startLine && position.character < startColumn) {
+    return false;
+  }
+  if (position.line === endLine && position.character > endColumn) {
+    return false;
+  }
+
+  return true;
+}
+
+/** Check if a position is at the start of a chained reference */
+export function isPositionAtStartOfChainedRef(
+  typeReference: ChainedSymbolReference,
+  position: { line: number; character: number },
+): boolean {
+  const chainedRefStart = typeReference.location.identifierRange;
+  return (
+    position.line === chainedRefStart.startLine &&
+    position.character === chainedRefStart.startColumn
+  );
+}
+
+/** Check if a position is on the first node of a chained reference */
+export function isPositionOnFirstNode(
+  typeReference: ChainedSymbolReference,
+  firstNode: SymbolReference,
+  position: { line: number; character: number },
+): boolean {
+  const firstNodeStart = firstNode.location.identifierRange;
+  const isAtStartOfFirstNode =
+    position.line === firstNodeStart.startLine &&
+    position.character === firstNodeStart.startColumn;
+  const isWithinFirstNode = isPositionWithinLocation(
+    firstNode.location,
+    position,
+  );
+  const isAtStart = isPositionAtStartOfChainedRef(typeReference, position);
+
+  return isAtStartOfFirstNode || isWithinFirstNode || isAtStart;
+}
+
+/** Find the specific chain member at a given position within a chained expression */
+export function findChainMemberAtPosition(
+  chainedRef: ChainedSymbolReference,
+  position: { line: number; character: number },
+): { member: SymbolReference; index: number } | null {
+  if (!isChainedSymbolReference(chainedRef)) {
+    return null;
+  }
+  const chainNodes = chainedRef.chainNodes;
+  if (chainNodes?.length === 0) {
+    return null;
+  }
+
+  for (let i = 0; i < chainNodes.length; i++) {
+    const node = chainNodes[i];
+    if (isPositionWithinLocation(node.location, position)) {
+      return { member: node, index: i };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Find the containing semantic symbol for a reference using SymbolTable scope hierarchy.
+ * Walks from innermost scope outward to find the nearest Method/Class/Interface/Enum/Trigger.
+ */
+export function findContainingSymbolFromSymbolTable(
+  typeRef: SymbolReference,
+  symbolTable: SymbolTable,
+): ApexSymbol | null {
+  const position = {
+    line: typeRef.location.identifierRange.startLine,
+    character: typeRef.location.identifierRange.startColumn,
+  };
+
+  const scopeHierarchy = symbolTable.getScopeHierarchy(position);
+  const allSymbols = symbolTable.getAllSymbols();
+
+  for (const blockSymbol of [...scopeHierarchy].reverse()) {
+    if (blockSymbol.parentId) {
+      const parent = allSymbols.find((s) => s.id === blockSymbol.parentId);
+      if (parent) {
+        if (parent.kind === SymbolKind.Method || inTypeSymbolGroup(parent)) {
+          return parent;
+        }
+
+        if (isBlockSymbol(parent) && parent.parentId) {
+          let currentId: string | undefined = parent.parentId;
+          const visited = new Set<string>();
+          visited.add(parent.id);
+
+          while (currentId && !visited.has(currentId)) {
+            visited.add(currentId);
+            const ancestor = allSymbols.find((s) => s.id === currentId);
+            if (!ancestor) {
+              break;
+            }
+            if (
+              ancestor.kind === SymbolKind.Method ||
+              inTypeSymbolGroup(ancestor)
+            ) {
+              return ancestor;
+            }
+            if (isBlockSymbol(ancestor) && ancestor.parentId) {
+              currentId = ancestor.parentId;
+            } else {
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const topLevelSymbol = allSymbols.find(inTypeSymbolGroup);
+  return topLevelSymbol || null;
+}

--- a/packages/apex-parser-ast/src/symbols/ops/referenceOps.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/referenceOps.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Effect } from 'effect';
+import type { ApexSymbol } from '../../types/symbol';
+import type { EnumValue } from '@salesforce/apex-lsp-shared';
+import type { ReferenceResult, ReferenceType } from '../ApexSymbolRefManager';
+import type { SymbolReference } from '../../types/symbolReference';
+import { SymbolIndexStore } from '../services/symbolIndexStore';
+import { ReferenceStore } from '../services/referenceStore';
+import { CacheStore } from '../services/cacheStore';
+
+/** Find all references pointing to the given symbol, with cache */
+export const findReferencesTo = (
+  symbol: ApexSymbol,
+): Effect.Effect<ReferenceResult[], never, ReferenceStore | CacheStore> =>
+  Effect.gen(function* () {
+    const cache = yield* CacheStore;
+    const cacheKey = `refs_to_${symbol.name}`;
+    const cached = yield* cache.get<ReferenceResult[]>(cacheKey);
+    if (cached) return cached;
+
+    const refs = yield* ReferenceStore;
+    const results = yield* refs.findReferencesTo(symbol);
+    yield* cache.set(cacheKey, results, 'relationship');
+    return results;
+  });
+
+/** Find all references originating from the given symbol, with cache */
+export const findReferencesFrom = (
+  symbol: ApexSymbol,
+): Effect.Effect<ReferenceResult[], never, ReferenceStore | CacheStore> =>
+  Effect.gen(function* () {
+    const cache = yield* CacheStore;
+    const cacheKey = `refs_from_${symbol.name}`;
+    const cached = yield* cache.get<ReferenceResult[]>(cacheKey);
+    if (cached) return cached;
+
+    const refs = yield* ReferenceStore;
+    const results = yield* refs.findReferencesFrom(symbol);
+    yield* cache.set(cacheKey, results, 'relationship');
+    return results;
+  });
+
+/** Find symbols related by a specific relationship type */
+export const findRelatedSymbols = (
+  symbol: ApexSymbol,
+  relationshipType: EnumValue<typeof ReferenceType>,
+): Effect.Effect<ApexSymbol[], never, ReferenceStore | CacheStore> =>
+  Effect.gen(function* () {
+    const references = yield* findReferencesFrom(symbol);
+    return references
+      .filter((ref) => ref.referenceType === relationshipType)
+      .map((ref) => ref.symbol);
+  });
+
+/** Get SymbolReference data at a specific position in a file */
+export const getReferencesAtPosition = (
+  fileUri: string,
+  position: { line: number; character: number },
+): Effect.Effect<SymbolReference[], never, SymbolIndexStore> =>
+  Effect.gen(function* () {
+    const index = yield* SymbolIndexStore;
+    const symbolTable = yield* index.getSymbolTableForFile(fileUri);
+    if (!symbolTable) return [];
+    try {
+      return symbolTable.getReferencesAtPosition(position);
+    } catch {
+      return [];
+    }
+  });
+
+/** Get all references in a file */
+export const getAllReferencesInFile = (
+  fileUri: string,
+): Effect.Effect<SymbolReference[], never, SymbolIndexStore> =>
+  Effect.gen(function* () {
+    const index = yield* SymbolIndexStore;
+    const symbolTable = yield* index.getSymbolTableForFile(fileUri);
+    if (!symbolTable) return [];
+    try {
+      return symbolTable.getAllReferences();
+    } catch {
+      return [];
+    }
+  });

--- a/packages/apex-parser-ast/src/symbols/ops/resolutionContext.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/resolutionContext.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  SymbolKind,
+  SymbolVisibility,
+  type ApexSymbol,
+  type Position,
+  type TypeSymbol,
+} from '../../types/symbol';
+import type { SymbolResolutionContext } from '../../types/ISymbolManager';
+
+/** Extract namespace from file URI */
+export function extractNamespaceFromUri(fileUri: string): string {
+  if (fileUri.includes('test')) {
+    return 'public';
+  }
+  const match = fileUri.match(/\/([^\/]+)\.cls$/);
+  return match ? match[1] : 'public';
+}
+
+/** Extract current scope from document text and position */
+export function extractCurrentScope(
+  documentText: string,
+  position: Position,
+): string {
+  const lines = documentText.split('\n');
+  const currentLine = lines[position.line] || '';
+
+  if (currentLine.includes('public class')) {
+    return 'class';
+  } else if (currentLine.includes('public static')) {
+    return 'static';
+  } else if (currentLine.includes('public')) {
+    return 'instance';
+  }
+
+  return 'global';
+}
+
+/** Extract access modifier from document text and position */
+export function extractAccessModifier(
+  documentText: string,
+  position: Position,
+): 'public' | 'private' | 'protected' | 'global' {
+  const lines = documentText.split('\n');
+  const currentLine = lines[position.line] || '';
+
+  if (currentLine.includes('private')) {
+    return 'private';
+  } else if (currentLine.includes('protected')) {
+    return 'protected';
+  } else if (currentLine.includes('global')) {
+    return 'global';
+  }
+
+  return 'public';
+}
+
+/** Extract import statements from document text */
+export function extractImportStatements(documentText: string): string[] {
+  const lines = documentText.split('\n');
+  const imports: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('import ')) {
+      imports.push(trimmed);
+    }
+  }
+  return imports;
+}
+
+/** Create fallback resolution context when no symbols are available */
+export function createFallbackResolutionContext(
+  documentText: string,
+  position: Position,
+  fileUri: string,
+): SymbolResolutionContext {
+  const namespaceContext = extractNamespaceFromUri(fileUri);
+  const currentScope = extractCurrentScope(documentText, position);
+  const importStmts = extractImportStatements(documentText);
+  const accessMod = extractAccessModifier(documentText, position);
+
+  return {
+    sourceFile: fileUri,
+    importStatements: importStmts,
+    namespaceContext,
+    currentScope,
+    scopeChain: [currentScope],
+    parameterTypes: [],
+    accessModifier: accessMod,
+    isStatic: false,
+    inheritanceChain: [],
+    interfaceImplementations: [],
+  };
+}
+
+/** Extract namespace from text (fallback method) */
+export function extractNamespaceFromText(line: string): string {
+  if (line.includes('global')) return 'global';
+  if (line.includes('public')) return 'public';
+  if (line.includes('private')) return 'private';
+  if (line.includes('protected')) return 'protected';
+  return '';
+}
+
+/** Determine scope from text (fallback method) */
+export function determineScopeFromText(line: string): string {
+  if (line.includes('class') || line.includes('interface')) return 'class';
+  if (line.includes('method') || line.includes('(')) return 'method';
+  if (line.includes('trigger')) return 'trigger';
+  return 'global';
+}
+
+/** Extract access modifier from text (fallback method) */
+export function extractAccessModifierFromText(
+  line: string,
+): 'public' | 'private' | 'protected' | 'global' {
+  if (line.includes('global')) return 'global';
+  if (line.includes('public')) return 'public';
+  if (line.includes('private')) return 'private';
+  if (line.includes('protected')) return 'protected';
+  return 'public';
+}
+
+/** Extract static status from text (fallback method) */
+export function extractIsStaticFromText(line: string): boolean {
+  return line.includes('static');
+}
+
+/** Create fallback resolution context using text parsing when no symbols are loaded */
+export function createFallbackChainResolutionContext(
+  documentText: string,
+  position: Position,
+  fileUri: string,
+): SymbolResolutionContext {
+  const lines = documentText.split('\n');
+  const currentLine = lines[position.line] || '';
+
+  const namespaceContext = extractNamespaceFromText(currentLine);
+  const currentScope = determineScopeFromText(currentLine);
+  const accessMod = extractAccessModifierFromText(currentLine);
+  const isStatic = extractIsStaticFromText(currentLine);
+
+  return {
+    sourceFile: fileUri,
+    namespaceContext,
+    currentScope,
+    scopeChain: [currentScope, 'global'],
+    expectedType: undefined,
+    parameterTypes: [],
+    accessModifier: accessMod,
+    isStatic,
+    inheritanceChain: [],
+    interfaceImplementations: [],
+    importStatements: [],
+  };
+}
+
+/** Determine scope from containing symbol */
+export function determineScopeFromSymbol(symbol: ApexSymbol | null): string {
+  if (!symbol) return 'global';
+
+  switch (symbol.kind) {
+    case SymbolKind.Class:
+    case SymbolKind.Interface:
+      return 'class';
+    case SymbolKind.Method:
+      return 'method';
+    case SymbolKind.Trigger:
+      return 'trigger';
+    case SymbolKind.Variable:
+    case SymbolKind.Field:
+      return 'field';
+    default:
+      return 'global';
+  }
+}
+
+/** Extract inheritance chain from class symbols */
+export function extractInheritanceFromSymbols(symbols: ApexSymbol[]): string[] {
+  const inheritanceChain: string[] = [];
+
+  for (const symbol of symbols) {
+    if (symbol.kind === SymbolKind.Class) {
+      const typeSymbol = symbol as TypeSymbol;
+      if (typeSymbol.superClass) {
+        inheritanceChain.push(typeSymbol.superClass);
+      }
+    }
+  }
+
+  return inheritanceChain;
+}
+
+/** Extract interface implementations from class symbols */
+export function extractInterfaceImplementationsFromSymbols(
+  symbols: ApexSymbol[],
+): string[] {
+  const implementations: string[] = [];
+
+  for (const symbol of symbols) {
+    if (symbol.kind === SymbolKind.Class) {
+      const typeSymbol = symbol as TypeSymbol;
+      if (typeSymbol.interfaces && typeSymbol.interfaces.length > 0) {
+        implementations.push(...typeSymbol.interfaces);
+      }
+    }
+  }
+
+  return implementations;
+}
+
+/** Extract access modifier from symbol */
+export function extractAccessModifierFromSymbol(
+  symbol: ApexSymbol | null,
+): 'public' | 'private' | 'protected' | 'global' {
+  if (!symbol || !symbol.modifiers) return 'public';
+
+  if (symbol.modifiers.visibility === SymbolVisibility.Global) return 'global';
+  if (symbol.modifiers.visibility === SymbolVisibility.Public) return 'public';
+  if (symbol.modifiers.visibility === SymbolVisibility.Private)
+    return 'private';
+  if (symbol.modifiers.visibility === SymbolVisibility.Protected)
+    return 'protected';
+
+  return 'public';
+}
+
+/** Extract static status from symbol */
+export function extractIsStaticFromSymbol(symbol: ApexSymbol | null): boolean {
+  if (!symbol || !symbol.modifiers) return false;
+  return symbol.modifiers.isStatic || false;
+}

--- a/packages/apex-parser-ast/src/symbols/ops/stdlibLoading.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/stdlibLoading.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Effect } from 'effect';
+import type { SymbolTable } from '../../types/symbol';
+import { ConcurrencyGuards } from '../services/concurrencyGuards';
+import { SymbolIndexStore } from '../services/symbolIndexStore';
+import { ResourceLoaderService } from '../services/ResourceLoaderService';
+
+/** Check if a type name represents a standard Apex class */
+export const isStandardApexClass = (
+  name: string,
+): Effect.Effect<boolean, never, ResourceLoaderService> =>
+  Effect.gen(function* () {
+    const loader = yield* ResourceLoaderService;
+
+    const parts = name.split('.');
+    if (parts.length === 2) {
+      const [namespace, className] = parts;
+      if (!loader.isStdApexNamespace(namespace)) return false;
+      return loader.hasClass(`${namespace}.${className}.cls`);
+    }
+    if (parts.length === 1) {
+      return loader.findNamespaceForClass(parts[0]).size > 0;
+    }
+    return false;
+  });
+
+/** Get available standard classes from the resource loader */
+export const getAvailableStandardClasses = (): Effect.Effect<
+  string[],
+  never,
+  ResourceLoaderService
+> =>
+  Effect.gen(function* () {
+    const loader = yield* ResourceLoaderService;
+    const namespaces = loader.getStandardNamespaces();
+    const result: string[] = [];
+    for (const [ns, classes] of namespaces) {
+      for (const cls of classes) {
+        result.push(`${ns}/${cls}`);
+      }
+    }
+    return result;
+  });
+
+/**
+ * Resolve a standard Apex class by loading its SymbolTable from the stdlib cache.
+ * Uses ConcurrencyGuards to prevent recursive loops and deduplicate concurrent loads.
+ */
+export const resolveStandardApexClass = (
+  name: string,
+): Effect.Effect<
+  SymbolTable | null,
+  never,
+  ResourceLoaderService | SymbolIndexStore | ConcurrencyGuards
+> =>
+  Effect.gen(function* () {
+    const loader = yield* ResourceLoaderService;
+
+    const guards = yield* ConcurrencyGuards;
+    const isLoading = yield* guards.isLoadingSymbolTable(name);
+    if (isLoading) return null;
+
+    yield* guards.setLoadingSymbolTable(name, true);
+    try {
+      const existing = yield* guards.getInFlightStdlibHydration(name);
+      if (existing) {
+        return yield* Effect.promise(() => existing);
+      }
+
+      const promise = loader.getSymbolTable(`${name}.cls`);
+
+      yield* guards.setInFlightStdlibHydration(name, promise);
+      try {
+        return yield* Effect.promise(() => promise);
+      } finally {
+        Effect.runSync(guards.removeInFlightStdlibHydration(name));
+      }
+    } finally {
+      Effect.runSync(guards.setLoadingSymbolTable(name, false));
+    }
+  });

--- a/packages/apex-parser-ast/src/symbols/ops/symbolLookup.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/symbolLookup.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Effect } from 'effect';
+import type { ApexSymbol, SymbolTable } from '../../types/symbol';
+import { SymbolIndexStore } from '../services/symbolIndexStore';
+import { CacheStore } from '../services/cacheStore';
+import { FileStateStore } from '../services/fileStateStore';
+import { createFileUri, extractFilePath } from '../../types/ProtocolHandler';
+import { extractFilePathFromUri } from '../../types/UriBasedIdGenerator';
+import { isApexKeyword, BUILTIN_TYPE_NAMES } from '../../utils/ApexKeywords';
+import type { ApexComment } from '../../parser/listeners/ApexCommentCollectorListener';
+import { ResourceLoaderService } from '../services/ResourceLoaderService';
+import { BuiltInTypeTablesImpl } from '../../utils/BuiltInTypeTables';
+import { CommentAssociator } from '../../utils/CommentAssociator';
+
+/** Look up a symbol by ID, with cache layer */
+export const getSymbol = (
+  symbolId: string,
+): Effect.Effect<ApexSymbol | null, never, SymbolIndexStore | CacheStore> =>
+  Effect.gen(function* () {
+    const cache = yield* CacheStore;
+    const cached = yield* cache.get<ApexSymbol>(symbolId);
+    if (cached) return cached;
+
+    const index = yield* SymbolIndexStore;
+    const symbol = yield* index.getSymbol(symbolId);
+    if (symbol) {
+      yield* cache.set(symbolId, symbol, 'symbol_lookup');
+    }
+    return symbol;
+  });
+
+/** Find all symbols with a given name, with keyword guard and cache */
+export const findByName = (
+  name: string,
+): Effect.Effect<
+  ApexSymbol[],
+  never,
+  SymbolIndexStore | CacheStore | ResourceLoaderService
+> =>
+  Effect.gen(function* () {
+    const loader = yield* ResourceLoaderService;
+    const isStandardNamespace = loader.isStdApexNamespace(name);
+    const isStdlibPrimitiveTypeName = BUILTIN_TYPE_NAMES.has(
+      name.toLowerCase(),
+    );
+
+    if (
+      isApexKeyword(name) &&
+      !isStandardNamespace &&
+      !isStdlibPrimitiveTypeName
+    ) {
+      return [];
+    }
+
+    const cache = yield* CacheStore;
+    const cacheKey = `symbol_name_${name.toLowerCase()}`;
+    const cached = yield* cache.get<ApexSymbol[]>(cacheKey);
+    if (cached) return cached;
+
+    const index = yield* SymbolIndexStore;
+    const symbols = yield* index.findByName(name);
+    yield* cache.set(cacheKey, symbols, 'symbol_lookup');
+    return symbols;
+  });
+
+/** Find a symbol by its fully qualified name, with cache */
+export const findByFQN = (
+  fqn: string,
+): Effect.Effect<ApexSymbol | null, never, SymbolIndexStore | CacheStore> =>
+  Effect.gen(function* () {
+    const cache = yield* CacheStore;
+    const cacheKey = `symbol_fqn_${fqn}`;
+    const cached = yield* cache.get<ApexSymbol>(cacheKey);
+    if (cached) return cached;
+
+    const index = yield* SymbolIndexStore;
+    const symbol = yield* index.findByFQN(fqn);
+    if (symbol) {
+      yield* cache.set(cacheKey, symbol, 'fqn_lookup');
+    }
+    return symbol ?? null;
+  });
+
+/** Find all symbols matching a given FQN */
+export const findSymbolsByFQN = (
+  fqn: string,
+): Effect.Effect<ApexSymbol[], never, SymbolIndexStore> =>
+  Effect.gen(function* () {
+    const index = yield* SymbolIndexStore;
+    return yield* index.findSymbolsByFQN(fqn);
+  });
+
+/** Find all symbols in a specific file, with cache and URI normalization */
+export const findInFile = (
+  fileUri: string,
+): Effect.Effect<ApexSymbol[], never, SymbolIndexStore | CacheStore> =>
+  Effect.gen(function* () {
+    const cache = yield* CacheStore;
+    const cacheKey = `file_symbols_${fileUri}`;
+    const cached = yield* cache.get<ApexSymbol[]>(cacheKey);
+    if (cached) return cached;
+
+    const properUri = createFileUri(fileUri);
+    const normalizedUri = extractFilePathFromUri(properUri);
+    const index = yield* SymbolIndexStore;
+    const symbols = yield* index.getSymbolsInFile(normalizedUri);
+    yield* cache.set(cacheKey, symbols, 'file_lookup');
+    return symbols;
+  });
+
+/** Find files containing a symbol with the given name */
+export const findFilesForSymbol = (
+  name: string,
+): Effect.Effect<string[], never, SymbolIndexStore> =>
+  Effect.gen(function* () {
+    const index = yield* SymbolIndexStore;
+    const fileUris = yield* index.getFilesForSymbol(name);
+    return fileUris.map((fileUri) =>
+      fileUri.startsWith('file://') ? extractFilePath(fileUri) : fileUri,
+    );
+  });
+
+/** Get all symbols across all files for completion purposes */
+export const getAllSymbolsForCompletion = (): Effect.Effect<
+  ApexSymbol[],
+  never,
+  SymbolIndexStore | CacheStore | FileStateStore
+> =>
+  Effect.gen(function* () {
+    const fileState = yield* FileStateStore;
+    const allMeta = yield* fileState.getAllFileMetadata();
+    const symbols: ApexSymbol[] = [];
+    for (const fileUri of allMeta.keys()) {
+      const fileSymbols = yield* findInFile(fileUri);
+      symbols.push(...fileSymbols);
+    }
+    return symbols;
+  });
+
+/** Get SymbolTable for a file */
+export const getSymbolTableForFile = (
+  fileUri: string,
+): Effect.Effect<SymbolTable | undefined, never, SymbolIndexStore> =>
+  Effect.gen(function* () {
+    const index = yield* SymbolIndexStore;
+    return yield* index.getSymbolTableForFile(fileUri);
+  });
+
+/** Get the FQN for a standard Apex class */
+export const findFQNForStandardClass = (
+  className: string,
+): Effect.Effect<string | null, never, ResourceLoaderService> =>
+  Effect.gen(function* () {
+    const loader = yield* ResourceLoaderService;
+    try {
+      return yield* Effect.promise(() => loader.resolveClassFqn(className));
+    } catch {
+      return null;
+    }
+  });
+
+/** Check if a type name represents a standard library type */
+export const isStandardLibraryType = (
+  name: string,
+): Effect.Effect<boolean, never, ResourceLoaderService> =>
+  Effect.gen(function* () {
+    try {
+      const builtIn = BuiltInTypeTablesImpl.getInstance();
+      if (builtIn.findType(name.toLowerCase())) return true;
+    } catch {
+      // BuiltInTypeTables not initialized
+    }
+
+    const loader = yield* ResourceLoaderService;
+    const parts = name.split('.');
+    if (parts.length === 2) {
+      const [namespace, cls] = parts;
+      if (!loader.isStdApexNamespace(namespace)) return false;
+      return loader.hasClass(`${namespace}.${cls}.cls`);
+    }
+    if (parts.length === 1) {
+      return loader.findNamespaceForClass(parts[0]).size > 0;
+    }
+    return false;
+  });
+
+/** Get documentation block comments associated with a symbol */
+export const getBlockCommentsForSymbol = (
+  symbol: ApexSymbol,
+): Effect.Effect<ApexComment[], never, FileStateStore> =>
+  Effect.gen(function* () {
+    const fileUri = symbol.fileUri || '';
+    if (!fileUri) return [];
+    const fileState = yield* FileStateStore;
+    const associations = yield* fileState.getCommentAssociations(fileUri);
+    if (!associations || associations.length === 0) return [];
+    const key =
+      symbol.key?.unifiedId ||
+      `${symbol.kind}:${symbol.name}:${symbol.fileUri}`;
+    const associator = new CommentAssociator();
+    return associator.getDocumentationForSymbol(key, associations);
+  });

--- a/packages/apex-parser-ast/src/symbols/ops/symbolMutation.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/symbolMutation.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Effect } from 'effect';
+import type { CommentAssociation } from '../../parser/listeners/ApexCommentCollectorListener';
+import { SymbolIndexStore } from '../services/symbolIndexStore';
+import { ReferenceStore } from '../services/referenceStore';
+import { CacheStore } from '../services/cacheStore';
+import { FileStateStore } from '../services/fileStateStore';
+import { createFileUri } from '../../types/ProtocolHandler';
+import { extractFilePathFromUri } from '../../types/UriBasedIdGenerator';
+
+type MutationDeps =
+  | SymbolIndexStore
+  | ReferenceStore
+  | CacheStore
+  | FileStateStore;
+
+/** Remove a file and all its symbols from the graph, cache, and state */
+export const removeFile = (
+  fileUri: string,
+): Effect.Effect<void, never, MutationDeps> =>
+  Effect.gen(function* () {
+    const properUri = createFileUri(fileUri);
+    const normalizedUri = extractFilePathFromUri(properUri);
+
+    const index = yield* SymbolIndexStore;
+    yield* index.removeFile(normalizedUri);
+
+    const fileState = yield* FileStateStore;
+    yield* fileState.removeFileMetadata(normalizedUri);
+    yield* fileState.removeLastProcessedTableState(normalizedUri);
+
+    const cache = yield* CacheStore;
+    yield* cache.invalidatePattern(normalizedUri);
+  });
+
+/** Clear all symbols, references, cache, and state */
+export const clear = (): Effect.Effect<void, never, MutationDeps> =>
+  Effect.gen(function* () {
+    const index = yield* SymbolIndexStore;
+    yield* index.clear();
+
+    const refs = yield* ReferenceStore;
+    yield* refs.clear();
+
+    const cache = yield* CacheStore;
+    yield* cache.clear();
+
+    const fileState = yield* FileStateStore;
+    yield* fileState.clear();
+  });
+
+/** Optimize memory by cleaning up caches */
+export const optimizeMemory = (): Effect.Effect<void, never, CacheStore> =>
+  Effect.gen(function* () {
+    const cache = yield* CacheStore;
+    yield* cache.optimize();
+  });
+
+/** Store per-file comment associations */
+export const setCommentAssociations = (
+  fileUri: string,
+  associations: CommentAssociation[],
+): Effect.Effect<void, never, FileStateStore> =>
+  Effect.gen(function* () {
+    const fileState = yield* FileStateStore;
+    yield* fileState.setCommentAssociations(fileUri, associations || []);
+  });

--- a/packages/apex-parser-ast/src/symbols/ops/symbolProvider.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/symbolProvider.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Effect } from 'effect';
+import { type ApexSymbol, SymbolKind } from '../../types/symbol';
+import { SymbolIndexStore } from '../services/symbolIndexStore';
+import { CacheStore } from '../services/cacheStore';
+import { ResourceLoaderService } from '../services/ResourceLoaderService';
+import { BuiltInTypeTablesImpl } from '../../utils/BuiltInTypeTables';
+import { findByName, findByFQN } from './symbolLookup';
+
+type ProviderDeps = SymbolIndexStore | CacheStore | ResourceLoaderService;
+
+function tryGetBuiltInTypes(): BuiltInTypeTablesImpl | undefined {
+  try {
+    return BuiltInTypeTablesImpl.getInstance();
+  } catch {
+    return undefined;
+  }
+}
+
+/** Resolve a symbol by full name with namespace-aware fallback */
+export const find = (
+  referencingType: ApexSymbol,
+  fullName: string,
+): Effect.Effect<ApexSymbol | null, never, ProviderDeps> =>
+  Effect.gen(function* () {
+    const byFqn = yield* findByFQN(fullName);
+    if (byFqn) return byFqn;
+
+    if (fullName.includes('.')) {
+      const [namespace, typeName] = fullName.split('.', 2);
+      const byName = yield* findByName(typeName);
+      const namespaceCandidates = byName.filter((candidate) => {
+        const ns =
+          typeof candidate.namespace === 'string'
+            ? candidate.namespace
+            : (candidate.namespace?.toString?.() ?? '');
+        return ns.toLowerCase() === namespace.toLowerCase();
+      });
+      const typeMatch = namespaceCandidates.find(
+        (c) =>
+          c.kind === SymbolKind.Class ||
+          c.kind === SymbolKind.Interface ||
+          c.kind === SymbolKind.Enum ||
+          c.kind === SymbolKind.Trigger,
+      );
+      if (typeMatch) return typeMatch;
+      if (namespaceCandidates.length > 0) return namespaceCandidates[0];
+
+      const loader = yield* ResourceLoaderService;
+      if (loader.isStdApexNamespace(namespace)) {
+        const stdlibTable = yield* Effect.promise(() =>
+          loader.getSymbolTable(`${namespace}/${typeName}.cls`),
+        );
+        const classSymbol = stdlibTable
+          ?.getAllSymbols()
+          .find(
+            (c) =>
+              c.kind === SymbolKind.Class &&
+              c.name.toLowerCase() === typeName.toLowerCase(),
+          );
+        if (classSymbol) return classSymbol;
+      }
+    }
+
+    const symbols = yield* findByName(fullName);
+    return symbols.length > 0 ? symbols[0] : null;
+  });
+
+/** Find a scalar keyword type (void, null) — not wrapper types like String */
+export const findScalarKeywordType = (
+  name: string,
+): Effect.Effect<ApexSymbol | null> =>
+  Effect.sync(() => {
+    const builtIn = tryGetBuiltInTypes();
+    return builtIn?.findType(name.toLowerCase()) ?? null;
+  });
+
+/** Find an SObject type by name */
+export const findSObjectType = (
+  name: string,
+): Effect.Effect<ApexSymbol | null, never, ProviderDeps> =>
+  Effect.gen(function* () {
+    const symbols = yield* findByName(name);
+    return (
+      symbols.find((s) => s.kind === 'class' && s.namespace === 'SObject') ??
+      null
+    );
+  });
+
+/** Find a type from an external package */
+export const findExternalType = (
+  name: string,
+  packageName: string,
+): Effect.Effect<ApexSymbol | null, never, ProviderDeps> =>
+  Effect.gen(function* () {
+    const symbols = yield* findByName(name);
+    return symbols.find((s) => s.namespace === packageName) ?? null;
+  });
+
+/** Resolve an unqualified name using default namespace order (System, Schema) */
+export const findInDefaultNamespaceOrder = (
+  name: string,
+  referencingType: ApexSymbol,
+): Effect.Effect<ApexSymbol | null, never, ProviderDeps> =>
+  Effect.gen(function* () {
+    const namespaces = ['System', 'Schema'];
+    for (const ns of namespaces) {
+      const result = yield* findInExplicitNamespace(ns, name, referencingType);
+      if (result) return result;
+    }
+    return null;
+  });
+
+/** Resolve an unqualified name in implicit file namespaces by slot */
+export const findInImplicitFileNamespaceSlot = (
+  name: string,
+  slot: number,
+  referencingType: ApexSymbol,
+): Effect.Effect<ApexSymbol | null, never, ProviderDeps> =>
+  Effect.gen(function* () {
+    const namespaces = ['System', 'Schema'];
+    const ns = namespaces[slot];
+    if (!ns) return null;
+    return yield* findInExplicitNamespace(ns, name, referencingType);
+  });
+
+/** Resolve a type by explicit namespace and unqualified type name */
+export const findInExplicitNamespace = (
+  namespaceName: string,
+  typeName: string,
+  referencingType: ApexSymbol,
+): Effect.Effect<ApexSymbol | null, never, ProviderDeps> =>
+  Effect.gen(function* () {
+    const fqn = `${namespaceName.toLowerCase()}.${typeName}`;
+    const byFind = yield* find(referencingType, fqn);
+    if (byFind) return byFind;
+    return yield* findScalarKeywordType(fqn);
+  });
+
+/** Whether the namespace token is a known built-in namespace alias */
+export const isBuiltInNamespace = (
+  namespaceName: string,
+): Effect.Effect<boolean, never, ResourceLoaderService> =>
+  Effect.gen(function* () {
+    if (!namespaceName) return false;
+    const loader = yield* ResourceLoaderService;
+    if (loader.isStdApexNamespace(namespaceName)) return true;
+    const n = namespaceName.toLowerCase();
+    return n === 'system' || n === 'schema';
+  });
+
+/** Whether the namespace should be treated as an SObject container */
+export const isSObjectContainerNamespace = (
+  namespaceName: string,
+): Effect.Effect<boolean> =>
+  Effect.succeed(namespaceName.toLowerCase() === 'schema');

--- a/packages/apex-parser-ast/src/symbols/ops/symbolRefResolution.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/symbolRefResolution.ts
@@ -1,0 +1,1029 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Effect } from 'effect';
+import { HashMap } from 'data-structure-typed';
+import type { ApexSymbol, SymbolTable } from '../../types/symbol';
+import { SymbolKind } from '../../types/symbol';
+import type { SymbolReference } from '../../types/symbolReference';
+import { ReferenceContext } from '../../types/symbolReference';
+import {
+  isChainedSymbolReference,
+  isBlockSymbol,
+  inTypeSymbolGroup,
+} from '../../utils/symbolNarrowing';
+import { createFileUri, isStandardApexUri } from '../../types/ProtocolHandler';
+import { extractFilePathFromUri } from '../../types/UriBasedIdGenerator';
+import { STANDARD_APEX_LIBRARY_URI } from '../../utils/ResourceUtils';
+import {
+  GlobalTypeRegistry,
+  GlobalTypeRegistryLive,
+} from '../../services/GlobalTypeRegistryService';
+import type { SymbolManagerOps } from '../services/symbolResolver';
+
+/**
+ * Extract qualifier and member information from a SymbolReference.
+ * Handles both chained references (using chainNodes) and simple dot-notation references.
+ */
+export function extractQualifierFromChain(typeRef: SymbolReference): {
+  qualifier: string;
+  member: string;
+  isQualified: boolean;
+} | null {
+  if (isChainedSymbolReference(typeRef)) {
+    const chainNodes = typeRef.chainNodes;
+
+    if (chainNodes && chainNodes.length >= 2) {
+      const qualifier = chainNodes[0].name;
+      const member = chainNodes[1].name;
+
+      return {
+        qualifier,
+        member,
+        isQualified: true,
+      };
+    }
+  }
+
+  if (typeRef.name.includes('.')) {
+    const parts = typeRef.name.split('.');
+    if (parts.length >= 2) {
+      const qualifier = parts.slice(0, -1).join('.');
+      const member = parts[parts.length - 1];
+
+      return {
+        qualifier,
+        member,
+        isQualified: true,
+      };
+    }
+  }
+
+  return null;
+}
+
+export function normalizeTypeNameForLookup(typeName: string): string {
+  return typeName.trim().replace(/<.*>/g, '').replace(/\[\]$/, '');
+}
+
+export function buildTypeLookupCandidates(typeName: string): string[] {
+  const normalized = normalizeTypeNameForLookup(typeName);
+  const candidates: string[] = [];
+  const seenLowercase = new Set<string>();
+  const push = (value: string): void => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+    const normalizedCandidate = trimmed.toLowerCase();
+    if (!seenLowercase.has(normalizedCandidate)) {
+      seenLowercase.add(normalizedCandidate);
+      candidates.push(trimmed);
+    }
+  };
+
+  push(normalized);
+  const parts = normalized.split('.').filter((p) => p.length > 0);
+  if (parts.length > 1) {
+    for (let i = 1; i < parts.length; i++) {
+      push(parts.slice(i).join('.'));
+    }
+    push(parts[parts.length - 1]);
+  }
+
+  return candidates;
+}
+
+export async function resolvePreferredTypeSymbolForLookup(
+  self: SymbolManagerOps,
+  rawTypeName: string,
+  fileUri?: string,
+  symbolTable?: SymbolTable,
+): Promise<ApexSymbol | null> {
+  const candidates = buildTypeLookupCandidates(rawTypeName);
+  const normalizedUri = fileUri
+    ? extractFilePathFromUri(createFileUri(fileUri))
+    : null;
+  const localTypeSymbols = symbolTable
+    ? symbolTable.getAllSymbols().filter(inTypeSymbolGroup)
+    : [];
+  const localById = new HashMap<string, ApexSymbol>();
+  for (const symbol of localTypeSymbols) {
+    localById.set(symbol.id, symbol);
+  }
+
+  const matchesCandidate = (symbol: ApexSymbol, candidate: string): boolean => {
+    if (symbol.name?.toLowerCase() === candidate.toLowerCase()) {
+      return true;
+    }
+    const fqn = (symbol as any)?.fqn as string | undefined;
+    if (fqn && fqn.toLowerCase() === candidate.toLowerCase()) {
+      return true;
+    }
+
+    const parts = candidate.split('.').filter((p) => p.length > 0);
+    if (
+      parts.length >= 2 &&
+      symbol.name?.toLowerCase() === parts[parts.length - 1].toLowerCase()
+    ) {
+      const parent = symbol.parentId
+        ? localById.get(symbol.parentId)
+        : undefined;
+      if (
+        parent?.name?.toLowerCase() === parts[parts.length - 2].toLowerCase()
+      ) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  for (const candidate of candidates) {
+    const localMatch = localTypeSymbols.find((s) =>
+      matchesCandidate(s, candidate),
+    );
+    if (localMatch) {
+      return localMatch;
+    }
+  }
+
+  for (const candidate of candidates) {
+    const typeCandidates = (await self.findSymbolByName(candidate)).filter(
+      inTypeSymbolGroup,
+    );
+    if (normalizedUri) {
+      const sameFile = typeCandidates.find((s) => s.fileUri === normalizedUri);
+      if (sameFile) {
+        return sameFile;
+      }
+    }
+    if (typeCandidates.length > 0) {
+      return typeCandidates[0];
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Validate that a type reference name is valid for resolution.
+ *
+ * The parser/listener extracts identifiers from parser nodes (id()?.text, typeName(), etc.),
+ * which are already validated by the ANTLR lexer/parser. This check only ensures we have a
+ * non-empty name before attempting resolution.
+ */
+export function isValidSymbolReferenceName(name: string): boolean {
+  return !!(name && name.length > 0);
+}
+
+/** Check if a name represents a valid namespace */
+export async function isValidNamespace(
+  self: SymbolManagerOps,
+  name: string,
+): Promise<boolean> {
+  if (self.isStandardApexClass(name)) {
+    return true;
+  }
+
+  const namespaceSymbols = await findSymbolsInNamespace(self, name);
+  return namespaceSymbols.length > 0;
+}
+
+/** Find all symbols in a given namespace */
+export async function findSymbolsInNamespace(
+  self: SymbolManagerOps,
+  namespaceName: string,
+): Promise<ApexSymbol[]> {
+  const allSymbols = await self.getAllSymbols();
+  return allSymbols.filter((symbol: ApexSymbol) => {
+    if (symbol.fileUri && isStandardApexUri(symbol.fileUri)) {
+      const pathParts = symbol.fileUri.split('/');
+      if (pathParts.length >= 2) {
+        const namespace = pathParts[1];
+        return namespace.toLowerCase() === namespaceName.toLowerCase();
+      }
+    }
+    return false;
+  });
+}
+
+/**
+ * Resolve an unqualified type reference using scope-based resolution.
+ * Walks the scope hierarchy from innermost to outermost looking for matching symbols.
+ */
+export function resolveUnqualifiedReferenceByScope(
+  self: SymbolManagerOps,
+  typeReference: SymbolReference,
+  sourceFile: string,
+  position: { line: number; character: number },
+): ApexSymbol | null {
+  try {
+    const symbolTable = self.symbolRefManager.getSymbolTableForFile(sourceFile);
+    if (!symbolTable) {
+      return null;
+    }
+
+    const scopeHierarchy = symbolTable.getScopeHierarchy(position);
+    const allFileSymbols = symbolTable.getAllSymbols();
+
+    const innermostToOutermost = [...scopeHierarchy].reverse();
+    for (const blockSymbol of innermostToOutermost) {
+      const isClassOrFileLevel =
+        isBlockSymbol(blockSymbol) &&
+        (blockSymbol.scopeType === 'class' || blockSymbol.scopeType === 'file');
+      const directChildren = allFileSymbols.filter(
+        (symbol) =>
+          symbol.name?.toLowerCase() === typeReference.name.toLowerCase() &&
+          symbol.parentId === blockSymbol.id &&
+          (((symbol.kind === SymbolKind.Variable ||
+            symbol.kind === SymbolKind.Parameter) &&
+            !isClassOrFileLevel) ||
+            symbol.kind === SymbolKind.Method),
+      );
+
+      const nestedBlocks = allFileSymbols.filter((s) => {
+        if (s.kind !== SymbolKind.Block || s.parentId !== blockSymbol.id) {
+          return false;
+        }
+        return scopeHierarchy.some(
+          (hierarchyBlock) => hierarchyBlock.id === s.id,
+        );
+      });
+      const symbolsInNestedBlocks: ApexSymbol[] = [];
+      for (const nestedBlock of nestedBlocks) {
+        const isInHierarchy = scopeHierarchy.some(
+          (hierarchyBlock) => hierarchyBlock.id === nestedBlock.id,
+        );
+        if (!isInHierarchy) {
+          continue;
+        }
+        const nestedSymbols = allFileSymbols.filter(
+          (symbol) =>
+            symbol.name === typeReference.name &&
+            symbol.parentId === nestedBlock.id &&
+            (symbol.kind === SymbolKind.Variable ||
+              symbol.kind === SymbolKind.Parameter ||
+              symbol.kind === SymbolKind.Method),
+        );
+        symbolsInNestedBlocks.push(...nestedSymbols);
+      }
+
+      const symbolsInScope = [...directChildren, ...symbolsInNestedBlocks];
+
+      if (symbolsInScope.length > 0) {
+        const validSymbols = symbolsInScope.filter((symbol) => {
+          if (
+            symbol.kind === SymbolKind.Variable ||
+            symbol.kind === SymbolKind.Parameter
+          ) {
+            const symbolBlock = allFileSymbols.find(
+              (s) => s.kind === SymbolKind.Block && s.id === symbol.parentId,
+            );
+            if (symbolBlock && isBlockSymbol(symbolBlock)) {
+              return scopeHierarchy.some(
+                (hierarchyBlock) => hierarchyBlock.id === symbolBlock.id,
+              );
+            }
+            return false;
+          }
+          return true;
+        });
+
+        if (validSymbols.length > 0) {
+          const prioritized = validSymbols.sort((a, b) => {
+            const aIsVar =
+              a.kind === SymbolKind.Variable || a.kind === SymbolKind.Parameter;
+            const bIsVar =
+              b.kind === SymbolKind.Variable || b.kind === SymbolKind.Parameter;
+            if (aIsVar && !bIsVar) return -1;
+            if (!aIsVar && bIsVar) return 1;
+            return 0;
+          });
+          return prioritized[0];
+        }
+      }
+    }
+
+    const parentScopeSearchOrder = [...scopeHierarchy].reverse();
+    for (const blockSymbol of parentScopeSearchOrder) {
+      if (!isBlockSymbol(blockSymbol)) {
+        continue;
+      }
+
+      const isClassOrFileLevel =
+        blockSymbol.scopeType === 'class' || blockSymbol.scopeType === 'file';
+      const isMethodLevel = blockSymbol.scopeType === 'method';
+
+      if (isClassOrFileLevel) {
+        const classFields = allFileSymbols.filter(
+          (s) =>
+            s.name === typeReference.name &&
+            s.parentId === blockSymbol.id &&
+            s.kind === SymbolKind.Field,
+        );
+        if (classFields.length > 0) {
+          return classFields[0];
+        }
+        const classMethods = allFileSymbols.filter(
+          (s) =>
+            s.name === typeReference.name &&
+            s.parentId === blockSymbol.id &&
+            s.kind === SymbolKind.Method,
+        );
+        if (classMethods.length > 0) {
+          return classMethods[0];
+        }
+      }
+
+      if (isMethodLevel) {
+        const parameters = allFileSymbols.filter(
+          (s) =>
+            s.name === typeReference.name &&
+            s.parentId === blockSymbol.id &&
+            s.kind === SymbolKind.Parameter,
+        );
+        if (parameters.length > 0) {
+          return parameters[0];
+        }
+      }
+    }
+
+    for (const blockSymbol of parentScopeSearchOrder) {
+      if (!isBlockSymbol(blockSymbol)) {
+        continue;
+      }
+      if (blockSymbol.scopeType === 'method' && blockSymbol.parentId) {
+        const directClassBlock = allFileSymbols.find(
+          (s) =>
+            isBlockSymbol(s) &&
+            s.scopeType === 'class' &&
+            s.id === blockSymbol.parentId,
+        );
+        if (directClassBlock) {
+          const classFields = allFileSymbols.filter(
+            (s) =>
+              s.name === typeReference.name &&
+              s.parentId === directClassBlock.id &&
+              s.kind === SymbolKind.Field,
+          );
+          if (classFields.length > 0) {
+            return classFields[0];
+          }
+          const classMethods = allFileSymbols.filter(
+            (s) =>
+              s.name === typeReference.name &&
+              s.parentId === directClassBlock.id &&
+              s.kind === SymbolKind.Method,
+          );
+          if (classMethods.length > 0) {
+            return classMethods[0];
+          }
+        }
+
+        const methodSymbol = allFileSymbols.find(
+          (s) => s.id === blockSymbol.parentId && s.kind === SymbolKind.Method,
+        );
+        if (methodSymbol && methodSymbol.parentId) {
+          const classBlock = allFileSymbols.find(
+            (s) =>
+              isBlockSymbol(s) &&
+              s.scopeType === 'class' &&
+              s.id === methodSymbol.parentId,
+          );
+          if (classBlock) {
+            const classFields = allFileSymbols.filter(
+              (s) =>
+                s.name === typeReference.name &&
+                s.parentId === classBlock.id &&
+                s.kind === SymbolKind.Field,
+            );
+            if (classFields.length > 0) {
+              return classFields[0];
+            }
+            const classMethods = allFileSymbols.filter(
+              (s) =>
+                s.name === typeReference.name &&
+                s.parentId === classBlock.id &&
+                s.kind === SymbolKind.Method,
+            );
+            if (classMethods.length > 0) {
+              return classMethods[0];
+            }
+          }
+        }
+      }
+    }
+    return null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+/** Determine if a reference is static based on its context (with caching) */
+export async function isStaticReference(
+  self: SymbolManagerOps,
+  typeRef: SymbolReference,
+): Promise<boolean> {
+  const cached = self.isStaticCache.get(typeRef);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const result = await computeIsStaticReference(self, typeRef);
+
+  self.isStaticCache.set(typeRef, result);
+  return result;
+}
+
+/** Compute whether a reference is static (internal implementation) */
+export async function computeIsStaticReference(
+  self: SymbolManagerOps,
+  typeRef: SymbolReference,
+): Promise<boolean> {
+  const qualifierInfo = extractQualifierFromChain(typeRef);
+  if (qualifierInfo && qualifierInfo.isQualified) {
+    const qualifierSymbols = await self.findSymbolByName(
+      qualifierInfo.qualifier,
+    );
+    if (qualifierSymbols.length > 0) {
+      const qualifierSymbol = qualifierSymbols[0];
+      return qualifierSymbol.kind === SymbolKind.Class;
+    }
+
+    let qualifierRef: SymbolReference;
+    if (isChainedSymbolReference(typeRef) && typeRef.chainNodes.length >= 2) {
+      qualifierRef = typeRef.chainNodes[0];
+    } else {
+      qualifierRef = {
+        name: qualifierInfo.qualifier,
+        context: ReferenceContext.NAMESPACE,
+        location: typeRef.location,
+        resolvedSymbolId: undefined,
+      };
+    }
+    const builtInQualifier =
+      await self.resolveStandardLibraryType(qualifierRef);
+    if (builtInQualifier) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/** Check if a symbol is accessible from a given file */
+export function isSymbolAccessibleFromFile(
+  symbol: ApexSymbol,
+  sourceFile: string,
+): boolean {
+  if (symbol.modifiers?.isBuiltIn) return true;
+  if (symbol.key.path[0] === sourceFile) return true;
+  if (symbol.modifiers?.visibility === 'global') return true;
+  if (symbol.modifiers?.visibility === 'public') return true;
+  return false;
+}
+
+function calculateSymbolSize(symbol: ApexSymbol): number {
+  if (!symbol.location) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  const { startLine, startColumn, endLine, endColumn } =
+    symbol.location.identifierRange;
+
+  const lineCount = endLine - startLine + 1;
+  const columnCount = endColumn - startColumn + 1;
+
+  return lineCount * 100 + columnCount;
+}
+
+/** Select the most specific symbol from a list of candidates */
+export function selectMostSpecificSymbol(
+  candidates: ApexSymbol[],
+  sourceFile: string,
+): ApexSymbol {
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+
+  const sameFileCandidates = candidates.filter(
+    (s) => s.key.path[0] === sourceFile,
+  );
+  if (sameFileCandidates.length > 0) {
+    candidates = sameFileCandidates;
+  }
+
+  candidates.sort((a, b) => {
+    const aSize = calculateSymbolSize(a);
+    const bSize = calculateSymbolSize(b);
+
+    if (Math.abs(aSize - bSize) > 10) {
+      const result = aSize - bSize;
+      return result;
+    }
+
+    const priorityOrder = [
+      'parameter',
+      'variable',
+      'field',
+      'method',
+      'constructor',
+      'class',
+      'interface',
+      'enum',
+    ];
+    const aPriority = priorityOrder.indexOf(a.kind) ?? 999;
+    const bPriority = priorityOrder.indexOf(b.kind) ?? 999;
+    const result = aPriority - bPriority;
+    return result;
+  });
+
+  return candidates[0];
+}
+
+export function isStandardApexClass(
+  self: SymbolManagerOps,
+  name: string,
+): boolean {
+  const parts = name.split('.');
+  const namespace = parts[0];
+  const className = parts[1];
+
+  if (parts.length === 2) {
+    if (!self.stdlibProvider.isStdApexNamespace(namespace)) {
+      return false;
+    }
+    return self.stdlibProvider.hasClass(`${namespace}.${className}.cls`);
+  }
+
+  if (parts.length === 1) {
+    const classNamespaces = self.stdlibProvider.findNamespaceForClass(parts[0]);
+    return classNamespaces.size > 0;
+  }
+
+  return false;
+}
+
+export async function resolveStandardLibraryType(
+  self: SymbolManagerOps,
+  typeRef: SymbolReference,
+): Promise<ApexSymbol | null> {
+  const name = typeRef.name;
+
+  if (!isValidSymbolReferenceName(name)) {
+    return null;
+  }
+
+  try {
+    if (isChainedSymbolReference(typeRef)) {
+      const chainNodes = typeRef.chainNodes;
+
+      if (chainNodes.length === 2) {
+        const qualifierNode = chainNodes[0];
+        const memberNode = chainNodes[1];
+
+        const qualifierSymbol = await resolveStandardLibraryType(
+          self,
+          qualifierNode,
+        );
+        if (qualifierSymbol) {
+          if (
+            memberNode.context === ReferenceContext.METHOD_CALL ||
+            memberNode.context === ReferenceContext.FIELD_ACCESS
+          ) {
+            const memberType =
+              memberNode.context === ReferenceContext.METHOD_CALL
+                ? 'method'
+                : 'property';
+            const resolvedMember = await self.resolveMemberInContext(
+              { type: 'symbol', symbol: qualifierSymbol },
+              memberNode.name,
+              memberType,
+            );
+            if (resolvedMember) {
+              self.logger.debug(
+                () =>
+                  `Resolved "${name}" via chain member lookup: ${resolvedMember.name}`,
+              );
+              return resolvedMember;
+            }
+          } else {
+            const fqn = `${qualifierNode.name}.${memberNode.name}`;
+            const memberSymbol = await resolveStandardApexClass(self, fqn);
+            if (memberSymbol) {
+              self.logger.debug(
+                () =>
+                  `Resolved "${name}" via chain nodes as ${fqn}: ${memberSymbol.name}`,
+              );
+              return memberSymbol;
+            }
+          }
+        }
+      }
+    }
+
+    const isStandard = self.isStandardApexClass(name);
+    const isStandardNamespace = self.stdlibProvider.isStdApexNamespace(name);
+
+    if (isStandard || isStandardNamespace) {
+      let standardClass: ApexSymbol | null = null;
+
+      if (name.includes('.')) {
+        standardClass = await resolveStandardApexClass(self, name);
+      } else {
+        const fqn = await self.findFQNForStandardClass(name);
+        if (fqn) {
+          standardClass = await resolveStandardApexClass(self, fqn);
+        }
+        if (!standardClass && isStandardNamespace) {
+          const namespaceClassFqn = `${name}.${name}`;
+          standardClass = await resolveStandardApexClass(
+            self,
+            namespaceClassFqn,
+          );
+        }
+      }
+
+      if (standardClass) {
+        return standardClass;
+      }
+    }
+
+    if (!name.includes('.')) {
+      const scalarKeyword = await self.findScalarKeywordType(name);
+      if (scalarKeyword) {
+        return {
+          ...scalarKeyword,
+          modifiers: {
+            ...scalarKeyword.modifiers,
+            isBuiltIn: true,
+          },
+        };
+      }
+
+      const fqn = await self.findFQNForStandardClass(name);
+      if (fqn) {
+        const standardClass = await resolveStandardApexClass(self, fqn);
+        if (standardClass) {
+          return standardClass;
+        }
+      }
+    }
+
+    const scalarKeywordFallback = await self.findScalarKeywordType(name);
+    if (scalarKeywordFallback) {
+      return {
+        ...scalarKeywordFallback,
+        modifiers: {
+          ...scalarKeywordFallback.modifiers,
+          isBuiltIn: true,
+        },
+      };
+    }
+
+    return null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+export async function resolveStandardApexClass(
+  self: SymbolManagerOps,
+  name: string,
+): Promise<ApexSymbol | null> {
+  try {
+    try {
+      const registryLookup = Effect.gen(function* () {
+        const registry = yield* GlobalTypeRegistry;
+        return yield* registry.resolveType(name);
+      });
+
+      const registryEntry = await Effect.runPromise(
+        registryLookup.pipe(Effect.provide(GlobalTypeRegistryLive)),
+      );
+
+      if (registryEntry) {
+        self.logger.debug(
+          () =>
+            `[resolveStandardApexClass] Found "${name}" in GlobalTypeRegistry: ${registryEntry.fqn}`,
+        );
+
+        let symbol = self.symbolRefManager.getSymbol(registryEntry.symbolId);
+        if (symbol) {
+          return symbol;
+        }
+
+        const match = registryEntry.fileUri.match(
+          /apexlib:\/\/resources\/StandardApexLibrary\/(.+\.cls)$/,
+        );
+        if (match) {
+          const classPath = match[1];
+          const symbolTable = await loadAndRegisterStdlibSymbolTable(
+            self,
+            registryEntry.fileUri,
+            classPath,
+          );
+          if (symbolTable) {
+            const symbols = symbolTable.getAllSymbols();
+            const foundSymbol = symbols.find(
+              (s) =>
+                s.name?.toLowerCase() === registryEntry.name.toLowerCase() &&
+                s.kind === SymbolKind.Class,
+            );
+            if (foundSymbol) {
+              self.logger.debug(
+                () =>
+                  `[resolveStandardApexClass] Loaded "${name}" from cache and found in graph`,
+              );
+              return foundSymbol;
+            } else {
+              self.logger.debug(
+                () =>
+                  `[resolveStandardApexClass] Found registry entry for "${name}" ` +
+                  'but symbol not found after loading from cache',
+              );
+            }
+          } else {
+            self.logger.debug(
+              () =>
+                `[resolveStandardApexClass] Found registry entry for "${name}" but getSymbolTable returned null`,
+            );
+          }
+        } else {
+          self.logger.debug(
+            () =>
+              `[resolveStandardApexClass] Found registry entry for "${name}" but ` +
+              `fileUri doesn't match apexlib://resources/StandardApexLibrary/ pattern: ${registryEntry.fileUri}`,
+          );
+        }
+      } else {
+        self.logger.debug(
+          () =>
+            `[resolveStandardApexClass] "${name}" not found in GlobalTypeRegistry, falling through to cache loading`,
+        );
+      }
+    } catch (error) {
+      self.logger.debug(
+        () =>
+          `[resolveStandardApexClass] GlobalTypeRegistry lookup failed for "${name}": ${error}`,
+      );
+    }
+
+    const parts = name.split('.');
+
+    let namespace: string;
+    let className: string;
+
+    if (parts.length < 2) {
+      const classNamespaces = self.stdlibProvider.findNamespaceForClass(
+        parts[0],
+      );
+
+      if (classNamespaces.size === 0) {
+        // Sync index empty (enrichment worker) — try async FQN resolution via provider
+        const fqn = await self.stdlibProvider.resolveClassFqn(parts[0]);
+        if (fqn) {
+          return resolveStandardApexClass(self, fqn);
+        }
+        self.logger.debug(
+          () => `Class "${parts[0]}" not found in any standard namespace`,
+        );
+        return null;
+      }
+
+      if (classNamespaces.size > 1) {
+        const namespaceList = Array.from(classNamespaces).join(', ');
+        self.logger.debug(
+          () =>
+            `Ambiguous class name "${parts[0]}" found in ${classNamespaces.size} namespaces: ${namespaceList}`,
+        );
+        return null;
+      }
+
+      namespace = Array.from(classNamespaces)[0];
+      className = parts[0];
+    } else {
+      namespace = parts[0];
+      className = parts[1];
+    }
+
+    self.logger.debug(
+      () =>
+        `[resolveStandardApexClass] Resolving "${name}" -> namespace="${namespace}", className="${className}"`,
+    );
+
+    let classPath = `${namespace}/${className}.cls`;
+
+    const namespaceStructure = self.stdlibProvider.getStandardNamespaces();
+    let classes = namespaceStructure.get(namespace);
+    if (!classes) {
+      for (const [nsKey, nsClasses] of namespaceStructure.entries()) {
+        if (nsKey.toLowerCase() === namespace.toLowerCase()) {
+          classes = nsClasses;
+          namespace = nsKey;
+          break;
+        }
+      }
+    }
+
+    if (classes) {
+      const target = className.toLowerCase();
+
+      for (const classFile of classes) {
+        const cleanClassName = classFile.replace(/\.cls$/, '');
+
+        if (cleanClassName.toLowerCase() === target) {
+          classPath = `${namespace}/${cleanClassName}.cls`;
+          self.logger.debug(
+            () =>
+              `Found class in namespace structure: ${classPath} (searched for ${name})`,
+          );
+          break;
+        }
+      }
+    } else {
+      self.logger.debug(
+        () =>
+          `Namespace "${namespace}" not found in stdlib provider namespace structure`,
+      );
+    }
+
+    const isStandardNamespace =
+      self.stdlibProvider.isStdApexNamespace(namespace);
+    const hasClass = self.stdlibProvider.hasClass(classPath);
+
+    if (!hasClass && !isStandardNamespace) {
+      // Sync index empty (enrichment worker) — attempt direct async load
+      const symbolTable = await self.stdlibProvider.getSymbolTable(classPath);
+      if (symbolTable) {
+        const fileUri = `${STANDARD_APEX_LIBRARY_URI}/${classPath}`;
+        await self.addSymbolTableAsync(symbolTable, fileUri);
+        const found = symbolTable
+          .getAllSymbols()
+          .find(
+            (s) =>
+              s.name?.toLowerCase() === className.toLowerCase() &&
+              s.kind === SymbolKind.Class,
+          );
+        return found ?? null;
+      }
+      self.logger.debug(
+        () =>
+          `Class not found in stdlib provider: ${classPath} (searched for ${name})`,
+      );
+      return null;
+    }
+
+    if (!hasClass && isStandardNamespace) {
+      self.logger.debug(
+        () =>
+          `Standard namespace "${namespace}" - trying to load ${classPath} even though hasClass returned false`,
+      );
+    }
+
+    const fileUri = `${STANDARD_APEX_LIBRARY_URI}/${classPath}`;
+    if (self.loadingSymbolTables.has(fileUri)) {
+      const graphSymbols = await self.findSymbolByName(className);
+      const graphClassSymbols = graphSymbols.filter(
+        (s) =>
+          s.kind === SymbolKind.Class &&
+          (s.fileUri === fileUri ||
+            s.fileUri?.includes('StandardApexLibrary') ||
+            s.fileUri?.includes('apexlib://')),
+      );
+      if (graphClassSymbols.length > 0) {
+        const fileSymbol = graphClassSymbols.find((s) => s.fileUri === fileUri);
+        if (fileSymbol) {
+          return fileSymbol;
+        }
+        const standardSymbol = graphClassSymbols.find(
+          (s) =>
+            s.fileUri?.includes('apexlib://') ||
+            s.fileUri?.includes('StandardApexLibrary'),
+        );
+        if (standardSymbol) {
+          return standardSymbol;
+        }
+        return graphClassSymbols[0];
+      }
+      return null;
+    }
+
+    try {
+      self.loadingSymbolTables.add(fileUri);
+
+      self.logger.debug(
+        () =>
+          '[resolveStandardApexClass] Loading class from ResourceLoader: ' +
+          `classPath="${classPath}", fileUri="${fileUri}"`,
+      );
+
+      const symbolTable = await loadAndRegisterStdlibSymbolTable(
+        self,
+        fileUri,
+        classPath,
+      );
+      if (!symbolTable) {
+        self.logger.debug(
+          () =>
+            `[resolveStandardApexClass] ResourceLoader returned null for "${classPath}"`,
+        );
+        return null;
+      }
+      const symbols = symbolTable.getAllSymbols();
+      let classSymbol = symbols.find(
+        (s) =>
+          s.name?.toLowerCase() === className.toLowerCase() &&
+          s.kind === SymbolKind.Class,
+      );
+
+      if (!classSymbol) {
+        classSymbol = symbols.find((s) => s.kind === SymbolKind.Class);
+        if (classSymbol && !classSymbol.name) {
+          classSymbol.name = className;
+        }
+      }
+
+      if (classSymbol) {
+        classSymbol.fileUri = fileUri;
+        if (!classSymbol.name || classSymbol.name === '') {
+          classSymbol.name = className;
+        }
+        return classSymbol;
+      }
+
+      const graphSymbols = await self.findSymbolByName(className);
+      const graphClassSymbols = graphSymbols.filter(
+        (s) =>
+          s.kind === SymbolKind.Class &&
+          (s.fileUri === fileUri ||
+            s.fileUri?.includes('StandardApexLibrary') ||
+            s.fileUri?.includes('apexlib://')),
+      );
+      if (graphClassSymbols.length > 0) {
+        const fileSymbol = graphClassSymbols.find((s) => s.fileUri === fileUri);
+        if (fileSymbol) {
+          self.logger.debug(
+            () =>
+              `Found class "${className}" from symbol graph after loading: ${fileSymbol.name}`,
+          );
+          return fileSymbol;
+        }
+        const standardSymbol = graphClassSymbols.find(
+          (s) =>
+            s.fileUri?.includes('apexlib://') ||
+            s.fileUri?.includes('StandardApexLibrary'),
+        );
+        if (standardSymbol) {
+          self.logger.debug(
+            () =>
+              `Found class "${className}" from symbol graph (standard): ${standardSymbol.name}`,
+          );
+          return standardSymbol;
+        }
+        return graphClassSymbols[0];
+      }
+      return null;
+    } catch (_error) {
+      return null;
+    } finally {
+      self.loadingSymbolTables.delete(fileUri);
+    }
+  } catch (error) {
+    self.logger.warn(
+      () => `❌ Failed to resolve standard Apex class ${name}: ${error}`,
+    );
+    return null;
+  }
+}
+
+export async function loadAndRegisterStdlibSymbolTable(
+  self: SymbolManagerOps,
+  fileUri: string,
+  classPath: string,
+): Promise<SymbolTable | null> {
+  const inFlight = self.inFlightStdlibHydration.get(fileUri);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const hydrationPromise = (async () => {
+    const symbolTable = await self.stdlibProvider.getSymbolTable(classPath);
+    if (!symbolTable) {
+      return null;
+    }
+
+    await self.addSymbolTableAsync(symbolTable, fileUri);
+    return symbolTable;
+  })().finally(() => {
+    self.inFlightStdlibHydration.delete(fileUri);
+  });
+
+  self.inFlightStdlibHydration.set(fileUri, hydrationPromise);
+  return hydrationPromise;
+}

--- a/packages/apex-parser-ast/src/symbols/ops/symbolResolution.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/symbolResolution.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Effect } from 'effect';
+import type { Position } from '../../types/symbol';
+import type {
+  SymbolResolutionContext,
+  SymbolResolutionResult,
+} from '../../types/ISymbolManager';
+import { SymbolIndexStore } from '../services/symbolIndexStore';
+import { CacheStore } from '../services/cacheStore';
+import { FileStateStore } from '../services/fileStateStore';
+import { ResourceLoaderService } from '../services/ResourceLoaderService';
+import { findByName, findInFile } from './symbolLookup';
+
+type ResolutionDeps =
+  | SymbolIndexStore
+  | CacheStore
+  | FileStateStore
+  | ResourceLoaderService;
+
+/** Resolve a symbol by name with context */
+export const resolveSymbol = (
+  name: string,
+  context: SymbolResolutionContext,
+): Effect.Effect<SymbolResolutionResult, never, ResolutionDeps> =>
+  Effect.gen(function* () {
+    const candidates = yield* findByName(name);
+
+    if (candidates.length === 0) {
+      return {
+        symbol: null,
+        fileUri: context.sourceFile,
+        confidence: 0,
+        isAmbiguous: false,
+        resolutionContext: 'No symbols found with this name',
+      };
+    }
+
+    if (candidates.length === 1) {
+      return {
+        symbol: candidates[0],
+        fileUri: candidates[0].key.path[0] || context.sourceFile,
+        confidence: 0.9,
+        isAmbiguous: false,
+        resolutionContext: 'Single symbol found',
+      };
+    }
+
+    return {
+      symbol: candidates[0],
+      fileUri: candidates[0].key.path[0] || context.sourceFile,
+      confidence: 0.5,
+      isAmbiguous: true,
+      candidates,
+      resolutionContext: 'Multiple candidates found',
+    };
+  });
+
+/** Create comprehensive resolution context for symbol lookup */
+export const createResolutionContext = (
+  documentText: string,
+  position: Position,
+  fileUri: string,
+): Effect.Effect<SymbolResolutionContext, never, ResolutionDeps> =>
+  Effect.gen(function* () {
+    yield* findInFile(fileUri);
+
+    const namespaceContext = extractNamespaceFromUri(fileUri);
+    const currentScope = extractCurrentScope(documentText, position);
+    const importStatements = extractImportStatements(documentText);
+    const accessModifier = extractAccessModifier(documentText, position);
+
+    return {
+      sourceFile: fileUri,
+      importStatements,
+      namespaceContext,
+      currentScope,
+      scopeChain: [currentScope],
+      parameterTypes: [],
+      accessModifier,
+      isStatic: false,
+      inheritanceChain: [],
+      interfaceImplementations: [],
+    };
+  });
+
+/** Create enhanced resolution context with request type information */
+export const createResolutionContextWithRequestType = (
+  documentText: string,
+  position: Position,
+  sourceFile: string,
+  requestType?: string,
+): Effect.Effect<
+  SymbolResolutionContext & { requestType?: string; position?: Position },
+  never,
+  ResolutionDeps
+> =>
+  Effect.gen(function* () {
+    const baseContext = yield* createResolutionContext(
+      documentText,
+      position,
+      sourceFile,
+    );
+    return { ...baseContext, requestType, position };
+  });
+
+/** Get the current detail level for a file */
+export const getDetailLevelForFile = (
+  fileUri: string,
+): Effect.Effect<
+  | import('../../parser/listeners/LayeredSymbolListenerBase').DetailLevel
+  | undefined,
+  never,
+  FileStateStore
+> =>
+  Effect.gen(function* () {
+    const fileState = yield* FileStateStore;
+    return yield* fileState.getDetailLevel(fileUri);
+  });
+
+function extractNamespaceFromUri(fileUri: string): string {
+  if (fileUri.includes('test')) return 'public';
+  const match = fileUri.match(/\/([^\/]+)\.cls$/);
+  return match ? match[1] : 'public';
+}
+
+function extractCurrentScope(documentText: string, position: Position): string {
+  const lines = documentText.split('\n');
+  const currentLine = lines[position.line] || '';
+  if (currentLine.includes('public class')) return 'class';
+  if (currentLine.includes('public static')) return 'static';
+  if (currentLine.includes('public')) return 'instance';
+  return 'global';
+}
+
+function extractAccessModifier(
+  documentText: string,
+  position: Position,
+): 'public' | 'private' | 'protected' | 'global' {
+  const lines = documentText.split('\n');
+  const currentLine = lines[position.line] || '';
+  if (currentLine.includes('private')) return 'private';
+  if (currentLine.includes('protected')) return 'protected';
+  if (currentLine.includes('global')) return 'global';
+  return 'public';
+}
+
+function extractImportStatements(documentText: string): string[] {
+  return documentText
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.startsWith('import '));
+}

--- a/packages/apex-parser-ast/src/symbols/ops/typeHierarchy.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/typeHierarchy.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Effect } from 'effect';
+import { type ApexSymbol, SymbolKind } from '../../types/symbol';
+import { SymbolIndexStore } from '../services/symbolIndexStore';
+import {
+  calculateFQN,
+  getAncestorChain as getAncestorChainUtil,
+  type FQNOptions,
+} from '../../utils/FQNUtils';
+
+/** Get the immediate containing type (class, interface, enum) for a symbol */
+export const getContainingType = (
+  symbol: ApexSymbol,
+): Effect.Effect<ApexSymbol | null, never, SymbolIndexStore> =>
+  Effect.gen(function* () {
+    const index = yield* SymbolIndexStore;
+    let current = yield* index.getParent(symbol);
+    while (current) {
+      if (
+        current.kind === SymbolKind.Class ||
+        current.kind === SymbolKind.Interface ||
+        current.kind === SymbolKind.Enum
+      ) {
+        return current;
+      }
+      current = yield* index.getParent(current);
+    }
+    return null;
+  });
+
+/** Get the full chain of ancestor types for a symbol */
+export const getAncestorChain = (
+  symbol: ApexSymbol,
+): Effect.Effect<ApexSymbol[]> =>
+  Effect.sync(() => getAncestorChainUtil(symbol));
+
+/** Construct fully qualified name for a symbol using hierarchical relationships */
+export const constructFQN = (
+  symbol: ApexSymbol,
+  options?: FQNOptions,
+): Effect.Effect<string, never, SymbolIndexStore> =>
+  Effect.gen(function* () {
+    const index = yield* SymbolIndexStore;
+    return calculateFQN(symbol, options, (parentId) =>
+      Effect.runSync(index.getSymbol(parentId)),
+    );
+  });

--- a/packages/apex-parser-ast/src/symbols/services/ResourceLoaderService.ts
+++ b/packages/apex-parser-ast/src/symbols/services/ResourceLoaderService.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * ResourceLoader Effect Service
+ *
+ * Provides access to the standard Apex library (stdlib) symbol tables,
+ * namespace indexes, and source files via Effect-TS Context.Tag DI.
+ *
+ * Three implementations:
+ *   - ResourceLoaderLive     — local ResourceLoader class; used in resourceLoader
+ *                              worker and in tests that exercise stdlib resolution
+ *   - ResourceLoaderRemoteLive — IPC bridge; defined in apex-ls package (depends
+ *                              on worker IPC infrastructure)
+ *   - ResourceLoaderNoOpLive — all methods return empty/null; used in unit tests
+ *                              that don't exercise stdlib resolution
+ */
+
+import { Context, Effect, Layer } from 'effect';
+import type { SymbolTable } from '../../types/symbol';
+
+/**
+ * Surface of the ResourceLoader exposed to ops code.
+ * All methods are required — consumers never null-check the provider.
+ *
+ * Sync methods (isStdApexNamespace, hasClass, findNamespaceForClass,
+ * getStandardNamespaces, resolveClassFqn) are called in tight inner loops;
+ * the local implementation serves them from memory, the remote implementation
+ * caches results after the first IPC call.
+ *
+ * Async methods (getSymbolTable, getFile) may involve IPC or disk I/O.
+ */
+export interface ResourceLoaderServiceShape {
+  /** True if the namespace name matches a known standard Apex namespace (e.g. "System"). */
+  isStdApexNamespace(namespace: string): boolean;
+  /** True if a class file exists at the given path (e.g. "System/Assert.cls"). */
+  hasClass(classPath: string): boolean;
+  /**
+   * Returns the set of namespaces that contain a class with the given name
+   * (e.g. "Assert" → Set{"System"}).
+   */
+  findNamespaceForClass(className: string): Set<string>;
+  /**
+   * Returns the full namespace → classFiles map.
+   * Values are plain strings (e.g. "Assert.cls") — CaseInsensitiveString
+   * is an internal detail of ResourceLoader and is not exposed here.
+   */
+  getStandardNamespaces(): Map<string, string[]>;
+  /**
+   * Resolves an unqualified or qualified class name to its canonical FQN
+   * (e.g. "assert" → "System.Assert"), or null if not found in stdlib.
+   * Async so that remote implementations can forward the call via IPC.
+   */
+  resolveClassFqn(className: string): Promise<string | null>;
+  /**
+   * Returns the parsed SymbolTable for a stdlib class path
+   * (e.g. "System/Assert.cls"), or null if not found.
+   */
+  getSymbolTable(classPath: string): Promise<SymbolTable | null>;
+  /** Returns the source text of a stdlib class for goto-definition. */
+  getFile(path: string): Promise<string | undefined>;
+}
+
+/**
+ * Effect Context.Tag for ResourceLoaderService.
+ * Follows the GlobalTypeRegistry pattern used throughout this codebase.
+ */
+export class ResourceLoaderService extends Context.Tag('ResourceLoaderService')<
+  ResourceLoaderService,
+  ResourceLoaderServiceShape
+>() {}
+
+/**
+ * Standalone no-op instance used as the default constructor argument for
+ * ApexSymbolManager in environments that don't provide a layer (e.g. test
+ * environments that don't need stdlib resolution).
+ *
+ * Using an instance instead of a Layer avoids the Effect runtime overhead
+ * for plain-constructor call sites.
+ */
+export const ResourceLoaderNoOpInstance: ResourceLoaderServiceShape = {
+  isStdApexNamespace: () => false,
+  hasClass: () => false,
+  findNamespaceForClass: () => new Set<string>(),
+  getStandardNamespaces: () => new Map<string, string[]>(),
+  resolveClassFqn: () => Promise.resolve(null),
+  getSymbolTable: () => Promise.resolve(null),
+  getFile: () => Promise.resolve(undefined),
+};
+
+/**
+ * Local layer — wraps the existing ResourceLoader singleton.
+ * Calls initialize() so callers don't need to do it separately.
+ * Used in the resourceLoader worker and in integration tests that
+ * need real stdlib symbol data.
+ */
+export const ResourceLoaderLive: Layer.Layer<ResourceLoaderService> =
+  Layer.effect(
+    ResourceLoaderService,
+    Effect.gen(function* () {
+      const { ResourceLoader } = yield* Effect.promise(
+        () =>
+          import('../../utils/resourceLoader') as Promise<{
+            ResourceLoader: typeof import('../../utils/resourceLoader').ResourceLoader;
+          }>,
+      );
+      const rl = ResourceLoader.getInstance();
+      yield* Effect.promise(() => rl.initialize());
+      return {
+        isStdApexNamespace: (namespace: string) =>
+          rl.isStdApexNamespace(namespace),
+        hasClass: (classPath: string) => rl.hasClass(classPath),
+        findNamespaceForClass: (className: string) =>
+          rl.findNamespaceForClass(className),
+        getStandardNamespaces: () => {
+          const original = rl.getStandardNamespaces();
+          const result = new Map<string, string[]>();
+          for (const [k, v] of original) {
+            result.set(
+              k,
+              v.map((cis) => cis.value),
+            );
+          }
+          return result;
+        },
+        resolveClassFqn: (className: string) =>
+          Promise.resolve(rl.resolveStandardClassFqn(className)),
+        getSymbolTable: (classPath: string) => rl.getSymbolTable(classPath),
+        getFile: (path: string) => rl.getFile(path),
+      } satisfies ResourceLoaderServiceShape;
+    }),
+  );
+
+/**
+ * No-op Layer — for tests that do not exercise stdlib resolution.
+ * All methods return safe empty/null values; no ZIP loading, no initialization.
+ * Replace ResourceLoader.getInstance()+resetInstance() patterns with this.
+ */
+export const ResourceLoaderNoOpLive: Layer.Layer<ResourceLoaderService> =
+  Layer.succeed(ResourceLoaderService, ResourceLoaderNoOpInstance);

--- a/packages/apex-parser-ast/src/symbols/services/cacheStore.ts
+++ b/packages/apex-parser-ast/src/symbols/services/cacheStore.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { HashMap } from 'data-structure-typed';
+import { Context, Effect, Layer } from 'effect';
+import type { ApexSymbol } from '../../types/symbol';
+import type {
+  UnifiedCache,
+  CacheEntryType,
+  UnifiedCacheStats,
+} from '../../utils/UnifiedCache';
+
+/**
+ * Data service for the caching layer.
+ * Wraps UnifiedCache, parentLookupCache, and symbolCache.
+ * Pure derivation — can be dropped entirely in worker proxy scenarios.
+ */
+export interface CacheStoreShape {
+  readonly get: <T>(key: string) => Effect.Effect<T | undefined>;
+  readonly set: <T>(
+    key: string,
+    value: T,
+    type: CacheEntryType,
+  ) => Effect.Effect<void>;
+  readonly invalidatePattern: (pattern: string) => Effect.Effect<void>;
+  readonly clear: () => Effect.Effect<void>;
+  readonly optimize: () => Effect.Effect<void>;
+  readonly getStats: () => Effect.Effect<UnifiedCacheStats>;
+
+  readonly getParentCache: (
+    fileUri: string,
+  ) => Effect.Effect<HashMap<string, ApexSymbol> | undefined>;
+  readonly setParentCache: (
+    fileUri: string,
+    cache: HashMap<string, ApexSymbol>,
+  ) => Effect.Effect<void>;
+  readonly clearParentCache: () => Effect.Effect<void>;
+}
+
+export class CacheStore extends Context.Tag('CacheStore')<
+  CacheStore,
+  CacheStoreShape
+>() {}
+
+/** Shim Layer that delegates to existing UnifiedCache and parent cache instances */
+export const cacheStoreShim = (
+  unifiedCache: UnifiedCache,
+  parentLookupCache: HashMap<string, HashMap<string, ApexSymbol>>,
+): Layer.Layer<CacheStore> =>
+  Layer.succeed(CacheStore, {
+    get: <T>(key: string) =>
+      Effect.sync(() => unifiedCache.get(key) as T | undefined),
+    set: <T>(key: string, value: T, type: CacheEntryType) =>
+      Effect.sync(() => unifiedCache.set(key, value, type)),
+    invalidatePattern: (pattern) =>
+      Effect.sync(() => unifiedCache.invalidatePattern(pattern)),
+    clear: () =>
+      Effect.sync(() => {
+        unifiedCache.clear();
+        parentLookupCache.clear();
+      }),
+    optimize: () => Effect.sync(() => unifiedCache.optimize()),
+    getStats: () => Effect.sync(() => unifiedCache.getStats()),
+
+    getParentCache: (fileUri) =>
+      Effect.sync(() => parentLookupCache.get(fileUri) ?? undefined),
+    setParentCache: (fileUri, cache) =>
+      Effect.sync(() => {
+        parentLookupCache.set(fileUri, cache);
+      }),
+    clearParentCache: () => Effect.sync(() => parentLookupCache.clear()),
+  });

--- a/packages/apex-parser-ast/src/symbols/services/concurrencyGuards.ts
+++ b/packages/apex-parser-ast/src/symbols/services/concurrencyGuards.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Context, Effect, Layer } from 'effect';
+import type { SymbolTable } from '../../types/symbol';
+
+/**
+ * Data service for reentrancy guards and deduplication state.
+ * Wraps loadingSymbolTables, inFlightStdlibHydration, and
+ * resolvingCrossFileRefs from ApexSymbolManager.
+ */
+export interface ConcurrencyGuardsShape {
+  readonly isLoadingSymbolTable: (uri: string) => Effect.Effect<boolean>;
+  readonly setLoadingSymbolTable: (
+    uri: string,
+    loading: boolean,
+  ) => Effect.Effect<void>;
+
+  readonly isResolvingCrossFileRefs: (uri: string) => Effect.Effect<boolean>;
+  readonly setResolvingCrossFileRefs: (
+    uri: string,
+    resolving: boolean,
+  ) => Effect.Effect<void>;
+
+  readonly getInFlightStdlibHydration: (
+    name: string,
+  ) => Effect.Effect<Promise<SymbolTable | null> | undefined>;
+  readonly setInFlightStdlibHydration: (
+    name: string,
+    promise: Promise<SymbolTable | null>,
+  ) => Effect.Effect<void>;
+  readonly removeInFlightStdlibHydration: (name: string) => Effect.Effect<void>;
+}
+
+export class ConcurrencyGuards extends Context.Tag('ConcurrencyGuards')<
+  ConcurrencyGuards,
+  ConcurrencyGuardsShape
+>() {}
+
+/** Shim Layer that delegates to existing Set/Map fields */
+export const concurrencyGuardsShim = (
+  loadingSymbolTables: Set<string>,
+  inFlightStdlibHydration: Map<string, Promise<SymbolTable | null>>,
+  resolvingCrossFileRefs: Set<string>,
+): Layer.Layer<ConcurrencyGuards> =>
+  Layer.succeed(ConcurrencyGuards, {
+    isLoadingSymbolTable: (uri) =>
+      Effect.sync(() => loadingSymbolTables.has(uri)),
+    setLoadingSymbolTable: (uri, loading) =>
+      Effect.sync(() => {
+        if (loading) loadingSymbolTables.add(uri);
+        else loadingSymbolTables.delete(uri);
+      }),
+
+    isResolvingCrossFileRefs: (uri) =>
+      Effect.sync(() => resolvingCrossFileRefs.has(uri)),
+    setResolvingCrossFileRefs: (uri, resolving) =>
+      Effect.sync(() => {
+        if (resolving) resolvingCrossFileRefs.add(uri);
+        else resolvingCrossFileRefs.delete(uri);
+      }),
+
+    getInFlightStdlibHydration: (name) =>
+      Effect.sync(() => inFlightStdlibHydration.get(name)),
+    setInFlightStdlibHydration: (name, promise) =>
+      Effect.sync(() => {
+        inFlightStdlibHydration.set(name, promise);
+      }),
+    removeInFlightStdlibHydration: (name) =>
+      Effect.sync(() => {
+        inFlightStdlibHydration.delete(name);
+      }),
+  });

--- a/packages/apex-parser-ast/src/symbols/services/fileStateStore.ts
+++ b/packages/apex-parser-ast/src/symbols/services/fileStateStore.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { HashMap } from 'data-structure-typed';
+import { Context, Effect, Layer } from 'effect';
+import type { DetailLevel } from '../../parser/listeners/LayeredSymbolListenerBase';
+import type { CommentAssociation } from '../../parser/listeners/ApexCommentCollectorListener';
+
+/** Per-file tracking metadata */
+export interface FileMetadata {
+  fileUri: string;
+  symbolCount: number;
+  lastUpdated: number;
+}
+
+/**
+ * Data service for per-file state: metadata, detail levels,
+ * processed-table checksums, and comment associations.
+ */
+export interface FileStateStoreShape {
+  readonly getFileMetadata: (
+    fileUri: string,
+  ) => Effect.Effect<FileMetadata | undefined>;
+  readonly setFileMetadata: (
+    fileUri: string,
+    metadata: FileMetadata,
+  ) => Effect.Effect<void>;
+  readonly removeFileMetadata: (fileUri: string) => Effect.Effect<void>;
+  readonly getAllFileMetadata: () => Effect.Effect<Map<string, FileMetadata>>;
+
+  readonly getDetailLevel: (
+    fileUri: string,
+  ) => Effect.Effect<DetailLevel | undefined>;
+  readonly setDetailLevel: (
+    fileUri: string,
+    level: DetailLevel,
+  ) => Effect.Effect<void>;
+
+  readonly getLastProcessedTableState: (
+    fileUri: string,
+  ) => Effect.Effect<string | undefined>;
+  readonly setLastProcessedTableState: (
+    fileUri: string,
+    state: string,
+  ) => Effect.Effect<void>;
+  readonly removeLastProcessedTableState: (
+    fileUri: string,
+  ) => Effect.Effect<void>;
+
+  readonly getCommentAssociations: (
+    fileUri: string,
+  ) => Effect.Effect<CommentAssociation[] | undefined>;
+  readonly setCommentAssociations: (
+    fileUri: string,
+    associations: CommentAssociation[],
+  ) => Effect.Effect<void>;
+
+  readonly clear: () => Effect.Effect<void>;
+}
+
+export class FileStateStore extends Context.Tag('FileStateStore')<
+  FileStateStore,
+  FileStateStoreShape
+>() {}
+
+/** Shim Layer that delegates to existing HashMap fields */
+export const fileStateStoreShim = (
+  fileMetadata: HashMap<string, FileMetadata>,
+  fileDetailLevels: HashMap<string, DetailLevel>,
+  lastProcessedTableStateByFile: HashMap<string, string>,
+  fileCommentAssociations: HashMap<string, CommentAssociation[]>,
+): Layer.Layer<FileStateStore> =>
+  Layer.succeed(FileStateStore, {
+    getFileMetadata: (fileUri) =>
+      Effect.sync(() => fileMetadata.get(fileUri) ?? undefined),
+    setFileMetadata: (fileUri, metadata) =>
+      Effect.sync(() => {
+        fileMetadata.set(fileUri, metadata);
+      }),
+    removeFileMetadata: (fileUri) =>
+      Effect.sync(() => {
+        fileMetadata.delete(fileUri);
+      }),
+    getAllFileMetadata: () =>
+      Effect.sync(() => {
+        const result = new Map<string, FileMetadata>();
+        for (const [k, v] of fileMetadata) {
+          if (v !== undefined) result.set(k, v);
+        }
+        return result;
+      }),
+
+    getDetailLevel: (fileUri) =>
+      Effect.sync(() => fileDetailLevels.get(fileUri) ?? undefined),
+    setDetailLevel: (fileUri, level) =>
+      Effect.sync(() => {
+        fileDetailLevels.set(fileUri, level);
+      }),
+
+    getLastProcessedTableState: (fileUri) =>
+      Effect.sync(
+        () => lastProcessedTableStateByFile.get(fileUri) ?? undefined,
+      ),
+    setLastProcessedTableState: (fileUri, state) =>
+      Effect.sync(() => {
+        lastProcessedTableStateByFile.set(fileUri, state);
+      }),
+    removeLastProcessedTableState: (fileUri) =>
+      Effect.sync(() => {
+        lastProcessedTableStateByFile.delete(fileUri);
+      }),
+
+    getCommentAssociations: (fileUri) =>
+      Effect.sync(() => fileCommentAssociations.get(fileUri) ?? undefined),
+    setCommentAssociations: (fileUri, associations) =>
+      Effect.sync(() => {
+        fileCommentAssociations.set(fileUri, associations);
+      }),
+
+    clear: () =>
+      Effect.sync(() => {
+        fileMetadata.clear();
+        fileDetailLevels.clear();
+        lastProcessedTableStateByFile.clear();
+        fileCommentAssociations.clear();
+      }),
+  });

--- a/packages/apex-parser-ast/src/symbols/services/referenceStore.ts
+++ b/packages/apex-parser-ast/src/symbols/services/referenceStore.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Context, Effect, Layer } from 'effect';
+import type { ApexSymbol, SymbolLocation } from '../../types/symbol';
+import type { EnumValue } from '@salesforce/apex-lsp-shared';
+import type {
+  ReferenceType,
+  ReferenceResult,
+  DependencyAnalysis,
+  ApexSymbolRefManager,
+} from '../ApexSymbolRefManager';
+import type {
+  GraphData,
+  FileGraphData,
+  TypeGraphData,
+} from '../../types/graph';
+
+/**
+ * Data service for the reference graph (reference triad).
+ * Wraps reverseIndex, forwardIndex, and refStore from ApexSymbolRefManager.
+ */
+export interface ReferenceStoreShape {
+  readonly addReference: (
+    sourceSymbol: ApexSymbol,
+    targetSymbol: ApexSymbol,
+    referenceType: EnumValue<typeof ReferenceType>,
+    location: SymbolLocation,
+    context?: {
+      methodName?: string;
+      parameterIndex?: number;
+      isStatic?: boolean;
+      namespace?: string;
+    },
+  ) => Effect.Effect<void>;
+  readonly findReferencesTo: (
+    symbol: ApexSymbol,
+  ) => Effect.Effect<ReferenceResult[]>;
+  readonly findReferencesFrom: (
+    symbol: ApexSymbol,
+  ) => Effect.Effect<ReferenceResult[]>;
+  readonly clearReferenceStateForFile: (fileUri: string) => Effect.Effect<void>;
+  readonly clear: () => Effect.Effect<void>;
+
+  readonly analyzeDependencies: (
+    symbol: ApexSymbol,
+  ) => Effect.Effect<DependencyAnalysis>;
+  readonly detectCircularDependencies: () => Effect.Effect<string[][]>;
+
+  readonly getGraphData: () => Effect.Effect<GraphData>;
+  readonly getGraphDataForFile: (
+    fileUri: string,
+  ) => Effect.Effect<FileGraphData>;
+  readonly getGraphDataByType: (
+    symbolType: string,
+  ) => Effect.Effect<TypeGraphData>;
+
+  readonly getStats: () => Effect.Effect<{ totalReferences: number }>;
+}
+
+export class ReferenceStore extends Context.Tag('ReferenceStore')<
+  ReferenceStore,
+  ReferenceStoreShape
+>() {}
+
+/** Shim Layer that delegates to an existing ApexSymbolRefManager instance */
+export const referenceStoreShim = (
+  manager: ApexSymbolRefManager,
+): Layer.Layer<ReferenceStore> =>
+  Layer.succeed(ReferenceStore, {
+    addReference: (
+      sourceSymbol,
+      targetSymbol,
+      referenceType,
+      location,
+      context,
+    ) =>
+      Effect.sync(() =>
+        manager.addReference(
+          sourceSymbol,
+          targetSymbol,
+          referenceType,
+          location,
+          context,
+        ),
+      ),
+    findReferencesTo: (symbol) =>
+      Effect.sync(() => manager.findReferencesTo(symbol)),
+    findReferencesFrom: (symbol) =>
+      Effect.sync(() => manager.findReferencesFrom(symbol)),
+    clearReferenceStateForFile: (fileUri) =>
+      Effect.sync(() => manager.clearReferenceStateForFile(fileUri)),
+    clear: () => Effect.sync(() => manager.clear()),
+
+    analyzeDependencies: (symbol) =>
+      Effect.sync(() => manager.analyzeDependencies(symbol)),
+    detectCircularDependencies: () =>
+      Effect.sync(() => manager.detectCircularDependencies()),
+
+    getGraphData: () => Effect.sync(() => manager.getGraphData()),
+    getGraphDataForFile: (fileUri) =>
+      Effect.sync(() => manager.getGraphDataForFile(fileUri)),
+    getGraphDataByType: (symbolType) =>
+      Effect.sync(() => manager.getGraphDataByType(symbolType)),
+
+    getStats: () =>
+      Effect.sync(() => ({
+        totalReferences: manager.getStats().totalEdges,
+      })),
+  });

--- a/packages/apex-parser-ast/src/symbols/services/symbolIndexStore.ts
+++ b/packages/apex-parser-ast/src/symbols/services/symbolIndexStore.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Context, Effect, Layer } from 'effect';
+import type { ApexSymbol, SymbolTable } from '../../types/symbol';
+import type {
+  SymbolTableRegistrationResult,
+  ApexSymbolRefManager,
+} from '../ApexSymbolRefManager';
+
+/**
+ * Data service for symbol storage and index-based lookups.
+ * Wraps the 7 symbol indexes from ApexSymbolRefManager:
+ * nameIndex, fileIndex, fqnIndex, symbolIdIndex,
+ * symbolQualifiedIndex, symbolFileMap, fileToSymbolTable.
+ */
+export interface SymbolIndexStoreShape {
+  readonly getSymbol: (symbolId: string) => Effect.Effect<ApexSymbol | null>;
+  readonly findByName: (name: string) => Effect.Effect<ApexSymbol[]>;
+  readonly findByFQN: (fqn: string) => Effect.Effect<ApexSymbol | null>;
+  readonly findSymbolsByFQN: (fqn: string) => Effect.Effect<ApexSymbol[]>;
+  readonly getSymbolsInFile: (fileUri: string) => Effect.Effect<ApexSymbol[]>;
+  readonly getFilesForSymbol: (name: string) => Effect.Effect<string[]>;
+  readonly getSymbolTableForFile: (
+    fileUri: string,
+  ) => Effect.Effect<SymbolTable | undefined>;
+  readonly getParent: (symbol: ApexSymbol) => Effect.Effect<ApexSymbol | null>;
+  readonly getSymbolIds: () => Effect.Effect<Set<string>>;
+  readonly getFileToSymbolTable: () => Effect.Effect<
+    Iterable<[string, SymbolTable | undefined]>
+  >;
+
+  readonly addSymbol: (
+    symbol: ApexSymbol,
+    fileUri: string,
+    symbolTable?: SymbolTable,
+  ) => Effect.Effect<void>;
+  readonly registerSymbolTable: (
+    symbolTable: SymbolTable,
+    fileUri: string,
+    options?: {
+      mergeReferences?: boolean;
+      hasErrors?: boolean;
+      hasHardIncompleteParse?: boolean;
+    },
+  ) => Effect.Effect<SymbolTableRegistrationResult>;
+  readonly removeFile: (fileUri: string) => Effect.Effect<void>;
+  readonly clear: () => Effect.Effect<void>;
+
+  readonly getStats: () => Effect.Effect<{
+    totalSymbols: number;
+    totalFiles: number;
+  }>;
+}
+
+export class SymbolIndexStore extends Context.Tag('SymbolIndexStore')<
+  SymbolIndexStore,
+  SymbolIndexStoreShape
+>() {}
+
+/** Shim Layer that delegates to an existing ApexSymbolRefManager instance */
+export const symbolIndexStoreShim = (
+  manager: ApexSymbolRefManager,
+): Layer.Layer<SymbolIndexStore> =>
+  Layer.succeed(SymbolIndexStore, {
+    getSymbol: (symbolId) => Effect.sync(() => manager.getSymbol(symbolId)),
+    findByName: (name) => Effect.sync(() => manager.findSymbolByName(name)),
+    findByFQN: (fqn) => Effect.sync(() => manager.findSymbolByFQN(fqn)),
+    findSymbolsByFQN: (fqn) => Effect.sync(() => manager.findSymbolsByFQN(fqn)),
+    getSymbolsInFile: (fileUri) =>
+      Effect.sync(() => manager.getSymbolsInFile(fileUri)),
+    getFilesForSymbol: (name) =>
+      Effect.sync(() => manager.getFilesForSymbol(name)),
+    getSymbolTableForFile: (fileUri) =>
+      Effect.sync(() => manager.getSymbolTableForFile(fileUri)),
+    getParent: (symbol) => Effect.sync(() => manager.getParent(symbol)),
+    getSymbolIds: () => Effect.sync(() => manager.getSymbolIds()),
+    getFileToSymbolTable: () =>
+      Effect.sync(() => manager.getFileToSymbolTable()),
+
+    addSymbol: (symbol, fileUri, symbolTable) =>
+      Effect.sync(() => manager.addSymbol(symbol, fileUri, symbolTable)),
+    registerSymbolTable: (symbolTable, fileUri, options) =>
+      Effect.sync(() =>
+        manager.registerSymbolTable(symbolTable, fileUri, options),
+      ),
+    removeFile: (fileUri) => Effect.sync(() => manager.removeFile(fileUri)),
+    clear: () => Effect.sync(() => manager.clear()),
+
+    getStats: () =>
+      Effect.sync(() => {
+        const stats = manager.getStats();
+        return {
+          totalSymbols: stats.totalSymbols,
+          totalFiles: stats.totalFiles,
+        };
+      }),
+  });

--- a/packages/apex-parser-ast/src/symbols/services/symbolIndexStoreLive.ts
+++ b/packages/apex-parser-ast/src/symbols/services/symbolIndexStoreLive.ts
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Effect, Layer, Ref } from 'effect';
+import { HashMap } from 'data-structure-typed';
+import type { ApexSymbol, SymbolTable } from '../../types/symbol';
+import { extractFilePathFromUri } from '../../types/UriBasedIdGenerator';
+import { CaseInsensitiveHashMap } from '../../utils/CaseInsensitiveMap';
+import type { SymbolTableRegistrationResult } from '../ApexSymbolRefManager';
+import { SymbolIndexStore } from './symbolIndexStore';
+
+/**
+ * Ref-based state for the SymbolIndexStore.
+ * Each field is an Effect Ref holding the actual data.
+ */
+interface SymbolIndexState {
+  readonly nameIndex: Ref.Ref<CaseInsensitiveHashMap<string[]>>;
+  readonly fileIndex: Ref.Ref<CaseInsensitiveHashMap<string[]>>;
+  readonly fqnIndex: Ref.Ref<CaseInsensitiveHashMap<string[]>>;
+  readonly symbolIdIndex: Ref.Ref<HashMap<string, ApexSymbol>>;
+  readonly symbolFileMap: Ref.Ref<CaseInsensitiveHashMap<string>>;
+  readonly fileToSymbolTable: Ref.Ref<CaseInsensitiveHashMap<SymbolTable>>;
+  readonly symbolToFiles: Ref.Ref<CaseInsensitiveHashMap<string[]>>;
+}
+
+/**
+ * Real Effect-managed SymbolIndexStore implementation.
+ * Data is owned by Refs — Layer memoization replaces singleton lifecycle.
+ */
+export const SymbolIndexStoreLive: Layer.Layer<SymbolIndexStore> = Layer.effect(
+  SymbolIndexStore,
+  Effect.gen(function* () {
+    const state: SymbolIndexState = {
+      nameIndex: yield* Ref.make(new CaseInsensitiveHashMap<string[]>()),
+      fileIndex: yield* Ref.make(new CaseInsensitiveHashMap<string[]>()),
+      fqnIndex: yield* Ref.make(new CaseInsensitiveHashMap<string[]>()),
+      symbolIdIndex: yield* Ref.make(new HashMap<string, ApexSymbol>()),
+      symbolFileMap: yield* Ref.make(new CaseInsensitiveHashMap<string>()),
+      fileToSymbolTable: yield* Ref.make(
+        new CaseInsensitiveHashMap<SymbolTable>(),
+      ),
+      symbolToFiles: yield* Ref.make(new CaseInsensitiveHashMap<string[]>()),
+    };
+
+    const getSymbolIdIndex = () => Ref.get(state.symbolIdIndex);
+
+    return {
+      getSymbol: (symbolId) =>
+        Effect.gen(function* () {
+          const idx = yield* getSymbolIdIndex();
+          return idx.get(symbolId) ?? null;
+        }),
+
+      findByName: (name) =>
+        Effect.gen(function* () {
+          const nameIdx = yield* Ref.get(state.nameIndex);
+          const ids = nameIdx.get(name) ?? [];
+          const symIdx = yield* getSymbolIdIndex();
+          return ids
+            .map((id) => symIdx.get(id))
+            .filter((s): s is ApexSymbol => s !== undefined);
+        }),
+
+      findByFQN: (fqn) =>
+        Effect.gen(function* () {
+          const fqnIdx = yield* Ref.get(state.fqnIndex);
+          const ids = fqnIdx.get(fqn);
+          if (!ids || ids.length === 0) return null;
+          const symIdx = yield* getSymbolIdIndex();
+          return symIdx.get(ids[0]) ?? null;
+        }),
+
+      findSymbolsByFQN: (fqn) =>
+        Effect.gen(function* () {
+          const fqnIdx = yield* Ref.get(state.fqnIndex);
+          const ids = fqnIdx.get(fqn) ?? [];
+          const symIdx = yield* getSymbolIdIndex();
+          return ids
+            .map((id) => symIdx.get(id))
+            .filter((s): s is ApexSymbol => s !== undefined);
+        }),
+
+      getSymbolsInFile: (fileUri) =>
+        Effect.gen(function* () {
+          const normalizedUri = extractFilePathFromUri(fileUri);
+          const fileIdx = yield* Ref.get(state.fileIndex);
+          const ids = fileIdx.get(normalizedUri) ?? [];
+          const symIdx = yield* getSymbolIdIndex();
+          return ids
+            .map((id) => symIdx.get(id))
+            .filter((s): s is ApexSymbol => s !== undefined);
+        }),
+
+      getFilesForSymbol: (name) =>
+        Effect.gen(function* () {
+          const s2f = yield* Ref.get(state.symbolToFiles);
+          return s2f.get(name) ?? [];
+        }),
+
+      getSymbolTableForFile: (fileUri) =>
+        Effect.gen(function* () {
+          const normalizedUri = extractFilePathFromUri(fileUri);
+          const f2st = yield* Ref.get(state.fileToSymbolTable);
+          return f2st.get(normalizedUri);
+        }),
+
+      getParent: (symbol) =>
+        Effect.gen(function* () {
+          if (!symbol.parentId) return null;
+          const symIdx = yield* getSymbolIdIndex();
+          return symIdx.get(symbol.parentId) ?? null;
+        }),
+
+      getSymbolIds: () =>
+        Effect.gen(function* () {
+          const symIdx = yield* getSymbolIdIndex();
+          return new Set(symIdx.keys());
+        }),
+
+      getFileToSymbolTable: () =>
+        Effect.gen(function* () {
+          return yield* Ref.get(state.fileToSymbolTable);
+        }),
+
+      addSymbol: (symbol, fileUri, symbolTable) =>
+        Effect.gen(function* () {
+          const normalizedUri = extractFilePathFromUri(fileUri);
+          const symbolId = symbol.key?.unifiedId || symbol.id;
+
+          yield* Ref.update(state.symbolIdIndex, (idx) => {
+            idx.set(symbolId, symbol);
+            return idx;
+          });
+
+          yield* Ref.update(state.nameIndex, (idx) => {
+            const existing = idx.get(symbol.name) ?? [];
+            if (!existing.includes(symbolId)) existing.push(symbolId);
+            idx.set(symbol.name, existing);
+            return idx;
+          });
+
+          yield* Ref.update(state.fileIndex, (idx) => {
+            const existing = idx.get(normalizedUri) ?? [];
+            if (!existing.includes(symbolId)) existing.push(symbolId);
+            idx.set(normalizedUri, existing);
+            return idx;
+          });
+
+          yield* Ref.update(state.symbolFileMap, (m) => {
+            m.set(symbolId, normalizedUri);
+            return m;
+          });
+
+          if (symbol.fqn) {
+            yield* Ref.update(state.fqnIndex, (idx) => {
+              const existing = idx.get(symbol.fqn!) ?? [];
+              if (!existing.includes(symbolId)) existing.push(symbolId);
+              idx.set(symbol.fqn!, existing);
+              return idx;
+            });
+          }
+
+          if (symbolTable) {
+            yield* Ref.update(state.fileToSymbolTable, (m) => {
+              m.set(normalizedUri, symbolTable);
+              return m;
+            });
+          }
+        }),
+
+      registerSymbolTable: (symbolTable, fileUri, _options) =>
+        Effect.gen(function* () {
+          const normalizedUri = extractFilePathFromUri(fileUri);
+          const f2st = yield* Ref.get(state.fileToSymbolTable);
+          const existing = f2st.get(normalizedUri);
+          if (existing === symbolTable) {
+            const meta = existing.getMetadata();
+            return {
+              decision: 'noop-same-instance' as const,
+              fileUri: normalizedUri,
+              canonicalTable: existing,
+              incomingVersion: meta.documentVersion,
+              storedVersion: meta.documentVersion,
+            };
+          }
+
+          yield* Ref.update(state.fileToSymbolTable, (m) => {
+            m.set(normalizedUri, symbolTable);
+            return m;
+          });
+
+          const meta = symbolTable.getMetadata();
+          return {
+            decision: 'accepted-replace' as const,
+            fileUri: normalizedUri,
+            canonicalTable: symbolTable,
+            incomingVersion: meta.documentVersion,
+            storedVersion: existing?.getMetadata().documentVersion,
+          } satisfies SymbolTableRegistrationResult;
+        }),
+
+      removeFile: (fileUri) =>
+        Effect.gen(function* () {
+          const normalizedUri = extractFilePathFromUri(fileUri);
+          const fileIdx = yield* Ref.get(state.fileIndex);
+          const symbolIds = fileIdx.get(normalizedUri) ?? [];
+
+          for (const symbolId of symbolIds) {
+            yield* Ref.update(state.symbolIdIndex, (m) => {
+              m.delete(symbolId);
+              return m;
+            });
+            yield* Ref.update(state.symbolFileMap, (m) => {
+              m.delete(symbolId);
+              return m;
+            });
+          }
+
+          yield* Ref.update(state.fileIndex, (idx) => {
+            idx.delete(normalizedUri);
+            return idx;
+          });
+          yield* Ref.update(state.fileToSymbolTable, (m) => {
+            m.delete(normalizedUri);
+            return m;
+          });
+        }),
+
+      clear: () =>
+        Effect.gen(function* () {
+          yield* Ref.set(
+            state.nameIndex,
+            new CaseInsensitiveHashMap<string[]>(),
+          );
+          yield* Ref.set(
+            state.fileIndex,
+            new CaseInsensitiveHashMap<string[]>(),
+          );
+          yield* Ref.set(
+            state.fqnIndex,
+            new CaseInsensitiveHashMap<string[]>(),
+          );
+          yield* Ref.set(
+            state.symbolIdIndex,
+            new HashMap<string, ApexSymbol>(),
+          );
+          yield* Ref.set(
+            state.symbolFileMap,
+            new CaseInsensitiveHashMap<string>(),
+          );
+          yield* Ref.set(
+            state.fileToSymbolTable,
+            new CaseInsensitiveHashMap<SymbolTable>(),
+          );
+          yield* Ref.set(
+            state.symbolToFiles,
+            new CaseInsensitiveHashMap<string[]>(),
+          );
+        }),
+
+      getStats: () =>
+        Effect.gen(function* () {
+          const symIdx = yield* getSymbolIdIndex();
+          const fileIdx = yield* Ref.get(state.fileIndex);
+          return {
+            totalSymbols: symIdx.size,
+            totalFiles: fileIdx.size,
+          };
+        }),
+    };
+  }),
+);

--- a/packages/apex-parser-ast/src/symbols/services/symbolManagerFacade.ts
+++ b/packages/apex-parser-ast/src/symbols/services/symbolManagerFacade.ts
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Context, Effect, Layer } from 'effect';
+import type {
+  ApexSymbol,
+  SymbolTable,
+  Position,
+  SymbolResolutionStrategy,
+} from '../../types/symbol';
+import type {
+  SymbolResolutionContext,
+  SymbolResolutionResult,
+} from '../../types/ISymbolManager';
+import type { EnumValue } from '@salesforce/apex-lsp-shared';
+import type {
+  ReferenceResult,
+  ReferenceType,
+  DependencyAnalysis,
+  SymbolTableRegistrationResult,
+} from '../ApexSymbolRefManager';
+import type { SymbolReference } from '../../types/symbolReference';
+import type {
+  ApexComment,
+  CommentAssociation,
+} from '../../parser/listeners/ApexCommentCollectorListener';
+import type {
+  GraphData,
+  FileGraphData,
+  TypeGraphData,
+} from '../../types/graph';
+import type { DetailLevel } from '../../parser/listeners/LayeredSymbolListenerBase';
+import type { FQNOptions } from '../../utils/FQNUtils';
+import { SymbolIndexStore as SymbolIndexStoreTag } from './symbolIndexStore';
+import type { SymbolIndexStore } from './symbolIndexStore';
+import { ReferenceStore as ReferenceStoreTag } from './referenceStore';
+import type { ReferenceStore } from './referenceStore';
+import type { CacheStore } from './cacheStore';
+import type { FileStateStore } from './fileStateStore';
+import type { ConcurrencyGuards } from './concurrencyGuards';
+import type { ResourceLoaderService } from './ResourceLoaderService';
+
+import {
+  getSymbol,
+  findByName,
+  findByFQN,
+  findInFile,
+  findFilesForSymbol,
+  getAllSymbolsForCompletion,
+  getSymbolTableForFile,
+  findFQNForStandardClass,
+  isStandardLibraryType,
+  getBlockCommentsForSymbol,
+} from '../ops/symbolLookup';
+import {
+  getContainingType,
+  getAncestorChain,
+  constructFQN,
+} from '../ops/typeHierarchy';
+import {
+  findReferencesTo,
+  findReferencesFrom,
+  findRelatedSymbols,
+  getReferencesAtPosition,
+  getAllReferencesInFile,
+} from '../ops/referenceOps';
+import {
+  analyzeDependencies,
+  detectCircularDependencies,
+  getGraphData,
+  getGraphDataForFile,
+  getGraphDataByType,
+} from '../ops/graphAnalysis';
+import {
+  find,
+  findScalarKeywordType,
+  findSObjectType,
+  findExternalType,
+  findInDefaultNamespaceOrder,
+  findInImplicitFileNamespaceSlot,
+  findInExplicitNamespace,
+  isBuiltInNamespace,
+  isSObjectContainerNamespace,
+} from '../ops/symbolProvider';
+import {
+  removeFile,
+  clear,
+  optimizeMemory,
+  setCommentAssociations,
+} from '../ops/symbolMutation';
+import {
+  resolveSymbol,
+  createResolutionContext,
+  createResolutionContextWithRequestType,
+  getDetailLevelForFile,
+} from '../ops/symbolResolution';
+
+/**
+ * Effect-based ISymbolManager interface.
+ * All methods return Effect — the target API for the decomposed architecture.
+ * Extends SymbolProvider methods (also Effect-returning).
+ */
+export interface IEffectSymbolManagerShape {
+  // SymbolProvider methods
+  readonly find: (
+    referencingType: ApexSymbol,
+    fullName: string,
+  ) => Effect.Effect<ApexSymbol | null>;
+  readonly findScalarKeywordType: (
+    name: string,
+  ) => Effect.Effect<ApexSymbol | null>;
+  readonly findSObjectType: (name: string) => Effect.Effect<ApexSymbol | null>;
+  readonly findExternalType: (
+    name: string,
+    packageName: string,
+  ) => Effect.Effect<ApexSymbol | null>;
+  readonly findInDefaultNamespaceOrder: (
+    name: string,
+    referencingType: ApexSymbol,
+  ) => Effect.Effect<ApexSymbol | null>;
+  readonly findInImplicitFileNamespaceSlot: (
+    name: string,
+    slot: number,
+    referencingType: ApexSymbol,
+  ) => Effect.Effect<ApexSymbol | null>;
+  readonly findInExplicitNamespace: (
+    namespaceName: string,
+    typeName: string,
+    referencingType: ApexSymbol,
+  ) => Effect.Effect<ApexSymbol | null>;
+  readonly isBuiltInNamespace: (
+    namespaceName: string,
+  ) => Effect.Effect<boolean>;
+  readonly isSObjectContainerNamespace: (
+    namespaceName: string,
+  ) => Effect.Effect<boolean>;
+
+  // ISymbolManager methods
+  readonly addSymbol: (
+    symbol: ApexSymbol,
+    fileUri: string,
+  ) => Effect.Effect<void>;
+  readonly getSymbol: (symbolId: string) => Effect.Effect<ApexSymbol | null>;
+  readonly findSymbolByName: (name: string) => Effect.Effect<ApexSymbol[]>;
+  readonly findSymbolByFQN: (fqn: string) => Effect.Effect<ApexSymbol | null>;
+  readonly findFQNForStandardClass: (
+    className: string,
+  ) => Effect.Effect<string | null>;
+  readonly findSymbolsInFile: (fileUri: string) => Effect.Effect<ApexSymbol[]>;
+  readonly findFilesForSymbol: (name: string) => Effect.Effect<string[]>;
+  readonly resolveCrossFileReferencesForFile: (
+    fileUri: string,
+  ) => Effect.Effect<void>;
+  readonly resolveSymbol: (
+    name: string,
+    context: SymbolResolutionContext,
+  ) => Effect.Effect<SymbolResolutionResult>;
+  readonly getAllReferencesInFile: (
+    fileUri: string,
+  ) => Effect.Effect<SymbolReference[]>;
+  readonly getAllSymbolsForCompletion: () => Effect.Effect<ApexSymbol[]>;
+  readonly findReferencesTo: (
+    symbol: ApexSymbol,
+  ) => Effect.Effect<ReferenceResult[]>;
+  readonly findReferencesFrom: (
+    symbol: ApexSymbol,
+  ) => Effect.Effect<ReferenceResult[]>;
+  readonly findRelatedSymbols: (
+    symbol: ApexSymbol,
+    relationshipType: EnumValue<typeof ReferenceType>,
+  ) => Effect.Effect<ApexSymbol[]>;
+  readonly analyzeDependencies: (
+    symbol: ApexSymbol,
+  ) => Effect.Effect<DependencyAnalysis>;
+  readonly detectCircularDependencies: () => Effect.Effect<string[][]>;
+  readonly getStats: () => Effect.Effect<{
+    totalSymbols: number;
+    totalFiles: number;
+    totalReferences: number;
+    circularDependencies: number;
+    cacheHitRate: number;
+  }>;
+  readonly clear: () => Effect.Effect<void>;
+  readonly removeFile: (fileUri: string) => Effect.Effect<void>;
+  readonly addSymbolTable: (
+    symbolTable: SymbolTable,
+    fileUri: string,
+    documentVersion?: number,
+    hasErrors?: boolean,
+  ) => Effect.Effect<void>;
+  readonly registerSymbolTableForFile: (
+    symbolTable: SymbolTable,
+    fileUri: string,
+    options?: { mergeReferences?: boolean; hasErrors?: boolean },
+  ) => Effect.Effect<SymbolTableRegistrationResult>;
+  readonly getSymbolTableForFile: (
+    fileUri: string,
+  ) => Effect.Effect<SymbolTable | undefined>;
+  readonly optimizeMemory: () => Effect.Effect<void>;
+  readonly createResolutionContext: (
+    documentText: string,
+    position: Position,
+    sourceFile: string,
+  ) => Effect.Effect<SymbolResolutionContext>;
+  readonly constructFQN: (
+    symbol: ApexSymbol,
+    options?: FQNOptions,
+  ) => Effect.Effect<string>;
+  readonly getContainingType: (
+    symbol: ApexSymbol,
+  ) => Effect.Effect<ApexSymbol | null>;
+  readonly getAncestorChain: (
+    symbol: ApexSymbol,
+  ) => Effect.Effect<ApexSymbol[]>;
+  readonly setCommentAssociations: (
+    fileUri: string,
+    associations: CommentAssociation[],
+  ) => Effect.Effect<void>;
+  readonly getBlockCommentsForSymbol: (
+    symbol: ApexSymbol,
+  ) => Effect.Effect<ApexComment[]>;
+  readonly getReferencesAtPosition: (
+    fileUri: string,
+    position: { line: number; character: number },
+  ) => Effect.Effect<SymbolReference[]>;
+  readonly getSymbolAtPosition: (
+    fileUri: string,
+    position: { line: number; character: number },
+    strategy?: SymbolResolutionStrategy,
+  ) => Effect.Effect<ApexSymbol | null>;
+  readonly getSymbolAtPositionWithinScope: (
+    fileUri: string,
+    position: { line: number; character: number },
+  ) => Effect.Effect<ApexSymbol | null>;
+  readonly createResolutionContextWithRequestType: (
+    documentText: string,
+    position: { line: number; character: number },
+    sourceFile: string,
+    requestType?: string,
+  ) => Effect.Effect<
+    SymbolResolutionContext & {
+      requestType?: string;
+      position?: { line: number; character: number };
+    }
+  >;
+  readonly getGraphData: () => Effect.Effect<GraphData>;
+  readonly getGraphDataForFile: (
+    fileUri: string,
+  ) => Effect.Effect<FileGraphData>;
+  readonly getGraphDataByType: (
+    symbolType: string,
+  ) => Effect.Effect<TypeGraphData>;
+  readonly getDetailLevelForFile: (
+    fileUri: string,
+  ) => Effect.Effect<DetailLevel | null>;
+  readonly enrichToLevel: (
+    fileUri: string,
+    targetLevel: DetailLevel,
+    documentText: string,
+  ) => Effect.Effect<void>;
+  readonly resolveWithEnrichment: <T>(
+    fileUri: string,
+    documentText: string,
+    resolver: () => T | null,
+  ) => Effect.Effect<T | null>;
+  readonly isStandardLibraryType: (name: string) => Effect.Effect<boolean>;
+}
+
+/** Effect Tag for the new Effect-based ISymbolManager */
+export class IEffectSymbolManager extends Context.Tag('IEffectSymbolManager')<
+  IEffectSymbolManager,
+  IEffectSymbolManagerShape
+>() {}
+
+/**
+ * All data services required by the facade
+ */
+type FacadeDeps =
+  | SymbolIndexStore
+  | ReferenceStore
+  | CacheStore
+  | FileStateStore
+  | ConcurrencyGuards
+  | ResourceLoaderService;
+
+/**
+ * Live implementation of IEffectSymbolManager.
+ * Thin facade: captures service context once, each method delegates
+ * to standalone functions with context provided.
+ *
+ * For methods not yet extracted to standalone functions (addSymbol,
+ * addSymbolTable, getSymbolAtPosition, etc.), the facade delegates
+ * to the existing ApexSymbolManager instance passed at construction time.
+ */
+export const iEffectSymbolManagerFromLegacy = (
+  legacyManager: import('../../types/ISymbolManager').ISymbolManager &
+    import('../../namespace/NamespaceUtils').SymbolProvider,
+): Layer.Layer<IEffectSymbolManager, never, FacadeDeps> =>
+  Layer.effect(
+    IEffectSymbolManager,
+    Effect.gen(function* () {
+      const ctx = yield* Effect.context<FacadeDeps>();
+      const provide = <A, E>(
+        eff: Effect.Effect<A, E, FacadeDeps>,
+      ): Effect.Effect<A, E> => Effect.provide(eff, ctx);
+
+      return {
+        // SymbolProvider (standalone functions)
+        find: (ref, name) => provide(find(ref, name)),
+        findScalarKeywordType: (name) => findScalarKeywordType(name),
+        findSObjectType: (name) => provide(findSObjectType(name)),
+        findExternalType: (name, pkg) => provide(findExternalType(name, pkg)),
+        findInDefaultNamespaceOrder: (name, ref) =>
+          provide(findInDefaultNamespaceOrder(name, ref)),
+        findInImplicitFileNamespaceSlot: (name, slot, ref) =>
+          provide(findInImplicitFileNamespaceSlot(name, slot, ref)),
+        findInExplicitNamespace: (ns, type, ref) =>
+          provide(findInExplicitNamespace(ns, type, ref)),
+        isBuiltInNamespace: (name) => provide(isBuiltInNamespace(name)),
+        isSObjectContainerNamespace: (name) =>
+          isSObjectContainerNamespace(name),
+
+        // Lookups (standalone functions)
+        getSymbol: (id) => provide(getSymbol(id)),
+        findSymbolByName: (name) => provide(findByName(name)),
+        findSymbolByFQN: (fqn) => provide(findByFQN(fqn)),
+        findFQNForStandardClass: (cls) => provide(findFQNForStandardClass(cls)),
+        findSymbolsInFile: (uri) => provide(findInFile(uri)),
+        findFilesForSymbol: (name) => provide(findFilesForSymbol(name)),
+        getAllSymbolsForCompletion: () => provide(getAllSymbolsForCompletion()),
+        getSymbolTableForFile: (uri) => provide(getSymbolTableForFile(uri)),
+        isStandardLibraryType: (name) => provide(isStandardLibraryType(name)),
+        getBlockCommentsForSymbol: (sym) =>
+          provide(getBlockCommentsForSymbol(sym)),
+
+        // References (standalone functions)
+        findReferencesTo: (sym) => provide(findReferencesTo(sym)),
+        findReferencesFrom: (sym) => provide(findReferencesFrom(sym)),
+        findRelatedSymbols: (sym, type) =>
+          provide(findRelatedSymbols(sym, type)),
+        getReferencesAtPosition: (uri, pos) =>
+          provide(getReferencesAtPosition(uri, pos)),
+        getAllReferencesInFile: (uri) => provide(getAllReferencesInFile(uri)),
+
+        // Type hierarchy (standalone functions)
+        getContainingType: (sym) => provide(getContainingType(sym)),
+        getAncestorChain: (sym) => getAncestorChain(sym),
+        constructFQN: (sym, opts) => provide(constructFQN(sym, opts)),
+
+        // Analysis (standalone functions)
+        analyzeDependencies: (sym) => provide(analyzeDependencies(sym)),
+        detectCircularDependencies: () => provide(detectCircularDependencies()),
+        getGraphData: () => provide(getGraphData()),
+        getGraphDataForFile: (uri) => provide(getGraphDataForFile(uri)),
+        getGraphDataByType: (type) => provide(getGraphDataByType(type)),
+
+        // Resolution (standalone functions)
+        resolveSymbol: (name, ctx) => provide(resolveSymbol(name, ctx)),
+        createResolutionContext: (text, pos, file) =>
+          provide(createResolutionContext(text, pos, file)),
+        createResolutionContextWithRequestType: (text, pos, file, type) =>
+          provide(
+            createResolutionContextWithRequestType(text, pos, file, type),
+          ),
+        getDetailLevelForFile: (uri) =>
+          provide(getDetailLevelForFile(uri)).pipe(
+            Effect.map((level) => level ?? null),
+          ),
+
+        // Mutations (standalone functions)
+        removeFile: (uri) => provide(removeFile(uri)),
+        clear: () => provide(clear()),
+        optimizeMemory: () => provide(optimizeMemory()),
+        setCommentAssociations: (uri, assoc) =>
+          provide(setCommentAssociations(uri, assoc)),
+
+        // Stats (composed from services)
+        getStats: () =>
+          provide(
+            Effect.gen(function* () {
+              const idx = yield* SymbolIndexStoreTag;
+              const idxStats = yield* idx.getStats();
+              const refs = yield* ReferenceStoreTag;
+              const refStats = yield* refs.getStats();
+              return {
+                totalSymbols: idxStats.totalSymbols,
+                totalFiles: idxStats.totalFiles,
+                totalReferences: refStats.totalReferences,
+                circularDependencies: 0,
+                cacheHitRate: 0,
+              };
+            }),
+          ),
+
+        // Legacy bridge — delegate to existing ApexSymbolManager
+        addSymbol: (sym, uri) =>
+          Effect.promise(() =>
+            Promise.resolve(legacyManager.addSymbol(sym, uri)),
+          ),
+        addSymbolTable: (st, uri, ver, err) =>
+          legacyManager.addSymbolTable(st, uri, ver, err),
+        registerSymbolTableForFile: (st, uri, opts) =>
+          legacyManager.registerSymbolTableForFile(st, uri, opts),
+        resolveCrossFileReferencesForFile: (uri) =>
+          legacyManager.resolveCrossFileReferencesForFile(uri),
+        getSymbolAtPosition: (uri, pos, strategy) =>
+          Effect.promise(() =>
+            legacyManager.getSymbolAtPosition(uri, pos, strategy),
+          ),
+        getSymbolAtPositionWithinScope: (uri, pos) =>
+          Effect.promise(() =>
+            legacyManager.getSymbolAtPositionWithinScope(uri, pos),
+          ),
+        enrichToLevel: (uri, level, text) =>
+          legacyManager.enrichToLevel(uri, level, text),
+        resolveWithEnrichment: (uri, text, resolver) =>
+          legacyManager.resolveWithEnrichment(uri, text, resolver),
+      };
+    }),
+  );

--- a/packages/apex-parser-ast/src/symbols/services/symbolResolver.ts
+++ b/packages/apex-parser-ast/src/symbols/services/symbolResolver.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Context, Effect } from 'effect';
+import type { ApexSymbol, SymbolTable } from '../../types/symbol';
+import type { SymbolReference } from '../../types/symbolReference';
+import type { GenericTypeSubstitutionMap } from '../../utils/genericTypeSubstitution';
+import type { LoggerInterface } from '@salesforce/apex-lsp-shared';
+import type { BuiltInTypeTablesImpl } from '../../utils/BuiltInTypeTables';
+import type { UnifiedCache } from '../../utils/UnifiedCache';
+import type { ResourceLoaderServiceShape } from './ResourceLoaderService';
+
+/**
+ * Context for chain resolution - discriminated union for type safety.
+ * Shared between ApexSymbolManager and extracted ops modules.
+ */
+export type ChainResolutionContext =
+  | { type: 'symbol'; symbol: ApexSymbol }
+  | { type: 'namespace'; name: string }
+  | { type: 'global' }
+  | undefined;
+
+/**
+ * Effect service tag that breaks the mutual recursion between:
+ *   resolveMemberInContext <-> addSymbolTable <-> resolveStandardApexClass
+ *
+ * Extracted ops modules depend on this service abstractly instead of
+ * calling `this` on ApexSymbolManager. The concrete implementation is
+ * wired in Phase 6 as a Layer that composes the ops.
+ */
+export interface SymbolResolverShape {
+  /** Resolve a standard Apex class by loading its SymbolTable from stdlib */
+  readonly resolveStandardApexClass: (
+    name: string,
+  ) => Effect.Effect<ApexSymbol | null>;
+
+  /** Resolve a member (property, method, inner class) within a context */
+  readonly resolveMemberInContext: (
+    context: ChainResolutionContext,
+    memberName: string,
+    memberType: 'property' | 'method' | 'class',
+    typeSubstitutions?: GenericTypeSubstitutionMap | null,
+  ) => Effect.Effect<ApexSymbol | null>;
+
+  /** Register a SymbolTable (lazy-loads stdlib when resolving) */
+  readonly addSymbolTable: (
+    symbolTable: SymbolTable,
+    fileUri: string,
+    documentVersion?: number,
+    hasErrors?: boolean,
+  ) => Effect.Effect<void>;
+
+  /** Resolve a standard library type from a symbol reference */
+  readonly resolveStandardLibraryType: (
+    typeRef: SymbolReference,
+  ) => Effect.Effect<ApexSymbol | null>;
+
+  /** Check if a name represents a standard Apex class */
+  readonly isStandardApexClass: (name: string) => Effect.Effect<boolean>;
+}
+
+export class SymbolResolver extends Context.Tag('SymbolResolver')<
+  SymbolResolver,
+  SymbolResolverShape
+>() {}
+
+/**
+ * Structural interface satisfied by ApexSymbolManager.
+ * Extracted ops functions take `self: SymbolManagerOps` as their first
+ * parameter instead of using `this`. This breaks the tight coupling to
+ * the class while keeping the refactoring mechanical (`this.` → `self.`).
+ */
+export interface SymbolManagerOps {
+  // Lookup methods (already extracted to ops, but still available on the class)
+  findSymbolByName(name: string): Promise<ApexSymbol[]>;
+  findSymbolByFQN(fqn: string): Promise<ApexSymbol | null>;
+  findSymbolsInFile(fileUri: string): Promise<ApexSymbol[]>;
+  findFQNForStandardClass(name: string): Promise<string | null>;
+  findScalarKeywordType(name: string): Promise<ApexSymbol | null>;
+  getSymbol(symbolId: string): Promise<ApexSymbol | null>;
+  getReferencesAtPosition(
+    fileUri: string,
+    position: { line: number; character: number },
+  ): Promise<SymbolReference[]>;
+  getAllReferencesInFile(fileUri: string): Promise<SymbolReference[]>;
+  getAllSymbols(): Promise<ApexSymbol[]>;
+  getContainingType(symbol: ApexSymbol): Promise<ApexSymbol | null>;
+  getSymbolTableForFile(fileUri: string): Promise<SymbolTable | undefined>;
+
+  // Recursive cluster methods
+  resolveStandardApexClass(name: string): Promise<ApexSymbol | null>;
+  resolveMemberInContext(
+    context: ChainResolutionContext,
+    memberName: string,
+    memberType: 'property' | 'method' | 'class',
+    typeSubstitutions?: GenericTypeSubstitutionMap | null,
+  ): Promise<ApexSymbol | null>;
+  resolveStandardLibraryType(
+    typeRef: SymbolReference,
+  ): Promise<ApexSymbol | null>;
+  addSymbolTable(
+    symbolTable: SymbolTable,
+    fileUri: string,
+    documentVersion?: number,
+    hasErrors?: boolean,
+  ): Promise<void>;
+  addSymbolTableAsync(
+    symbolTable: SymbolTable,
+    fileUri: string,
+    documentVersion?: number,
+    hasErrors?: boolean,
+  ): Promise<void>;
+  isStandardApexClass(name: string): boolean;
+
+  // Direct state access
+  readonly symbolRefManager: {
+    getSymbol(id: string): ApexSymbol | null;
+    getSymbolTableForFile(uri: string): SymbolTable | undefined;
+    getSymbolsInFile(uri: string): ApexSymbol[];
+    getParent(symbol: ApexSymbol): ApexSymbol | null;
+    addReference(
+      sourceId: string,
+      targetId: string,
+      type: string,
+      fileUri: string,
+    ): void;
+    enqueueDeferredReference(
+      sourceId: string,
+      targetName: string,
+      type: string,
+      fileUri: string,
+      context?: string,
+    ): void;
+    findSymbolByName(name: string): ApexSymbol[];
+    getStats(): { totalReferences: number };
+  };
+  /**
+   * Stdlib provider — always present, never null.
+   * Local workers use ResourceLoaderLive; enrichment workers use ResourceLoaderRemoteLive;
+   * tests that don't exercise stdlib use ResourceLoaderNoOpLive/ResourceLoaderNoOpInstance.
+   */
+  readonly stdlibProvider: ResourceLoaderServiceShape;
+  readonly logger: LoggerInterface;
+  readonly builtInTypeTables: BuiltInTypeTablesImpl;
+  readonly unifiedCache: UnifiedCache;
+  readonly loadingSymbolTables: Set<string>;
+  readonly inFlightStdlibHydration: Map<string, Promise<SymbolTable | null>>;
+  readonly isStaticCache: WeakMap<SymbolReference, boolean>;
+}

--- a/packages/apex-parser-ast/src/types/queue.ts
+++ b/packages/apex-parser-ast/src/types/queue.ts
@@ -68,6 +68,18 @@ export interface SchedulerMetrics {
   readonly backPressureDuration?: Readonly<Record<Priority, number>>;
   /** Back pressure metrics: back pressure event count per priority */
   readonly backPressureEvents?: Readonly<Record<Priority, number>>;
+  /** Worker topology status (present when workers are enabled) */
+  readonly workerTopology?: {
+    readonly enabled: boolean;
+    readonly dataOwner: { readonly active: boolean };
+    readonly enrichmentPool: {
+      readonly size: number;
+      readonly active: boolean;
+    };
+    readonly resourceLoader: { readonly active: boolean } | null;
+    readonly dispatchedCount: number;
+    readonly coordinatorOnlyTypes: readonly string[];
+  };
 }
 
 export interface PriorityScheduler {

--- a/packages/apex-parser-ast/src/types/symbol.ts
+++ b/packages/apex-parser-ast/src/types/symbol.ts
@@ -2047,6 +2047,9 @@ export class SymbolTable {
     position: Position,
     location: SymbolLocation,
   ): boolean {
+    if (!location?.identifierRange) {
+      return false;
+    }
     return (
       position.line >= location.identifierRange.startLine &&
       position.line <= location.identifierRange.endLine &&
@@ -2122,9 +2125,61 @@ export class SymbolTable {
    * @param json The JSON representation of a symbol table
    * @returns A new symbol table
    */
-  static fromJSON(json: any): SymbolTable {
+  /**
+   * Reconstruct a SymbolTable from wire-serialized data (JSON round-trip).
+   * Rebuilds internal HashMap index from the flat symbol array.
+   */
+  static fromSerializedData(data: {
+    symbols: ApexSymbol[];
+    references?: SymbolReference[];
+    hierarchicalReferences?: HierarchicalReference[];
+    metadata?: Partial<SymbolTableMetadata>;
+    fileUri?: string;
+  }): SymbolTable {
     const table = new SymbolTable();
-    // TODO: Implement reconstruction of symbol table from JSON
+    const uri = data.fileUri ?? data.metadata?.fileUri ?? 'unknown';
+    table.setFileUri(uri);
+    if (data.metadata) {
+      table.setMetadata(data.metadata);
+    }
+
+    for (const sym of data.symbols) {
+      const key = sym.key?.unifiedId ?? sym.id;
+      table.symbolMap.set(key, sym);
+      table.symbolArray.push(sym);
+      if (sym.parentId === null || sym.parentId === undefined) {
+        table.root = sym;
+      }
+    }
+
+    if (data.references) {
+      table.references = data.references;
+    }
+    if (data.hierarchicalReferences) {
+      table.hierarchicalReferences = data.hierarchicalReferences;
+    }
+
     return table;
+  }
+
+  static fromJSON(json: any): SymbolTable {
+    let symbols: ApexSymbol[] = json.symbolArray ?? [];
+    if (symbols.length === 0 && Array.isArray(json.symbols)) {
+      const first = json.symbols[0];
+      if (first && 'symbol' in first) {
+        symbols = json.symbols
+          .map((entry: { symbol?: ApexSymbol }) => entry.symbol)
+          .filter(Boolean) as ApexSymbol[];
+      } else {
+        symbols = json.symbols;
+      }
+    }
+    return SymbolTable.fromSerializedData({
+      symbols,
+      references: json.references ?? [],
+      hierarchicalReferences: json.hierarchicalReferences ?? [],
+      metadata: json.metadata,
+      fileUri: json.fileUri,
+    });
   }
 }

--- a/packages/apex-parser-ast/test/helpers/mockSymbolManager.ts
+++ b/packages/apex-parser-ast/test/helpers/mockSymbolManager.ts
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Effect, Layer } from 'effect';
+import type { SymbolTable } from '../../src/types/symbol';
+import type { ISymbolManager as ISymbolManagerInterface } from '../../src/types/ISymbolManager';
+import type { IEffectSymbolManagerShape } from '../../src/symbols/services/symbolManagerFacade';
+import { IEffectSymbolManager } from '../../src/symbols/services/symbolManagerFacade';
+import { ISymbolManager } from '../../src/semantics/validation/ArtifactLoadingHelper';
+import type { SymbolTableRegistrationResult } from '../../src/symbols/ApexSymbolRefManager';
+
+/** Partial overrides for mock symbol manager */
+export type MockSymbolManagerOverrides = Partial<ISymbolManagerInterface>;
+
+/**
+ * Create a mock ISymbolManager for tests. All methods return sensible defaults.
+ * Pass overrides to customize specific methods.
+ */
+export function createMockSymbolManager(
+  overrides: MockSymbolManagerOverrides = {},
+): ISymbolManagerInterface {
+  return {
+    addSymbol: jest.fn().mockResolvedValue(undefined),
+    getSymbol: jest.fn().mockResolvedValue(null),
+    findSymbolByName: jest.fn().mockResolvedValue([]),
+    findSymbolByFQN: jest.fn().mockResolvedValue(null),
+    findFQNForStandardClass: jest.fn().mockResolvedValue(null),
+    findSymbolsInFile: jest.fn().mockResolvedValue([]),
+    findFilesForSymbol: jest.fn().mockResolvedValue([]),
+    resolveCrossFileReferencesForFile: jest.fn().mockReturnValue(Effect.void),
+    resolveSymbol: jest.fn().mockResolvedValue({
+      symbol: null,
+      fileUri: '',
+      confidence: 0,
+      isAmbiguous: false,
+    }),
+    getAllReferencesInFile: jest.fn().mockResolvedValue([]),
+    getAllSymbolsForCompletion: jest.fn().mockResolvedValue([]),
+    findReferencesTo: jest.fn().mockResolvedValue([]),
+    findReferencesFrom: jest.fn().mockResolvedValue([]),
+    findRelatedSymbols: jest.fn().mockResolvedValue([]),
+    analyzeDependencies: jest.fn().mockResolvedValue({
+      dependencies: [],
+      dependents: [],
+      impactScore: 0,
+      circularDependencies: [],
+    }),
+    detectCircularDependencies: jest.fn().mockResolvedValue([]),
+    getStats: jest.fn().mockResolvedValue({
+      totalSymbols: 0,
+      totalFiles: 0,
+      totalReferences: 0,
+      circularDependencies: 0,
+      cacheHitRate: 0,
+    }),
+    clear: jest.fn().mockResolvedValue(undefined),
+    removeFile: jest.fn().mockResolvedValue(undefined),
+    addSymbolTable: jest.fn().mockReturnValue(Effect.void),
+    registerSymbolTableForFile: jest.fn().mockReturnValue(
+      Effect.succeed({
+        decision: 'accepted-replace',
+        fileUri: '',
+        canonicalTable: {} as SymbolTable,
+      } satisfies SymbolTableRegistrationResult),
+    ),
+    getSymbolTableForFile: jest.fn().mockResolvedValue(undefined),
+    optimizeMemory: jest.fn().mockResolvedValue(undefined),
+    createResolutionContext: jest.fn().mockResolvedValue({
+      sourceFile: '',
+      importStatements: [],
+      namespaceContext: '',
+      currentScope: '',
+      scopeChain: [],
+      parameterTypes: [],
+      accessModifier: 'public' as const,
+      isStatic: false,
+      inheritanceChain: [],
+      interfaceImplementations: [],
+    }),
+    constructFQN: jest.fn().mockResolvedValue(''),
+    getContainingType: jest.fn().mockResolvedValue(null),
+    getAncestorChain: jest.fn().mockResolvedValue([]),
+    setCommentAssociations: jest.fn().mockResolvedValue(undefined),
+    getBlockCommentsForSymbol: jest.fn().mockResolvedValue([]),
+    getReferencesAtPosition: jest.fn().mockResolvedValue([]),
+    getSymbolAtPosition: jest.fn().mockResolvedValue(null),
+    getSymbolAtPositionWithinScope: jest.fn().mockResolvedValue(null),
+    createResolutionContextWithRequestType: jest.fn().mockResolvedValue({
+      sourceFile: '',
+      importStatements: [],
+      namespaceContext: '',
+      currentScope: '',
+      scopeChain: [],
+      parameterTypes: [],
+      accessModifier: 'public' as const,
+      isStatic: false,
+      inheritanceChain: [],
+      interfaceImplementations: [],
+    }),
+    getGraphData: jest.fn().mockResolvedValue({ nodes: [], edges: [] }),
+    getGraphDataForFile: jest.fn().mockResolvedValue({ nodes: [], edges: [] }),
+    getGraphDataByType: jest.fn().mockResolvedValue({ nodes: [], edges: [] }),
+    getDetailLevelForFile: jest.fn().mockResolvedValue(null),
+    enrichToLevel: jest.fn().mockReturnValue(Effect.void),
+    resolveWithEnrichment: jest.fn().mockReturnValue(Effect.succeed(null)),
+    isStandardLibraryType: jest.fn().mockResolvedValue(false),
+
+    // SymbolProvider methods
+    find: jest.fn().mockResolvedValue(null),
+    findScalarKeywordType: jest.fn().mockResolvedValue(null),
+    findSObjectType: jest.fn().mockResolvedValue(null),
+    findExternalType: jest.fn().mockResolvedValue(null),
+    findInDefaultNamespaceOrder: jest.fn().mockResolvedValue(null),
+    findInImplicitFileNamespaceSlot: jest.fn().mockResolvedValue(null),
+    findInExplicitNamespace: jest.fn().mockResolvedValue(null),
+    isBuiltInNamespace: jest.fn().mockResolvedValue(false),
+    isSObjectContainerNamespace: jest.fn().mockResolvedValue(false),
+
+    ...overrides,
+  };
+}
+
+/**
+ * Create a Layer that provides a mock ISymbolManager via the Effect Tag
+ * used by validators in ArtifactLoadingHelper.
+ */
+export function createMockSymbolManagerLayer(
+  overrides: MockSymbolManagerOverrides = {},
+): Layer.Layer<typeof ISymbolManager> {
+  return Layer.succeed(ISymbolManager, createMockSymbolManager(overrides));
+}
+
+/**
+ * Create a mock IEffectSymbolManager Layer for testing the new facade.
+ * All methods return Effect-wrapped default values.
+ */
+export function createMockEffectSymbolManagerLayer(
+  overrides: Partial<IEffectSymbolManagerShape> = {},
+): Layer.Layer<IEffectSymbolManager> {
+  const defaults: IEffectSymbolManagerShape = {
+    find: () => Effect.succeed(null),
+    findScalarKeywordType: () => Effect.succeed(null),
+    findSObjectType: () => Effect.succeed(null),
+    findExternalType: () => Effect.succeed(null),
+    findInDefaultNamespaceOrder: () => Effect.succeed(null),
+    findInImplicitFileNamespaceSlot: () => Effect.succeed(null),
+    findInExplicitNamespace: () => Effect.succeed(null),
+    isBuiltInNamespace: () => Effect.succeed(false),
+    isSObjectContainerNamespace: () => Effect.succeed(false),
+
+    addSymbol: () => Effect.void,
+    getSymbol: () => Effect.succeed(null),
+    findSymbolByName: () => Effect.succeed([]),
+    findSymbolByFQN: () => Effect.succeed(null),
+    findFQNForStandardClass: () => Effect.succeed(null),
+    findSymbolsInFile: () => Effect.succeed([]),
+    findFilesForSymbol: () => Effect.succeed([]),
+    resolveCrossFileReferencesForFile: () => Effect.void,
+    resolveSymbol: () =>
+      Effect.succeed({
+        symbol: null,
+        fileUri: '',
+        confidence: 0,
+        isAmbiguous: false,
+      }),
+    getAllReferencesInFile: () => Effect.succeed([]),
+    getAllSymbolsForCompletion: () => Effect.succeed([]),
+    findReferencesTo: () => Effect.succeed([]),
+    findReferencesFrom: () => Effect.succeed([]),
+    findRelatedSymbols: () => Effect.succeed([]),
+    analyzeDependencies: () =>
+      Effect.succeed({
+        dependencies: [],
+        dependents: [],
+        impactScore: 0,
+        circularDependencies: [],
+      }),
+    detectCircularDependencies: () => Effect.succeed([]),
+    getStats: () =>
+      Effect.succeed({
+        totalSymbols: 0,
+        totalFiles: 0,
+        totalReferences: 0,
+        circularDependencies: 0,
+        cacheHitRate: 0,
+      }),
+    clear: () => Effect.void,
+    removeFile: () => Effect.void,
+    addSymbolTable: () => Effect.void,
+    registerSymbolTableForFile: () =>
+      Effect.succeed({
+        decision: 'accepted-replace',
+        fileUri: '',
+        canonicalTable: {} as SymbolTable,
+      } as SymbolTableRegistrationResult),
+    getSymbolTableForFile: () => Effect.succeed(undefined),
+    optimizeMemory: () => Effect.void,
+    createResolutionContext: () =>
+      Effect.succeed({
+        sourceFile: '',
+        importStatements: [],
+        namespaceContext: '',
+        currentScope: '',
+        scopeChain: [],
+        parameterTypes: [],
+        accessModifier: 'public' as const,
+        isStatic: false,
+        inheritanceChain: [],
+        interfaceImplementations: [],
+      }),
+    constructFQN: () => Effect.succeed(''),
+    getContainingType: () => Effect.succeed(null),
+    getAncestorChain: () => Effect.succeed([]),
+    setCommentAssociations: () => Effect.void,
+    getBlockCommentsForSymbol: () => Effect.succeed([]),
+    getReferencesAtPosition: () => Effect.succeed([]),
+    getSymbolAtPosition: () => Effect.succeed(null),
+    getSymbolAtPositionWithinScope: () => Effect.succeed(null),
+    createResolutionContextWithRequestType: () =>
+      Effect.succeed({
+        sourceFile: '',
+        importStatements: [],
+        namespaceContext: '',
+        currentScope: '',
+        scopeChain: [],
+        parameterTypes: [],
+        accessModifier: 'public' as const,
+        isStatic: false,
+        inheritanceChain: [],
+        interfaceImplementations: [],
+      }),
+    getGraphData: () => Effect.succeed({ nodes: [], edges: [] } as any),
+    getGraphDataForFile: () => Effect.succeed({ nodes: [], edges: [] } as any),
+    getGraphDataByType: () => Effect.succeed({ nodes: [], edges: [] } as any),
+    getDetailLevelForFile: () => Effect.succeed(null),
+    enrichToLevel: () => Effect.void,
+    resolveWithEnrichment: () => Effect.succeed(null),
+    isStandardLibraryType: () => Effect.succeed(false),
+  };
+
+  return Layer.succeed(IEffectSymbolManager, { ...defaults, ...overrides });
+}

--- a/packages/apex-parser-ast/test/helpers/testHelpers.ts
+++ b/packages/apex-parser-ast/test/helpers/testHelpers.ts
@@ -13,6 +13,7 @@ import {
   GlobalTypeRegistryLive,
 } from '../../src/services/GlobalTypeRegistryService';
 import { SchedulerInitializationService } from '../../src/scheduler/SchedulerInitializationService';
+import type { ResourceLoaderServiceShape } from '../../src/symbols/services/ResourceLoaderService';
 
 /**
  * Initialize ResourceLoader for testing.
@@ -28,6 +29,35 @@ export async function initializeResourceLoaderForTests(): Promise<ResourceLoader
   const resourceLoader = ResourceLoader.getInstance();
   await resourceLoader.initialize();
   return resourceLoader;
+}
+
+/**
+ * Create a ResourceLoaderServiceShape wrapping the initialized ResourceLoader singleton.
+ * Use in tests that require stdlib resolution after calling initializeResourceLoaderForTests().
+ */
+export function getResourceLoaderServiceShapeFromSingleton(): ResourceLoaderServiceShape {
+  const rl = ResourceLoader.getInstance();
+  return {
+    isStdApexNamespace: (namespace: string) => rl.isStdApexNamespace(namespace),
+    hasClass: (classPath: string) => rl.hasClass(classPath),
+    findNamespaceForClass: (className: string) =>
+      rl.findNamespaceForClass(className),
+    getStandardNamespaces: () => {
+      const original = rl.getStandardNamespaces();
+      const result = new Map<string, string[]>();
+      for (const [k, v] of original) {
+        result.set(
+          k,
+          v.map((cis) => cis.value),
+        );
+      }
+      return result;
+    },
+    resolveClassFqn: (className: string) =>
+      Promise.resolve(rl.resolveStandardClassFqn(className)),
+    getSymbolTable: (classPath: string) => rl.getSymbolTable(classPath),
+    getFile: (path: string) => rl.getFile(path),
+  };
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?

Phase 1 of the Apex Language Server worker-topology refactor — purely
additive Effect-based ops and services for symbol management, plus
small type and test-helper additions. Every export is dead code today;
no existing call site is changed.

#### `packages/apex-parser-ast/src/symbols/services/` (9 new)

- `cacheStore`, `referenceStore`, `fileStateStore`, `concurrencyGuards`
  — Effect data services backing the future split of read vs. mutate
  responsibilities across the worker pool.
- `symbolIndexStore` + `symbolIndexStoreLive` — primary symbol-index
  service Tag and a Layer providing the live in-memory implementation.
- `ResourceLoaderService` — Effect Layer wrapping the existing
  `ResourceLoader` singleton so stdlib lookups can be substituted in
  worker contexts.
- `symbolResolver` — pure resolver service that wraps the recursive
  symbol-chain walking logic.
- `symbolManagerFacade` — composes the seven new ops behind a single
  Effect Tag (`IEffectSymbolManager`) plus an
  `iEffectSymbolManagerFromLegacy` adapter for staged migration.
  Includes a one-line `Promise.resolve` bridge in the legacy adapter
  so it type-checks against the still-sync `addSymbol` signature on
  main; the wrapper drops out when Phase 2 makes it async.

#### `packages/apex-parser-ast/src/symbols/ops/` (12 new)

- `positionUtils`, `typeHierarchy`, `resolutionContext` — small
  utility ops shared across the others.
- `symbolLookup`, `symbolMutation`, `symbolProvider`, `symbolResolution`,
  `referenceOps`, `graphAnalysis`, `stdlibLoading` — the read /
  mutate / resolve API surface of the index, all consuming the new
  data services.
- `chainResolution` (3.5k LoC) and `symbolRefResolution` — the
  receiver/method chain and `SymbolReference` → `ApexSymbol`
  resolution ops, both consuming `symbolResolver`. `chainResolution`
  is kept in a single file to preserve current branch coverage; it is
  expected to fragment later.

#### `packages/apex-parser-ast/src/types/` (additive)

- `queue.ts` — optional `workerTopology` field on `SchedulerMetrics`
  carrying data-owner / enrichment-pool / resource-loader status,
  dispatched count, and coordinator-only request types.
- `symbol.ts` — defensive `identifierRange` guard in
  `SymbolTable.isPositionInIdentifierRange`, and a real implementation
  for `SymbolTable.fromJSON` (was returning an empty table) routed
  through a new `fromSerializedData` accepting both legacy
  `symbolArray` and wire-format `symbols` shapes. Required for IPC
  reconstruction across worker boundaries.

#### `packages/apex-parser-ast/test/helpers/` (additive)

- `mockSymbolManager.ts` — configurable `IEffectSymbolManagerShape`
  mock for upcoming op-level tests.
- `testHelpers.ts` — `getResourceLoaderServiceShapeFromSingleton`
  helper for tests that need stdlib resolution through the new
  service shape.

#### `packages/apex-parser-ast/src/index.ts`

- Re-exports the new Effect services, Tags, Layers, and Shape types.
- Re-exports op functions with the `*Op` suffix
  (`getSymbolOp`, `findByNameOp`, `resolveSymbolOp`, …) to avoid
  collision with method names on the legacy `ApexSymbolManager`.

### Notes

- 9 logically grouped commits in dependency order; every commit
  passes lint + the full test suite (husky pre-commit hook), so
  `git bisect` stays usable.
- Test suite: 4140 passed / 0 failed (488 pending) on the tip commit.
- The `HashingUtils` test referenced in the original story scope is
  already on main (landed via W-22109681 / #331); not duplicated
  here.
- Phase 2 (W-22201104) flips `ApexSymbolManager` callers to the
  facade. This PR sets up the surface area only.

### What issues does this PR fix or reference?

@W-22201103@


Made with [Cursor](https://cursor.com)