### PR TITLE
chore: make ISymbolManager resolveWithEnrichment support async resolvers - W-22201104

### DIFF
--- a/packages/apex-lsp-shared/test/settings/ApexLanguageServerSettings.test.ts
+++ b/packages/apex-lsp-shared/test/settings/ApexLanguageServerSettings.test.ts
@@ -286,7 +286,7 @@ describe('ApexLanguageServerSettings Validation', () => {
       const result = mergeWithDefaults({}, 'desktop');
 
       expect(
-        result.apex.deferredReferenceProcessing.enableCrossFileDeferral,
+        result.apex.deferredReferenceProcessing?.enableCrossFileDeferral,
       ).toBe(false);
     });
 
@@ -302,7 +302,7 @@ describe('ApexLanguageServerSettings Validation', () => {
       const result = mergeWithDefaults(partialConfig, 'desktop');
 
       expect(
-        result.apex.deferredReferenceProcessing.enableCrossFileDeferral,
+        result.apex.deferredReferenceProcessing?.enableCrossFileDeferral,
       ).toBe(true);
     });
   });

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
@@ -6040,12 +6040,12 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
   resolveWithEnrichment<T>(
     fileUri: string,
     documentText: string,
-    resolver: () => T | null,
+    resolver: () => Promise<T | null> | T | null,
   ): Effect.Effect<T | null, never, never> {
     const self = this;
     return Effect.gen(function* () {
       // Try at current level first
-      const result = resolver();
+      const result = yield* Effect.promise(() => Promise.resolve(resolver()));
       if (result !== null) {
         return result;
       }
@@ -6068,7 +6068,10 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
         yield* self.enrichToLevel(fileUri, layer, documentText);
 
         // Try resolution after enrichment
-        const enrichedResult = resolver();
+        const enrichedResult = yield* Effect.promise(() =>
+          Promise.resolve(resolver()),
+        );
+
         if (enrichedResult !== null) {
           self.logger.debug(
             () => `Found symbol after enriching to ${layer} level`,

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolRefManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolRefManager.ts
@@ -3381,11 +3381,11 @@ export class ApexSymbolRefManager {
     return this.forwardIndex;
   }
 
-  public getFileToSymbolTable(): HashMap<string, SymbolTable> {
+  public getFileToSymbolTable(): CaseInsensitiveHashMap<SymbolTable> {
     return this.fileToSymbolTable;
   }
 
-  public getFileIndex(): HashMap<string, string[]> {
+  public getFileIndex(): CaseInsensitiveHashMap<string[]> {
     return this.fileIndex;
   }
 

--- a/packages/apex-parser-ast/src/symbols/services/symbolManagerFacade.ts
+++ b/packages/apex-parser-ast/src/symbols/services/symbolManagerFacade.ts
@@ -266,7 +266,7 @@ export interface IEffectSymbolManagerShape {
   readonly resolveWithEnrichment: <T>(
     fileUri: string,
     documentText: string,
-    resolver: () => T | null,
+    resolver: () => Promise<T | null> | T | null,
   ) => Effect.Effect<T | null>;
   readonly isStandardLibraryType: (name: string) => Effect.Effect<boolean>;
 }

--- a/packages/apex-parser-ast/src/types/ISymbolManager.ts
+++ b/packages/apex-parser-ast/src/types/ISymbolManager.ts
@@ -202,7 +202,7 @@ export interface ISymbolManager extends SymbolProvider {
   resolveWithEnrichment<T>(
     fileUri: string,
     documentText: string,
-    resolver: () => T | null,
+    resolver: () => Promise<T | null> | T | null,
   ): Effect.Effect<T | null, never, never>;
 
   isStandardLibraryType(name: string): Promise<boolean>;


### PR DESCRIPTION
## Summary
- Update `resolveWithEnrichment` to accept async resolvers (`() => Promise<T | null> | T | null`)
- Fix return types on `getFileToSymbolTable` and `getFileIndex` to use `CaseInsensitiveHashMap`
- Add optional chaining in test assertions for `deferredReferenceProcessing`

## Test plan
- [x] All existing tests pass (4150 passed, 0 failed)
- [x] Lint and prettier checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)