### PR TITLE
fix(apex-lsp-web): add jest types and fix test tsconfig excludes - W-22201108

### DIFF
--- a/packages/apex-ls/test/integration/RemoteStdlibResolution.debug.node.test.ts
+++ b/packages/apex-ls/test/integration/RemoteStdlibResolution.debug.node.test.ts
@@ -14,7 +14,11 @@
  * The fix calls SymbolTable.fromSerializedData() to reconstruct.
  */
 
-import { SymbolTable } from '@salesforce/apex-lsp-parser-ast';
+import {
+  SymbolKind,
+  SymbolTable,
+  SymbolVisibility,
+} from '@salesforce/apex-lsp-parser-ast';
 
 describe('Remote stdlib SymbolTable deserialization', () => {
   it('SymbolTable.fromSerializedData reconstructs from a plain object', () => {
@@ -22,8 +26,9 @@ describe('Remote stdlib SymbolTable deserialization', () => {
     const serialized = {
       symbols: [
         {
+          id: 'system-string',
           name: 'String',
-          kind: 'class',
+          kind: SymbolKind.Class,
           location: {
             symbolRange: {
               startLine: 1,
@@ -38,7 +43,27 @@ describe('Remote stdlib SymbolTable deserialization', () => {
               endColumn: 19,
             },
           },
-          modifiers: { isBuiltIn: true },
+          fileUri: 'apexlib://resources/StandardApexLibrary/System/String.cls',
+          parentId: null,
+          key: {
+            prefix: 'class',
+            name: 'String',
+            path: ['System'],
+            unifiedId: 'system-string',
+          },
+          _isLoaded: true,
+          modifiers: {
+            visibility: SymbolVisibility.Public,
+            isStatic: false,
+            isFinal: false,
+            isAbstract: false,
+            isVirtual: false,
+            isOverride: false,
+            isTransient: false,
+            isTestMethod: false,
+            isWebService: false,
+            isBuiltIn: true,
+          },
         },
       ],
       references: [],

--- a/packages/apex-ls/test/tsconfig.json
+++ b/packages/apex-ls/test/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "rootDir": ".."
+    "rootDir": "..",
+    "types": ["node", "node/net", "node/stream", "node/buffer", "node/process", "jest"]
   },
-  "include": ["**/*.ts", "../src/**/*.ts"]
+  "include": ["**/*.ts", "../src/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- Add `jest` to the `types` array in `packages/apex-ls/test/tsconfig.json` so the IDE resolves `describe`/`it`/`expect` globals
- Override inherited `exclude` patterns that were inadvertently excluding the test files themselves
- Complete the `ApexSymbol` interface in `RemoteStdlibResolution.debug.node.test.ts` test fixture (add missing `id`, `fileUri`, `parentId`, `key`, `_isLoaded`, and full `modifiers`)

## Test plan
- [x] `tsc --noEmit` passes with no "Cannot find name 'describe'" errors
- [x] All tests pass (4216 passed, 0 failed)
- [x] Lint/Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)