### PR TITLE
feat(apex-lsp-extension): worker topology UI, status bar loading, and graph scope picker - W-22201120

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
+    env:
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/packages/apex-ls/src/server/LCSAdapter.ts
+++ b/packages/apex-ls/src/server/LCSAdapter.ts
@@ -938,10 +938,10 @@ export class LCSAdapter {
               'metrics' in result &&
               this.workerDispatcher?.getTopologyStatus
             ) {
-              const metrics = (result as { metrics: Record<string, unknown> })
-                .metrics;
-              metrics.workerTopology =
-                this.workerDispatcher.getTopologyStatus();
+              (result as { metrics: Record<string, unknown> }).metrics = {
+                ...(result as { metrics: Record<string, unknown> }).metrics,
+                workerTopology: this.workerDispatcher.getTopologyStatus(),
+              };
             }
             this.logger.debug(
               () =>

--- a/packages/apex-ls/src/server/LCSAdapter.ts
+++ b/packages/apex-ls/src/server/LCSAdapter.ts
@@ -938,7 +938,9 @@ export class LCSAdapter {
               'metrics' in result &&
               this.workerDispatcher?.getTopologyStatus
             ) {
-              (result as any).metrics.workerTopology =
+              const metrics = (result as { metrics: Record<string, unknown> })
+                .metrics;
+              metrics.workerTopology =
                 this.workerDispatcher.getTopologyStatus();
             }
             this.logger.debug(
@@ -1479,18 +1481,18 @@ export class LCSAdapter {
           // Callback function to send notifications to client
           const notificationCallback = (metrics: SchedulerMetrics) => {
             try {
-              const enrichedMetrics = this.workerDispatcher?.getTopologyStatus
-                ? {
-                    ...metrics,
-                    workerTopology: this.workerDispatcher.getTopologyStatus(),
-                  }
-                : metrics;
               this.logger.debug(
                 () =>
                   `Sending queue state notification: Started=${
                     metrics.tasksStarted
                   }, Completed=${metrics.tasksCompleted}`,
               );
+              const enrichedMetrics = this.workerDispatcher?.getTopologyStatus
+                ? {
+                    ...metrics,
+                    workerTopology: this.workerDispatcher.getTopologyStatus(),
+                  }
+                : metrics;
               this.connection.sendNotification('apex/queueStateChanged', {
                 metrics: enrichedMetrics,
                 metadata: {

--- a/packages/apex-ls/src/server/LCSAdapter.ts
+++ b/packages/apex-ls/src/server/LCSAdapter.ts
@@ -125,6 +125,15 @@ export class LCSAdapter {
       includeDiagnostics?: boolean;
     }): Promise<unknown>;
     isAvailable(): boolean;
+    getTopologyStatus?(): {
+      enabled: boolean;
+      dataOwner: { active: boolean };
+      enrichmentPool: { size: number; active: boolean };
+      resourceLoader: { active: boolean } | null;
+      compilation: { active: boolean };
+      dispatchedCount: number;
+      coordinatorOnlyTypes: readonly string[];
+    };
   };
   private workerPlatformWebUrl: string | undefined;
   private clientCapabilities?: ClientCapabilities;
@@ -923,6 +932,15 @@ export class LCSAdapter {
           );
           try {
             const result = await dispatchProcessOnQueueState(params);
+            if (
+              result &&
+              typeof result === 'object' &&
+              'metrics' in result &&
+              this.workerDispatcher?.getTopologyStatus
+            ) {
+              (result as any).metrics.workerTopology =
+                this.workerDispatcher.getTopologyStatus();
+            }
             this.logger.debug(
               () =>
                 `✅ apex/queueState processed successfully, result type: ${typeof result}`,
@@ -1461,6 +1479,12 @@ export class LCSAdapter {
           // Callback function to send notifications to client
           const notificationCallback = (metrics: SchedulerMetrics) => {
             try {
+              const enrichedMetrics = this.workerDispatcher?.getTopologyStatus
+                ? {
+                    ...metrics,
+                    workerTopology: this.workerDispatcher.getTopologyStatus(),
+                  }
+                : metrics;
               this.logger.debug(
                 () =>
                   `Sending queue state notification: Started=${
@@ -1468,7 +1492,7 @@ export class LCSAdapter {
                   }, Completed=${metrics.tasksCompleted}`,
               );
               this.connection.sendNotification('apex/queueStateChanged', {
-                metrics,
+                metrics: enrichedMetrics,
                 metadata: {
                   timestamp: Date.now(),
                 },

--- a/packages/apex-lsp-vscode-extension/src/graph/showGraph.ts
+++ b/packages/apex-lsp-vscode-extension/src/graph/showGraph.ts
@@ -423,6 +423,33 @@ export async function showGraph(context: vscode.ExtensionContext) {
   const fileUri = activeEditor?.document.uri.toString();
   const isApexFile = activeEditor?.document.languageId === 'apex';
 
+  let scopeChoice: 'file' | 'all';
+  if (fileUri && isApexFile) {
+    const picked = await vscode.window.showQuickPick(
+      [
+        {
+          label: 'Current File',
+          description: activeEditor!.document.fileName,
+          value: 'file' as const,
+        },
+        {
+          label: 'All Types',
+          description: 'Show the entire type graph',
+          value: 'all' as const,
+        },
+      ],
+      { placeHolder: 'Graph scope', title: 'Symbol Graph' },
+    );
+    if (!picked) {
+      return;
+    }
+    scopeChoice = picked.value;
+  } else {
+    scopeChoice = 'all';
+  }
+
+  const useFile = scopeChoice === 'file' && fileUri && isApexFile;
+
   // Get graph data from language server (custom request)
   let graphData: GraphData & {
     diagnostics?: unknown[];
@@ -432,11 +459,11 @@ export async function showGraph(context: vscode.ExtensionContext) {
   try {
     // Try to get data from language server, include diagnostics when viewing Apex file
     const requestParams: Record<string, unknown> = {
-      type: fileUri && isApexFile ? 'file' : 'all',
+      type: useFile ? 'file' : 'all',
       includeMetadata: true,
-      includeDiagnostics: !!fileUri && isApexFile,
+      includeDiagnostics: !!useFile,
     };
-    if (fileUri && isApexFile) {
+    if (useFile) {
       requestParams.fileUri = fileUri;
     }
 

--- a/packages/apex-lsp-vscode-extension/src/graph/showGraph.ts
+++ b/packages/apex-lsp-vscode-extension/src/graph/showGraph.ts
@@ -429,7 +429,7 @@ export async function showGraph(context: vscode.ExtensionContext) {
       [
         {
           label: 'Current File',
-          description: activeEditor!.document.fileName,
+          description: activeEditor?.document.fileName ?? '',
           value: 'file' as const,
         },
         {

--- a/packages/apex-lsp-vscode-extension/src/language-server.ts
+++ b/packages/apex-lsp-vscode-extension/src/language-server.ts
@@ -1380,6 +1380,7 @@ export async function restartLanguageServer(
  */
 export async function stopLanguageServer(): Promise<void> {
   logToOutputChannel('🛑 Stopping Apex Language Server...', 'info');
+  clearIngestionTimeout();
   if (Client) {
     try {
       await Client.dispose();

--- a/packages/apex-lsp-vscode-extension/src/language-server.ts
+++ b/packages/apex-lsp-vscode-extension/src/language-server.ts
@@ -80,6 +80,16 @@ const sharedWorkspaceLoadLayer = Layer.mergeAll(
   WorkspaceStateLive,
 );
 
+function registerIngestionCompleteHandler(client: ClientInterface) {
+  client.onNotification('apex/workspaceIngestionComplete', () => {
+    logToOutputChannel(
+      '✅ Server workspace ingestion complete — updating status bar',
+      'debug',
+    );
+    updateApexServerStatusReady();
+  });
+}
+
 /**
  * Environment detection
  */
@@ -862,14 +872,7 @@ async function createWebLanguageClient(
     },
   );
 
-  // Clear the status bar spinner once the server finishes ingesting workspace files
-  Client.onNotification('apex/workspaceIngestionComplete', () => {
-    logToOutputChannel(
-      '✅ Server workspace ingestion complete — updating status bar',
-      'debug',
-    );
-    updateApexServerStatusReady();
-  });
+  registerIngestionCompleteHandler(Client);
 
   // Initialize the language server
   logToOutputChannel('🔧 Creating initialization parameters...', 'debug');
@@ -1304,14 +1307,7 @@ async function createDesktopLanguageClient(
     },
   );
 
-  // Clear the status bar spinner once the server finishes ingesting workspace files
-  Client.onNotification('apex/workspaceIngestionComplete', () => {
-    logToOutputChannel(
-      '✅ Server workspace ingestion complete — updating status bar',
-      'debug',
-    );
-    updateApexServerStatusReady();
-  });
+  registerIngestionCompleteHandler(Client);
 
   logToOutputChannel('✅ Node.js language client started successfully', 'info');
 

--- a/packages/apex-lsp-vscode-extension/src/language-server.ts
+++ b/packages/apex-lsp-vscode-extension/src/language-server.ts
@@ -41,6 +41,7 @@ import {
   updateApexServerStatusReady,
   updateApexServerStatusError,
   updateApexServerStatusStopped,
+  clearIngestionTimeout,
 } from './status-bar';
 import {
   getWorkspaceSettings,
@@ -82,6 +83,7 @@ const sharedWorkspaceLoadLayer = Layer.mergeAll(
 
 function registerIngestionCompleteHandler(client: ClientInterface) {
   client.onNotification('apex/workspaceIngestionComplete', () => {
+    clearIngestionTimeout();
     logToOutputChannel(
       '✅ Server workspace ingestion complete — updating status bar',
       'debug',

--- a/packages/apex-lsp-vscode-extension/src/language-server.ts
+++ b/packages/apex-lsp-vscode-extension/src/language-server.ts
@@ -176,6 +176,15 @@ const createEnhancedInitializationOptions = async (
     }
   }
 
+  const workerPlatformWebUrl =
+    runtimePlatform === 'web'
+      ? vscode.Uri.joinPath(
+          context.extensionUri,
+          'dist',
+          'worker.platform.web.js',
+        ).toString()
+      : undefined;
+
   const enhancedOptions: ApexLanguageServerSettings = {
     apex: {
       ...safeSettings.apex,
@@ -187,6 +196,7 @@ const createEnhancedInitializationOptions = async (
         extensionVersion,
         workspaceFileCount,
         apexFileCount,
+        workerPlatformWebUrl,
       },
       resources: {
         ...safeSettings.apex?.resources,
@@ -852,6 +862,15 @@ async function createWebLanguageClient(
     },
   );
 
+  // Clear the status bar spinner once the server finishes ingesting workspace files
+  Client.onNotification('apex/workspaceIngestionComplete', () => {
+    logToOutputChannel(
+      '✅ Server workspace ingestion complete — updating status bar',
+      'debug',
+    );
+    updateApexServerStatusReady();
+  });
+
   // Initialize the language server
   logToOutputChannel('🔧 Creating initialization parameters...', 'debug');
 
@@ -1284,6 +1303,15 @@ async function createDesktopLanguageClient(
       }
     },
   );
+
+  // Clear the status bar spinner once the server finishes ingesting workspace files
+  Client.onNotification('apex/workspaceIngestionComplete', () => {
+    logToOutputChannel(
+      '✅ Server workspace ingestion complete — updating status bar',
+      'debug',
+    );
+    updateApexServerStatusReady();
+  });
 
   logToOutputChannel('✅ Node.js language client started successfully', 'info');
 

--- a/packages/apex-lsp-vscode-extension/src/server-config.ts
+++ b/packages/apex-lsp-vscode-extension/src/server-config.ts
@@ -7,6 +7,7 @@
  */
 
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
@@ -98,6 +99,19 @@ const getProfilingFlags = (runtimePlatform: 'desktop' | 'web'): string[] => {
   }
 
   if (flags.length > 0) {
+    // Pre-create per-role subdirectories so workers can write profiles
+    // immediately on startup (WorkerExecArgvBuilder rewrites the dir
+    // flags to <outputDir>/<role>).
+    const workerRoles = [
+      'dataOwner',
+      'enrichmentSearch',
+      'resourceLoader',
+      'compilation',
+    ];
+    for (const role of workerRoles) {
+      fs.mkdirSync(path.join(outputDir, role), { recursive: true });
+    }
+
     logToOutputChannel(
       `Profiling enabled: ${profilingType} (flags: ${flags.join(', ')})`,
       'info',

--- a/packages/apex-lsp-vscode-extension/src/settings/showPerformanceSettings.ts
+++ b/packages/apex-lsp-vscode-extension/src/settings/showPerformanceSettings.ts
@@ -151,6 +151,15 @@ async function saveSettingsToConfig(
       );
     }
   }
+
+  // Update experimental workers settings
+  if (settings.experimental?.workers) {
+    await apexConfig.update(
+      'experimental.workers',
+      settings.experimental.workers,
+      configTarget,
+    );
+  }
 }
 
 /**

--- a/packages/apex-lsp-vscode-extension/src/status-bar.ts
+++ b/packages/apex-lsp-vscode-extension/src/status-bar.ts
@@ -222,6 +222,15 @@ export const createApexServerStatusItem = (
   context.subscriptions.push(apexServerStatusItem);
 };
 
+export const updateApexServerStatusLoading = (message: string) => {
+  if (apexServerStatusItem) {
+    apexServerStatusItem.text = `$(sync~spin) ${message}`;
+    apexServerStatusItem.detail = 'Loading Apex workspace';
+    apexServerStatusItem.severity = vscode.LanguageStatusSeverity.Information;
+    apexServerStatusItem.busy = true;
+  }
+};
+
 export const updateApexServerStatusStarting = () => {
   if (apexServerStatusItem) {
     const currentLogLevel = getLogLevel();

--- a/packages/apex-lsp-vscode-extension/src/status-bar.ts
+++ b/packages/apex-lsp-vscode-extension/src/status-bar.ts
@@ -231,6 +231,27 @@ export const updateApexServerStatusLoading = (message: string) => {
   }
 };
 
+let ingestionTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+const INGESTION_TIMEOUT_MS = 5 * 60 * 1000;
+
+export function startIngestionTimeout() {
+  clearIngestionTimeout();
+  ingestionTimeoutHandle = setTimeout(() => {
+    logToOutputChannel(
+      '⚠️ Ingestion complete notification not received within 5 minutes — clearing spinner',
+      'warning',
+    );
+    updateApexServerStatusReady();
+  }, INGESTION_TIMEOUT_MS);
+}
+
+export function clearIngestionTimeout() {
+  if (ingestionTimeoutHandle !== undefined) {
+    clearTimeout(ingestionTimeoutHandle);
+    ingestionTimeoutHandle = undefined;
+  }
+}
+
 export const updateApexServerStatusStarting = () => {
   if (apexServerStatusItem) {
     const currentLogLevel = getLogLevel();

--- a/packages/apex-lsp-vscode-extension/src/webviews/performanceSettingsScript.ts
+++ b/packages/apex-lsp-vscode-extension/src/webviews/performanceSettingsScript.ts
@@ -206,14 +206,18 @@ class PerformanceSettingsUI {
 
     const settings = this.currentSettings?.apex || {};
 
-    content.innerHTML = `
-      <div id="status-message" class="status-message"></div>
-      ${this.renderQueueSettings(settings.queueProcessing, settings.scheduler)}
-      ${this.renderDeferredReferenceProcessing(settings.deferredReferenceProcessing)}
-      ${this.renderLoadWorkspace(settings.loadWorkspace)}
-      ${this.renderPerformance(settings.performance)}
-      ${this.renderCommentCollection(settings.commentCollection)}
-    `;
+    const sections = [
+      '<div id="status-message" class="status-message"></div>',
+      this.renderQueueSettings(settings.queueProcessing, settings.scheduler),
+      this.renderDeferredReferenceProcessing(
+        settings.deferredReferenceProcessing,
+      ),
+      this.renderLoadWorkspace(settings.loadWorkspace),
+      this.renderPerformance(settings.performance),
+      this.renderCommentCollection(settings.commentCollection),
+      this.renderExperimentalWorkers(settings.experimental),
+    ];
+    content.innerHTML = sections.join('\n');
 
     // Re-attach event listeners and update button state after render
     this.setupInputListeners();
@@ -905,6 +909,59 @@ class PerformanceSettingsUI {
                        ${def.enableForFoldingRanges ? 'checked' : ''}>
                 <span class="setting-label-text">Enable for Folding Ranges</span>
               </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderExperimentalWorkers(experimentalSettings: any): string {
+    const expanded = this.expandedSections.has('experimentalWorkers');
+    const workers = experimentalSettings?.workers || {
+      enabled: true,
+      poolSize: 2,
+      resourceLoader: true,
+    };
+
+    return `
+      <div class="settings-section" id="experimentalWorkers">
+        <div class="section-header">
+          <div class="section-title">Experimental Workers</div>
+          <div class="section-toggle">${expanded ? '▼' : '▶'}</div>
+        </div>
+        <div class="section-content ${expanded ? 'expanded' : ''}">
+          <div class="setting-help" style="margin-bottom: 12px; color: var(--vscode-descriptionForeground);">
+            Offload LSP processing to internal worker threads for improved responsiveness in large workspaces.
+            Changes require a server restart to take effect.
+          </div>
+          <div class="setting-group">
+            <div class="setting-item">
+              <label class="setting-label">
+                <input type="checkbox"
+                       data-path="experimental.workers.enabled"
+                       ${workers.enabled ? 'checked' : ''}>
+                <span class="setting-label-text">Enable Worker Threads</span>
+              </label>
+              <div class="setting-help">Master switch for internal worker thread topology (default: off)</div>
+            </div>
+            <div class="setting-item">
+              <label class="setting-label">
+                <span class="setting-label-text">Enrichment Pool Size</span>
+              </label>
+              <input type="number" class="setting-input"
+                     data-path="experimental.workers.poolSize"
+                     value="${workers.poolSize}" min="1" max="14">
+              <div class="setting-help">Number of enrichment/search worker threads (default: 2, max: cpus-2)</div>
+            </div>
+            <div class="setting-item">
+              <label class="setting-label">
+                <input type="checkbox"
+                       data-path="experimental.workers.resourceLoader"
+                       ${workers.resourceLoader ? 'checked' : ''}>
+                <span class="setting-label-text">Dedicated Resource Loader</span>
+              </label>
+              <div class="setting-help">Spawn a dedicated worker for stdlib/library loading (default: on)</div>
             </div>
           </div>
         </div>

--- a/packages/apex-lsp-vscode-extension/src/webviews/performanceSettingsScript.ts
+++ b/packages/apex-lsp-vscode-extension/src/webviews/performanceSettingsScript.ts
@@ -956,7 +956,7 @@ class PerformanceSettingsUI {
                        ${workers.enabled ? 'checked' : ''}>
                 <span class="setting-label-text">Enable Worker Threads</span>
               </label>
-              <div class="setting-help">Master switch for internal worker thread topology (default: off)</div>
+              <div class="setting-help">Master switch for internal worker thread topology (default: on)</div>
             </div>
             <div class="setting-item">
               <label class="setting-label">

--- a/packages/apex-lsp-vscode-extension/src/webviews/performanceSettingsScript.ts
+++ b/packages/apex-lsp-vscode-extension/src/webviews/performanceSettingsScript.ts
@@ -61,6 +61,17 @@ interface PerformanceSettings {
     enableForDocumentSymbols: boolean;
     enableForFoldingRanges: boolean;
   };
+  experimental?: ExperimentalSettings;
+}
+
+interface ExperimentalWorkersSettings {
+  enabled: boolean;
+  poolSize: number;
+  resourceLoader: boolean;
+}
+
+interface ExperimentalSettings {
+  workers?: ExperimentalWorkersSettings;
 }
 
 const PRIORITIES = [
@@ -916,9 +927,11 @@ class PerformanceSettingsUI {
     `;
   }
 
-  private renderExperimentalWorkers(experimentalSettings: any): string {
+  private renderExperimentalWorkers(
+    experimentalSettings: ExperimentalSettings | undefined,
+  ): string {
     const expanded = this.expandedSections.has('experimentalWorkers');
-    const workers = experimentalSettings?.workers || {
+    const workers: ExperimentalWorkersSettings = experimentalSettings?.workers || {
       enabled: true,
       poolSize: 2,
       resourceLoader: true,

--- a/packages/apex-lsp-vscode-extension/src/webviews/performanceSettingsScript.ts
+++ b/packages/apex-lsp-vscode-extension/src/webviews/performanceSettingsScript.ts
@@ -931,11 +931,12 @@ class PerformanceSettingsUI {
     experimentalSettings: ExperimentalSettings | undefined,
   ): string {
     const expanded = this.expandedSections.has('experimentalWorkers');
-    const workers: ExperimentalWorkersSettings = experimentalSettings?.workers || {
-      enabled: true,
-      poolSize: 2,
-      resourceLoader: true,
-    };
+    const workers: ExperimentalWorkersSettings =
+      experimentalSettings?.workers || {
+        enabled: true,
+        poolSize: 2,
+        resourceLoader: true,
+      };
 
     return `
       <div class="settings-section" id="experimentalWorkers">

--- a/packages/apex-lsp-vscode-extension/src/webviews/queueStateScript.ts
+++ b/packages/apex-lsp-vscode-extension/src/webviews/queueStateScript.ts
@@ -28,7 +28,7 @@ interface WorkerTopologyStatus {
   resourceLoader: { active: boolean } | null;
   compilation: { active: boolean };
   dispatchedCount: number;
-  coordinatorOnlyTypes: string[];
+  coordinatorOnlyTypes: readonly string[];
 }
 
 interface QueueStateData {

--- a/packages/apex-lsp-vscode-extension/src/webviews/queueStateScript.ts
+++ b/packages/apex-lsp-vscode-extension/src/webviews/queueStateScript.ts
@@ -21,6 +21,16 @@ interface WindowWithVSCode extends Window {
 declare function acquireVsCodeApi(): any;
 declare const initialData: any;
 
+interface WorkerTopologyStatus {
+  enabled: boolean;
+  dataOwner: { active: boolean };
+  enrichmentPool: { size: number; active: boolean };
+  resourceLoader: { active: boolean } | null;
+  compilation: { active: boolean };
+  dispatchedCount: number;
+  coordinatorOnlyTypes: string[];
+}
+
 interface QueueStateData {
   metrics: {
     queueSizes: Record<number, number>;
@@ -33,6 +43,7 @@ interface QueueStateData {
     queueUtilization?: Record<number, number>;
     activeTasks?: Record<number, number>;
     queueCapacity?: number | Record<number, number>;
+    workerTopology?: WorkerTopologyStatus;
   };
   metadata: {
     timestamp: number;
@@ -222,6 +233,12 @@ class QueueStateDashboard {
       </div>
     `;
 
+    // Build set of coordinator-only types for dispatch indicator
+    const coordinatorOnlySet = new Set(
+      metrics.workerTopology?.coordinatorOnlyTypes || [],
+    );
+    const workersEnabled = !!metrics.workerTopology?.enabled;
+
     // Render priority sections in priority order (1-5: Immediate, High, Normal, Low, Background)
     const priorityOrder = [1, 2, 3, 4, 5]; // Priority enum values
     const prioritySectionsHtml = priorityOrder
@@ -285,9 +302,25 @@ class QueueStateDashboard {
               return '';
             }
 
+            const coordStyle =
+              'font-size:10px;color:var(--vscode-descriptionForeground)' +
+              ';margin-left:6px';
+            const coordSpan =
+              `<span style="${coordStyle}"` +
+              ' title="Runs on coordinator thread">coord</span>';
+
+            const workerSpan =
+              '<span style="font-size:10px;color:#4CAF50;margin-left:6px" title="Dispatched to worker">worker</span>';
+            let dispatchTag = '';
+            if (workersEnabled) {
+              dispatchTag = coordinatorOnlySet.has(type)
+                ? coordSpan
+                : workerSpan;
+            }
+
             return `
               <div class="request-type-item">
-                <span class="request-type-name">${this.escapeHtml(type)}</span>
+                <span class="request-type-name">${this.escapeHtml(type)}${dispatchTag}</span>
                 <span class="request-type-count">${queued}/${active}/${processed}</span>
               </div>
             `;
@@ -349,10 +382,85 @@ class QueueStateDashboard {
       })
       .join('');
 
-    content.innerHTML = overviewHtml + prioritySectionsHtml;
+    const workerTopologyHtml = this.renderWorkerTopology(
+      metrics.workerTopology,
+    );
+    content.innerHTML =
+      overviewHtml + workerTopologyHtml + prioritySectionsHtml;
 
     // Set up toggle handlers (try to set up if not already done)
     this.setupPriorityToggles();
+  }
+
+  private renderWorkerTopology(
+    topology: WorkerTopologyStatus | undefined,
+  ): string {
+    /* eslint-disable max-len */
+    if (!topology || !topology.enabled) {
+      return `
+        <div class="worker-topology-section" style="margin:16px 0;padding:12px 16px;background:var(--vscode-editor-background);border:1px solid var(--vscode-panel-border);border-radius:6px;opacity:0.6">
+          <div style="font-size:13px;color:var(--vscode-descriptionForeground)">Worker topology not active</div>
+        </div>
+      `;
+    }
+
+    const dot =
+      'display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px';
+    const activeDot = `${dot};background:#4CAF50`;
+    const inactiveDot = `${dot};background:#9E9E9E`;
+
+    const roleCard = (
+      label: string,
+      active: boolean,
+      detail: string,
+    ): string => {
+      const dotStyle = active ? activeDot : inactiveDot;
+      const state = active ? 'Active' : 'Inactive';
+      return [
+        '<div style="flex:1;min-width:140px;padding:10px 14px;background:var(--vscode-editor-background);border:1px solid var(--vscode-panel-border);border-radius:6px">',
+        `<div style="font-size:11px;color:var(--vscode-descriptionForeground);margin-bottom:4px">${label}</div>`,
+        `<div style="font-size:13px;display:flex;align-items:center"><span style="${dotStyle}"></span>${state}</div>`,
+        `<div style="font-size:11px;color:var(--vscode-descriptionForeground);margin-top:2px">${detail}</div>`,
+        '</div>',
+      ].join('');
+    };
+
+    const coordinatorOnly = topology.coordinatorOnlyTypes
+      .map((t) => this.escapeHtml(t))
+      .join(', ');
+
+    const poolLabel = 'x' + topology.enrichmentPool.size + ' (queries)';
+    const cards = [
+      roleCard(
+        'Data Owner',
+        topology.dataOwner.active,
+        'x1 (storage + symbols)',
+      ),
+      roleCard('Compilation', topology.compilation.active, 'x1 (public-api)'),
+      roleCard('Enrichment Pool', topology.enrichmentPool.active, poolLabel),
+    ];
+    if (topology.resourceLoader) {
+      cards.push(
+        roleCard(
+          'Resource Loader',
+          topology.resourceLoader.active,
+          'x1 (stdlib)',
+        ),
+      );
+    }
+
+    return [
+      '<div class="worker-topology-section" style="margin:16px 0">',
+      '<div style="display:flex;align-items:center;margin-bottom:10px">',
+      `<span style="${activeDot}"></span>`,
+      '<span style="font-size:14px;font-weight:600;color:var(--vscode-foreground)">Worker Topology</span>',
+      `<span style="margin-left:12px;font-size:12px;color:var(--vscode-descriptionForeground)">${topology.dispatchedCount.toLocaleString()} dispatched</span>`,
+      '</div>',
+      `<div style="display:flex;gap:10px;flex-wrap:wrap">${cards.join('')}</div>`,
+      `<div style="margin-top:8px;font-size:11px;color:var(--vscode-descriptionForeground)">Coordinator-only: ${coordinatorOnly}</div>`,
+      '</div>',
+    ].join('\n');
+    /* eslint-enable max-len */
   }
 
   private handlePriorityHeaderClick = (event: MouseEvent): void => {

--- a/packages/apex-lsp-vscode-extension/src/workspace-find-files.ts
+++ b/packages/apex-lsp-vscode-extension/src/workspace-find-files.ts
@@ -107,7 +107,7 @@ async function walkDirectory(
 export async function findFilesAcrossWorkspaceFolders(
   pattern: string,
   exclude?: string | null,
-  maxResults?: number,
+  maxResults: number = Infinity,
 ): Promise<vscode.Uri[]> {
   const allFolders = vscode.workspace.workspaceFolders ?? [];
 
@@ -117,15 +117,14 @@ export async function findFilesAcrossWorkspaceFolders(
 
   const seen = new Set<string>();
   const results: vscode.Uri[] = [];
-  const limit = maxResults ?? 1000;
 
   // Pass 1: findFiles for schemes with a reliable search provider
   const searchFolders = allFolders.filter((f) =>
     SEARCH_PROVIDER_SCHEMES.has(f.uri.scheme),
   );
   for (const folder of searchFolders) {
-    if (results.length >= limit) break;
-    const remaining = limit - results.length;
+    if (results.length >= maxResults) break;
+    const remaining = maxResults - results.length;
     const relPattern = new vscode.RelativePattern(folder, pattern);
     try {
       const files = await vscode.workspace.findFiles(
@@ -149,11 +148,11 @@ export async function findFilesAcrossWorkspaceFolders(
   const fsFolders = allFolders.filter((f) =>
     FS_PROVIDER_SCHEMES.has(f.uri.scheme),
   );
-  if (fsFolders.length > 0 && results.length < limit) {
+  if (fsFolders.length > 0 && results.length < maxResults) {
     const matcher = globSegmentToRegex(pattern);
     for (const folder of fsFolders) {
-      if (results.length >= limit) break;
-      await walkDirectory(folder.uri, matcher, results, limit, 0);
+      if (results.length >= maxResults) break;
+      await walkDirectory(folder.uri, matcher, results, maxResults, 0);
     }
   }
 

--- a/packages/apex-lsp-vscode-extension/src/workspace-find-files.ts
+++ b/packages/apex-lsp-vscode-extension/src/workspace-find-files.ts
@@ -112,7 +112,11 @@ export async function findFilesAcrossWorkspaceFolders(
   const allFolders = vscode.workspace.workspaceFolders ?? [];
 
   if (allFolders.length === 0) {
-    return vscode.workspace.findFiles(pattern, exclude ?? null, maxResults);
+    return vscode.workspace.findFiles(
+      pattern,
+      exclude ?? null,
+      Number.isFinite(maxResults) ? maxResults : undefined,
+    );
   }
 
   const seen = new Set<string>();
@@ -130,7 +134,7 @@ export async function findFilesAcrossWorkspaceFolders(
       const files = await vscode.workspace.findFiles(
         relPattern,
         exclude ?? null,
-        remaining,
+        Number.isFinite(remaining) ? remaining : undefined,
       );
       for (const f of files) {
         const key = f.toString();
@@ -162,7 +166,11 @@ export async function findFilesAcrossWorkspaceFolders(
     searchFolders.length === 0 &&
     fsFolders.length === 0
   ) {
-    return vscode.workspace.findFiles(pattern, exclude ?? null, maxResults);
+    return vscode.workspace.findFiles(
+      pattern,
+      exclude ?? null,
+      Number.isFinite(maxResults) ? maxResults : undefined,
+    );
   }
 
   return results;

--- a/packages/apex-lsp-vscode-extension/src/workspace-loader.ts
+++ b/packages/apex-lsp-vscode-extension/src/workspace-loader.ts
@@ -23,11 +23,16 @@ import {
   encodeBatchForTransport,
   type FileData,
 } from './workspace-batch-compressor';
+import {
+  updateApexServerStatusLoading,
+  updateApexServerStatusReady,
+} from './status-bar';
 
 // --- Configuration ---
 export function getExcludeGlob(includeSfdxToolsCustomObjects: boolean): string {
   const exclude = [
     'node_modules',
+    '.sf/**',
     '.sfdx/tools/*/StandardApexLibrary',
     '.sfdx/tools/sobjects/standardObjects',
     ...(includeSfdxToolsCustomObjects
@@ -90,408 +95,298 @@ export async function loadWorkspaceForServer(
   // Note: State management is now handled by WorkspaceState service
   // This function is kept for internal use by the service only
 
-  // Wrap with VS Code progress notification
-  return vscode.window.withProgress(
-    {
-      location: vscode.ProgressLocation.Notification,
-      title: 'Sending Apex Artifacts to Apex Language Server',
-      cancellable: true,
-    },
-    async (progress, cancellationToken) => {
-      try {
-        // Derive file patterns from documentSelector
-        const filePatterns =
-          deriveFilePatternsFromDocumentSelector(documentSelector);
-        logToOutputChannel(
-          `📁 Loading workspace with patterns: ${filePatterns.join(', ')}`,
-          'debug',
-        );
+  // Derive file patterns from documentSelector
+  const filePatterns = deriveFilePatternsFromDocumentSelector(documentSelector);
+  logToOutputChannel(
+    `📁 Loading workspace with patterns: ${filePatterns.join(', ')}`,
+    'debug',
+  );
 
-        // Get settings from configuration
-        const settings = getWorkspaceSettings();
-        const maxConcurrency = settings.apex.loadWorkspace.maxConcurrency;
-        const excludeGlob = getExcludeGlob(
-          settings.apex.loadWorkspace.includeSfdxToolsCustomObjects ?? false,
-        );
+  // Get settings from configuration
+  const settings = getWorkspaceSettings();
+  const maxConcurrency = settings.apex.loadWorkspace.maxConcurrency;
+  const excludeGlob = getExcludeGlob(
+    settings.apex.loadWorkspace.includeSfdxToolsCustomObjects ?? false,
+  );
+  const isDevelopment = settings.apex.environment.serverMode === 'development';
+  const maxFileCount =
+    isDevelopment && settings.apex.loadWorkspace.maxFileCount
+      ? settings.apex.loadWorkspace.maxFileCount
+      : undefined;
 
-        // Send progress begin notification (LSP)
-        if (workDoneToken) {
-          sendProgressNotification(languageClient, workDoneToken, {
-            kind: 'begin',
-            title: 'Loading Apex workspace',
-            cancellable: true,
-            message: 'Scanning for Apex files...',
-            percentage: 0,
-          });
-        }
+  // Send progress begin notification (LSP)
+  if (workDoneToken) {
+    sendProgressNotification(languageClient, workDoneToken, {
+      kind: 'begin',
+      title: 'Loading Apex workspace',
+      cancellable: false,
+      message: 'Scanning for Apex files...',
+      percentage: 0,
+    });
+  }
 
-        // Report initial progress to VS Code notification
-        progress.report({
-          message: 'Scanning for Apex files...',
-          increment: 0,
-        });
+  updateApexServerStatusLoading('Scanning for Apex files...');
 
-        // Create the Effect fiber
-        const loadEffect = Effect.gen(function* (_: any) {
-          // Check for cancellation
-          if (cancellationToken.isCancellationRequested) {
-            return;
-          }
+  // Create the Effect fiber
+  const loadEffect = Effect.gen(function* (_: any) {
+    // Find all matching workspace files
+    const allUris: vscode.Uri[] = [];
+    for (const pattern of filePatterns) {
+      const uris = yield* _(
+        Effect.tryPromise({
+          try: () =>
+            findFilesAcrossWorkspaceFolders(pattern, excludeGlob, maxFileCount),
+          catch: (e: unknown) =>
+            new Error(
+              `Failed to find workspace files with pattern ${pattern}: ${String(formattedError(e))}`,
+            ),
+        }),
+      );
+      allUris.push(...uris);
+    }
 
-          // Find all matching workspace files
-          const allUris: vscode.Uri[] = [];
-          for (const pattern of filePatterns) {
-            if (cancellationToken.isCancellationRequested) {
-              return;
+    logToOutputChannel(`📁 Found ${allUris.length} files to load`, 'debug');
+
+    // Send progress report for file discovery (LSP)
+    if (workDoneToken) {
+      sendProgressNotification(languageClient, workDoneToken, {
+        kind: 'report',
+        message: `Found ${allUris.length} files to load`,
+        percentage: 10,
+      });
+    }
+    updateApexServerStatusLoading(`Found ${allUris.length} files to load`);
+
+    // Get batch size from settings
+    const batchSize = settings.apex.loadWorkspace.batchSize;
+
+    // Read all file contents in parallel
+    logToOutputChannel(`📖 Reading ${allUris.length} files...`, 'debug');
+
+    const fileDataArray = yield* _(
+      Effect.forEach(allUris, (uri) => readFileContent(uri), {
+        concurrency: maxConcurrency,
+      }),
+    );
+
+    // Filter out any failed reads (they return void on error)
+    const validFiles: FileData[] = fileDataArray.filter(
+      (file: FileData | undefined): file is FileData => file !== undefined,
+    );
+
+    logToOutputChannel(
+      `✅ Read ${validFiles.length} files, creating batches...`,
+      'debug',
+    );
+
+    // Create batches
+    const batches: readonly WorkspaceFileBatch[] = yield* _(
+      createFileBatches(validFiles, batchSize),
+    );
+
+    logToOutputChannel(
+      `📦 Created ${batches.length} batches (batch size: ${batchSize})`,
+      'info',
+    );
+
+    // Send progress report for batch creation
+    if (workDoneToken) {
+      sendProgressNotification(languageClient, workDoneToken, {
+        kind: 'report',
+        message: `Created ${batches.length} batches`,
+        percentage: 20,
+      });
+    }
+    updateApexServerStatusLoading(`Created ${batches.length} batches`);
+
+    // Phase 1: Compress and encode all batches (can be done in parallel)
+    const totalBatches = batches.length;
+
+    if (workDoneToken) {
+      sendProgressNotification(languageClient, workDoneToken, {
+        kind: 'report',
+        message: `Compressing ${totalBatches} batches...`,
+        percentage: 20,
+      });
+    }
+    updateApexServerStatusLoading(`Compressing ${totalBatches} batches...`);
+
+    // Compress and encode all batches in parallel
+    const preparedBatches = yield* _(
+      Effect.forEach(
+        batches,
+        (batch, index) =>
+          Effect.gen(function* () {
+            // Compress batch
+            const compressed = yield* _(compressBatch(batch));
+
+            // Encode for transport
+            const encodedData = yield* _(encodeBatchForTransport(compressed));
+
+            // Update progress during compression (LSP only — status bar phase message set above)
+            const compressionProgress =
+              20 + Math.floor(((index + 1) / totalBatches) * 30);
+            if (workDoneToken) {
+              sendProgressNotification(languageClient, workDoneToken, {
+                kind: 'report',
+                message: `Compressed batch ${index + 1}/${totalBatches}`,
+                percentage: compressionProgress,
+              });
             }
 
-            const uris = yield* _(
+            return {
+              batchIndex: batch.batchIndex,
+              totalBatches: batch.totalBatches,
+              isLastBatch: batch.isLastBatch,
+              compressedData: encodedData,
+              fileMetadata: batch.fileMetadata,
+            } as SendWorkspaceBatchParams;
+          }),
+        { concurrency: maxConcurrency }, // Parallel compression
+      ),
+    );
+
+    // Phase 2: Send all batches as requests in parallel
+    if (workDoneToken) {
+      sendProgressNotification(languageClient, workDoneToken, {
+        kind: 'report',
+        message: `Sending ${totalBatches} batches...`,
+        percentage: 50,
+      });
+    }
+    updateApexServerStatusLoading(`Sending ${totalBatches} batches...`);
+
+    // Send all batches as requests in parallel
+    // Server returns immediately after storing (no processing), so parallel sending is safe
+    // Use lower concurrency (2 instead of maxConcurrency) to avoid saturating LSP connection
+    // This allows hover requests to be interleaved with batch sends
+    const batchSendConcurrency = Math.min(2, maxConcurrency);
+    yield* _(
+      Effect.forEach(
+        preparedBatches as readonly SendWorkspaceBatchParams[],
+        (batchParams, index) =>
+          Effect.gen(function* () {
+            // Yield before sending to allow event loop to process hover requests
+            yield* Effect.yieldNow();
+
+            // Send as request - server stores and returns immediately
+            const result = yield* _(
               Effect.tryPromise({
                 try: () =>
-                  findFilesAcrossWorkspaceFolders(pattern, excludeGlob),
-                catch: (e: unknown) =>
+                  languageClient.sendRequest(
+                    'apex/sendWorkspaceBatch',
+                    batchParams,
+                  ),
+                catch: (err: unknown) =>
                   new Error(
-                    `Failed to find workspace files with pattern ${pattern}: ${String(formattedError(e))}`,
+                    `Failed to send batch ${batchParams.batchIndex + 1}: ${String(formattedError(err))}`,
                   ),
               }),
             );
-            allUris.push(...uris);
-          }
 
-          logToOutputChannel(
-            `📁 Found ${allUris.length} files to load`,
-            'debug',
-          );
+            if (!result.success) {
+              logToOutputChannel(
+                `⚠️ Batch ${batchParams.batchIndex + 1} failed: ${result.error ?? 'Unknown error'}`,
+                'warning',
+              );
+            } else {
+              const receivedCount = result.receivedCount ?? '?';
+              const total = result.totalBatches ?? batchParams.totalBatches;
+              logToOutputChannel(
+                `✅ Batch ${batchParams.batchIndex + 1}/${batchParams.totalBatches} stored ` +
+                  `(${receivedCount}/${total} received, ` +
+                  `${batchParams.fileMetadata.length} files)`,
+                'debug',
+              );
+            }
 
-          // Check for cancellation after file discovery
-          if (cancellationToken.isCancellationRequested) {
-            return;
-          }
+            // Update progress (LSP only — status bar shows phase message)
+            const sendProgress =
+              50 + Math.floor(((index + 1) / totalBatches) * 40);
+            if (workDoneToken) {
+              sendProgressNotification(languageClient, workDoneToken, {
+                kind: 'report',
+                message: `Sent batch ${index + 1}/${totalBatches}`,
+                percentage: sendProgress,
+              });
+            }
 
-          // Send progress report for file discovery (LSP)
-          if (workDoneToken) {
-            sendProgressNotification(languageClient, workDoneToken, {
-              kind: 'report',
-              message: `Found ${allUris.length} files to load`,
-              percentage: 10,
-            });
-          }
+            // Yield after each batch to allow hover requests to be processed
+            // Small delay helps prevent LSP connection saturation
+            yield* Effect.sleep(Duration.millis(10));
+          }),
+        { concurrency: batchSendConcurrency }, // Lower concurrency to avoid blocking hover requests
+      ),
+    );
 
-          // Report file discovery to VS Code notification
-          progress.report({
-            message: `Found ${allUris.length} files to load`,
-            increment: 10,
-          });
+    logToOutputChannel(
+      `✅ All ${totalBatches} batches stored successfully - triggering processing`,
+      'info',
+    );
 
-          // Get batch size from settings
-          const batchSize = settings.apex.loadWorkspace.batchSize;
+    // Trigger processing of all stored batches
+    const processResult = yield* _(
+      Effect.tryPromise({
+        try: () =>
+          languageClient.sendRequest('apex/processWorkspaceBatches', {
+            totalBatches,
+          }),
+        catch: (err: unknown) =>
+          new Error(
+            `Failed to trigger batch processing: ${String(formattedError(err))}`,
+          ),
+      }),
+    );
 
-          // Read all file contents in parallel
-          logToOutputChannel(`📖 Reading ${allUris.length} files...`, 'debug');
+    if (!processResult.success) {
+      logToOutputChannel(
+        `⚠️ Failed to trigger batch processing: ${processResult.error ?? 'Unknown error'}`,
+        'warning',
+      );
+    } else {
+      logToOutputChannel('✅ Batch processing triggered successfully', 'debug');
+    }
 
-          const fileDataArray = yield* _(
-            Effect.forEach(allUris, (uri) => readFileContent(uri), {
-              concurrency: maxConcurrency,
-            }),
-          );
+    logToOutputChannel(
+      `✅ Workspace loading complete (${allUris.length} files)`,
+      'info',
+    );
 
-          // Filter out any failed reads (they return void on error)
-          const validFiles: FileData[] = fileDataArray.filter(
-            (file: FileData | undefined): file is FileData =>
-              file !== undefined,
-          );
+    // Send progress end notification (LSP)
+    if (workDoneToken) {
+      sendProgressNotification(languageClient, workDoneToken, {
+        kind: 'end',
+        message: `Successfully loaded ${allUris.length} files`,
+      });
+    }
 
-          logToOutputChannel(
-            `✅ Read ${validFiles.length} files, creating batches...`,
-            'debug',
-          );
+    // Spinner stays active — server will send apex/workspaceIngestionComplete
+    // when background processing finishes, which clears the status bar.
+    updateApexServerStatusLoading(
+      `Ingesting ${allUris.length} files on server...`,
+    );
+  });
 
-          // Create batches
-          const batches: readonly WorkspaceFileBatch[] = yield* _(
-            createFileBatches(validFiles, batchSize),
-          );
+  try {
+    await Effect.runPromise(loadEffect as Effect.Effect<void, never, never>);
+  } catch (error) {
+    logToOutputChannel(
+      `Error during workspace loading: ${formattedError(error)}`,
+      'error',
+    );
 
-          logToOutputChannel(
-            `📦 Created ${batches.length} batches (batch size: ${batchSize})`,
-            'info',
-          );
+    // Send progress end notification on error (LSP)
+    if (workDoneToken) {
+      sendProgressNotification(languageClient, workDoneToken, {
+        kind: 'end',
+        message: `Workspace loading failed: ${formattedError(error)}`,
+      });
+    }
 
-          // Send progress report for batch creation
-          if (workDoneToken) {
-            sendProgressNotification(languageClient, workDoneToken, {
-              kind: 'report',
-              message: `Created ${batches.length} batches`,
-              percentage: 20,
-            });
-          }
-
-          progress.report({
-            message: `Created ${batches.length} batches`,
-            increment: 10,
-          });
-
-          // Phase 1: Compress and encode all batches (can be done in parallel)
-          const totalBatches = batches.length;
-
-          if (workDoneToken) {
-            sendProgressNotification(languageClient, workDoneToken, {
-              kind: 'report',
-              message: `Compressing ${totalBatches} batches...`,
-              percentage: 20,
-            });
-          }
-
-          progress.report({
-            message: `Compressing ${totalBatches} batches...`,
-            increment: 0,
-          });
-
-          // Compress and encode all batches in parallel
-          const preparedBatches = yield* _(
-            Effect.forEach(
-              batches,
-              (batch, index) =>
-                Effect.gen(function* () {
-                  // Check for cancellation
-                  if (cancellationToken.isCancellationRequested) {
-                    return yield* Effect.fail(new Error('Cancelled'));
-                  }
-
-                  // Compress batch
-                  const compressed = yield* _(compressBatch(batch));
-
-                  // Encode for transport
-                  const encodedData = yield* _(
-                    encodeBatchForTransport(compressed),
-                  );
-
-                  // Update progress during compression
-                  const compressionProgress =
-                    20 + Math.floor(((index + 1) / totalBatches) * 30);
-                  if (workDoneToken) {
-                    sendProgressNotification(languageClient, workDoneToken, {
-                      kind: 'report',
-                      message: `Compressed batch ${index + 1}/${totalBatches}`,
-                      percentage: compressionProgress,
-                    });
-                  }
-
-                  return {
-                    batchIndex: batch.batchIndex,
-                    totalBatches: batch.totalBatches,
-                    isLastBatch: batch.isLastBatch,
-                    compressedData: encodedData,
-                    fileMetadata: batch.fileMetadata,
-                  } as SendWorkspaceBatchParams;
-                }),
-              { concurrency: maxConcurrency }, // Parallel compression
-            ),
-          );
-
-          // Phase 2: Send all batches as notifications in parallel (fire-and-forget)
-          if (workDoneToken) {
-            sendProgressNotification(languageClient, workDoneToken, {
-              kind: 'report',
-              message: `Sending ${totalBatches} batches...`,
-              percentage: 50,
-            });
-          }
-
-          progress.report({
-            message: `Sending ${totalBatches} batches...`,
-            increment: 0,
-          });
-
-          // Send all batches as requests in parallel
-          // Server returns immediately after storing (no processing), so parallel sending is safe
-          // Use lower concurrency (2 instead of maxConcurrency) to avoid saturating LSP connection
-          // This allows hover requests to be interleaved with batch sends
-          const batchSendConcurrency = Math.min(2, maxConcurrency);
-          yield* _(
-            Effect.forEach(
-              preparedBatches as readonly SendWorkspaceBatchParams[],
-              (batchParams, index) =>
-                Effect.gen(function* () {
-                  // Check for cancellation
-                  if (cancellationToken.isCancellationRequested) {
-                    return yield* Effect.fail(new Error('Cancelled'));
-                  }
-
-                  // Yield before sending to allow event loop to process hover requests
-                  yield* Effect.yieldNow();
-
-                  // Send as request - server stores and returns immediately
-                  const result = yield* _(
-                    Effect.tryPromise({
-                      try: () =>
-                        languageClient.sendRequest(
-                          'apex/sendWorkspaceBatch',
-                          batchParams,
-                        ),
-                      catch: (err: unknown) =>
-                        new Error(
-                          `Failed to send batch ${batchParams.batchIndex + 1}: ${String(formattedError(err))}`,
-                        ),
-                    }),
-                  );
-
-                  if (!result.success) {
-                    logToOutputChannel(
-                      `⚠️ Batch ${batchParams.batchIndex + 1} failed: ${result.error ?? 'Unknown error'}`,
-                      'warning',
-                    );
-                  } else {
-                    const receivedCount = result.receivedCount ?? '?';
-                    const total =
-                      result.totalBatches ?? batchParams.totalBatches;
-                    logToOutputChannel(
-                      `✅ Batch ${batchParams.batchIndex + 1}/${batchParams.totalBatches} stored ` +
-                        `(${receivedCount}/${total} received, ` +
-                        `${batchParams.fileMetadata.length} files)`,
-                      'debug',
-                    );
-                  }
-
-                  // Update progress
-                  const sendProgress =
-                    50 + Math.floor(((index + 1) / totalBatches) * 40);
-                  if (workDoneToken) {
-                    sendProgressNotification(languageClient, workDoneToken, {
-                      kind: 'report',
-                      message: `Sent batch ${index + 1}/${totalBatches}`,
-                      percentage: sendProgress,
-                    });
-                  }
-
-                  progress.report({
-                    message: `Sent batch ${index + 1}/${totalBatches}`,
-                    increment: Math.floor(40 / totalBatches),
-                  });
-
-                  // Yield after each batch to allow hover requests to be processed
-                  // Small delay helps prevent LSP connection saturation
-                  yield* Effect.sleep(Duration.millis(10));
-                }),
-              { concurrency: batchSendConcurrency }, // Lower concurrency to avoid blocking hover requests
-            ),
-          );
-
-          logToOutputChannel(
-            `✅ All ${totalBatches} batches stored successfully - triggering processing`,
-            'info',
-          );
-
-          // Trigger processing of all stored batches
-          const processResult = yield* _(
-            Effect.tryPromise({
-              try: () =>
-                languageClient.sendRequest('apex/processWorkspaceBatches', {
-                  totalBatches,
-                }),
-              catch: (err: unknown) =>
-                new Error(
-                  `Failed to trigger batch processing: ${String(formattedError(err))}`,
-                ),
-            }),
-          );
-
-          if (!processResult.success) {
-            logToOutputChannel(
-              `⚠️ Failed to trigger batch processing: ${processResult.error ?? 'Unknown error'}`,
-              'warning',
-            );
-          } else {
-            logToOutputChannel(
-              '✅ Batch processing triggered successfully',
-              'debug',
-            );
-          }
-
-          // Check for cancellation before completion
-          if (cancellationToken.isCancellationRequested) {
-            return;
-          }
-
-          // Mark as complete (state managed by service)
-          logToOutputChannel(
-            `✅ Workspace loading complete (${allUris.length} files)`,
-            'info',
-          );
-
-          // Send progress end notification (LSP)
-          if (workDoneToken) {
-            sendProgressNotification(languageClient, workDoneToken, {
-              kind: 'end',
-              message: `Successfully loaded ${allUris.length} files`,
-            });
-          }
-
-          // Report completion to VS Code notification
-          // Calculate final percentage and increment to reach 100%
-          // All files should be processed now, so processedCount === totalFiles
-          const finalPercentage = Math.min(
-            90,
-            10 + Math.floor((allUris.length / allUris.length) * 80),
-          );
-          const finalIncrement = 100 - finalPercentage;
-          progress.report({
-            message: `Successfully loaded ${allUris.length} files`,
-            increment: finalIncrement,
-          });
-        });
-
-        // Run the Effect fiber and wait for completion
-        try {
-          await Effect.runPromise(
-            loadEffect as Effect.Effect<void, never, never>,
-          );
-
-          // If cancelled, send end notification
-          if (cancellationToken.isCancellationRequested && workDoneToken) {
-            sendProgressNotification(languageClient, workDoneToken, {
-              kind: 'end',
-              message: 'Workspace loading cancelled',
-            });
-          }
-        } catch (error) {
-          logToOutputChannel(
-            `Error during workspace loading: ${formattedError(error)}`,
-            'error',
-          );
-
-          // Send progress end notification on error (LSP)
-          if (workDoneToken) {
-            sendProgressNotification(languageClient, workDoneToken, {
-              kind: 'end',
-              message: `Workspace loading failed: ${formattedError(error)}`,
-            });
-          }
-
-          // Report error to VS Code notification
-          progress.report({
-            message: `Workspace loading failed: ${formattedError(error)}`,
-          });
-
-          throw error;
-        }
-      } catch (error) {
-        logToOutputChannel(
-          `Error setting up workspace loading: ${formattedError(error)}`,
-          'error',
-        );
-
-        // Send progress end notification on error (LSP)
-        if (workDoneToken) {
-          sendProgressNotification(languageClient, workDoneToken, {
-            kind: 'end',
-            message: `Workspace loading failed: ${formattedError(error)}`,
-          });
-        }
-
-        throw error;
-      }
-    },
-  );
+    // Restore ready state — no apex/workspaceIngestionComplete will arrive
+    updateApexServerStatusReady();
+    throw error;
+  }
 }
 
 /**

--- a/packages/apex-lsp-vscode-extension/src/workspace-loader.ts
+++ b/packages/apex-lsp-vscode-extension/src/workspace-loader.ts
@@ -26,6 +26,7 @@ import {
 import {
   updateApexServerStatusLoading,
   updateApexServerStatusReady,
+  startIngestionTimeout,
 } from './status-bar';
 
 // --- Configuration ---
@@ -365,6 +366,7 @@ export async function loadWorkspaceForServer(
     updateApexServerStatusLoading(
       `Ingesting ${allUris.length} files on server...`,
     );
+    startIngestionTimeout();
   });
 
   try {

--- a/packages/apex-lsp-vscode-extension/src/workspace-loader.ts
+++ b/packages/apex-lsp-vscode-extension/src/workspace-loader.ts
@@ -32,7 +32,7 @@ import {
 export function getExcludeGlob(includeSfdxToolsCustomObjects: boolean): string {
   const exclude = [
     'node_modules',
-    '.sf/**',
+    '.sf',
     '.sfdx/tools/*/StandardApexLibrary',
     '.sfdx/tools/sobjects/standardObjects',
     ...(includeSfdxToolsCustomObjects


### PR DESCRIPTION
## Summary

@W-22201120@

- **Status bar spinner for workspace loading**: Replace the `vscode.window.withProgress` notification toast with a persistent status bar spinner that tracks server-side ingestion, cleared only when the server sends `apex/workspaceIngestionComplete`. Includes a 5-minute safety timeout.
- **Worker topology monitoring UI**: Add live worker role cards to the queue state dashboard showing data owner, compilation, enrichment pool, and resource loader status. Request types display coord/worker dispatch indicators.
- **Performance settings for experimental workers**: New section in the performance settings webview with enable toggle, pool size slider, and dedicated resource loader checkbox.
- **Graph scope picker**: QuickPick prompt when viewing an Apex file to choose between "Current File" and "All Types" scope for the symbol graph.
- **Server-side topology enrichment**: Inject `workerTopology` from the WorkerCoordinator dispatcher into both `apex/queueState` responses and periodic `apex/queueStateChanged` notifications.

## Changes

| Package | Files | What |
|---------|-------|------|
| `apex-lsp-vscode-extension` | `workspace-loader.ts` | Flatten async flow, remove cancellation token, use status bar spinner, add `.sf` exclude |
| `apex-lsp-vscode-extension` | `language-server.ts` | Register `apex/workspaceIngestionComplete` handler, pass `workerPlatformWebUrl` |
| `apex-lsp-vscode-extension` | `status-bar.ts` | Add `updateApexServerStatusLoading`, ingestion timeout |
| `apex-lsp-vscode-extension` | `workspace-find-files.ts` | Default `maxResults` to `Infinity`, remove implicit 1000 cap |
| `apex-lsp-vscode-extension` | `queueStateScript.ts` | Render worker topology cards and dispatch indicators |
| `apex-lsp-vscode-extension` | `performanceSettingsScript.ts` | Experimental Workers settings section |
| `apex-lsp-vscode-extension` | `showPerformanceSettings.ts` | Persist `experimental.workers` settings |
| `apex-lsp-vscode-extension` | `showGraph.ts` | QuickPick scope chooser |
| `apex-lsp-vscode-extension` | `server-config.ts` | Pre-create per-role profiling subdirectories |
| `apex-ls` | `LCSAdapter.ts` | Enrich queueState with `workerTopology` from dispatcher |

## Test plan

- [ ] Open a workspace with Apex files — verify status bar shows loading spinner, transitions to "Ingesting N files on server...", and clears to ready once server finishes
- [ ] Kill the language server while loading — verify spinner clears after 5 minutes (or restart)
- [ ] Open Queue State dashboard in development mode — verify worker topology cards render with active/inactive indicators
- [ ] Toggle `apex.experimental.workers.enabled` in performance settings — verify it persists and UI reflects the change
- [ ] Run "Show Symbol Graph" on an Apex file — verify QuickPick offers "Current File" vs "All Types"
- [ ] Run "Show Symbol Graph" on a non-Apex file — verify it skips QuickPick and shows all types directly