### PR TITLE
fix: address review suggestions for worker topology PR

### DIFF
--- a/packages/apex-ls/src/server/LCSAdapter.ts
+++ b/packages/apex-ls/src/server/LCSAdapter.ts
@@ -938,10 +938,10 @@ export class LCSAdapter {
               'metrics' in result &&
               this.workerDispatcher?.getTopologyStatus
             ) {
-              const metrics = (result as { metrics: Record<string, unknown> })
-                .metrics;
-              metrics.workerTopology =
-                this.workerDispatcher.getTopologyStatus();
+              (result as { metrics: Record<string, unknown> }).metrics = {
+                ...(result as { metrics: Record<string, unknown> }).metrics,
+                workerTopology: this.workerDispatcher.getTopologyStatus(),
+              };
             }
             this.logger.debug(
               () =>

--- a/packages/apex-lsp-vscode-extension/src/graph/showGraph.ts
+++ b/packages/apex-lsp-vscode-extension/src/graph/showGraph.ts
@@ -429,7 +429,7 @@ export async function showGraph(context: vscode.ExtensionContext) {
       [
         {
           label: 'Current File',
-          description: activeEditor!.document.fileName,
+          description: activeEditor?.document.fileName ?? '',
           value: 'file' as const,
         },
         {

--- a/packages/apex-lsp-vscode-extension/src/language-server.ts
+++ b/packages/apex-lsp-vscode-extension/src/language-server.ts
@@ -1380,6 +1380,7 @@ export async function restartLanguageServer(
  */
 export async function stopLanguageServer(): Promise<void> {
   logToOutputChannel('🛑 Stopping Apex Language Server...', 'info');
+  clearIngestionTimeout();
   if (Client) {
     try {
       await Client.dispose();

--- a/packages/apex-lsp-vscode-extension/src/workspace-find-files.ts
+++ b/packages/apex-lsp-vscode-extension/src/workspace-find-files.ts
@@ -112,7 +112,11 @@ export async function findFilesAcrossWorkspaceFolders(
   const allFolders = vscode.workspace.workspaceFolders ?? [];
 
   if (allFolders.length === 0) {
-    return vscode.workspace.findFiles(pattern, exclude ?? null, maxResults);
+    return vscode.workspace.findFiles(
+      pattern,
+      exclude ?? null,
+      Number.isFinite(maxResults) ? maxResults : undefined,
+    );
   }
 
   const seen = new Set<string>();
@@ -130,7 +134,7 @@ export async function findFilesAcrossWorkspaceFolders(
       const files = await vscode.workspace.findFiles(
         relPattern,
         exclude ?? null,
-        remaining,
+        Number.isFinite(remaining) ? remaining : undefined,
       );
       for (const f of files) {
         const key = f.toString();
@@ -162,7 +166,11 @@ export async function findFilesAcrossWorkspaceFolders(
     searchFolders.length === 0 &&
     fsFolders.length === 0
   ) {
-    return vscode.workspace.findFiles(pattern, exclude ?? null, maxResults);
+    return vscode.workspace.findFiles(
+      pattern,
+      exclude ?? null,
+      Number.isFinite(maxResults) ? maxResults : undefined,
+    );
   }
 
   return results;


### PR DESCRIPTION
## Summary

- Avoid in-place mutation of metrics result in LCSAdapter by using spread
- Pass `undefined` instead of `Infinity` to `vscode.workspace.findFiles` API
- Replace non-null assertion with optional chaining in showGraph
- Clear ingestion timeout on server stop to prevent stale timer firing

## Test plan

- [ ] Verify queue state dashboard still renders worker topology cards correctly
- [ ] Verify workspace loading still completes and status bar clears
- [ ] Verify graph scope picker still works for Apex files