### PR TITLE
feat(infra): add wire schemas for Find References offload - W-22692413

### DIFF
--- a/packages/apex-lsp-shared/src/index.ts
+++ b/packages/apex-lsp-shared/src/index.ts
@@ -403,6 +403,8 @@ export {
   QuerySymbolSubset,
   UpdateSymbolSubset,
   ResolveDepUris,
+  ResolveDependentUris,
+  EnsureWorkspaceLoaded,
   WorkspaceBatchIngest,
   CompileDocument,
   WorkspaceBatchCompile,

--- a/packages/apex-lsp-shared/src/workerWireSchemas.ts
+++ b/packages/apex-lsp-shared/src/workerWireSchemas.ts
@@ -671,6 +671,59 @@ export class ResolveDepUris extends Schema.TaggedRequest<ResolveDepUris>()(
 ) {}
 
 // ---------------------------------------------------------------------------
+// ResolveDependentUris — enrichment worker asks data-owner to return symbol
+// tables for every file whose declared symbols reference any symbol declared
+// in `uri`. Inverse of ResolveDepUris (which resolves a class name's *deps*);
+// this resolves a URI's *dependents*. Used by Find References to load
+// caller-side symbol tables before the algorithm runs on the worker.
+// ---------------------------------------------------------------------------
+
+export class ResolveDependentUris extends Schema.TaggedRequest<ResolveDependentUris>()(
+  'ResolveDependentUris',
+  {
+    success: Schema.Struct({
+      entries: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+    }),
+    failure: Schema.Struct({
+      _tag: Schema.Literal('ResolveDependentUrisError'),
+      message: Schema.String,
+    }),
+    payload: {
+      uri: Schema.String,
+      // Optional: narrow to dependents that reference a specific symbol
+      // declared in `uri`. When omitted, dependents of *any* symbol in `uri`
+      // are returned. Accepted now to avoid a wire-schema break later.
+      symbolName: Schema.optional(Schema.String),
+    },
+  },
+) {}
+
+// ---------------------------------------------------------------------------
+// EnsureWorkspaceLoaded — worker → coordinator (over the assistance bus) to
+// ask the coordinator to send a workspace-load notification to the LSP
+// client. Fire-and-forget at the LSP layer (the notification carries no
+// result), but blocking at the assistance layer so the worker can await the
+// notification *send* before continuing. Used by Find References on the
+// enrichment worker, which has no LSP Connection of its own.
+// ---------------------------------------------------------------------------
+
+export class EnsureWorkspaceLoaded extends Schema.TaggedRequest<EnsureWorkspaceLoaded>()(
+  'EnsureWorkspaceLoaded',
+  {
+    success: Schema.Void,
+    failure: Schema.Struct({
+      _tag: Schema.Literal('EnsureWorkspaceLoadedError'),
+      message: Schema.String,
+    }),
+    payload: {
+      workDoneToken: Schema.optional(
+        Schema.Union(Schema.String, Schema.Number),
+      ),
+    },
+  },
+) {}
+
+// ---------------------------------------------------------------------------
 // QueryGraphData — coordinator asks data-owner to compute graph data
 // using the data-owner's own symbol manager (which holds all workspace symbols
 // after compilation and enrichment write-backs).
@@ -706,6 +759,7 @@ export const DataOwnerTags = [
   'QuerySymbolSubset',
   'UpdateSymbolSubset',
   'ResolveDepUris',
+  'ResolveDependentUris',
   'WorkspaceBatchIngest',
   'QueryGraphData',
   'DispatchDocumentOpen',
@@ -776,6 +830,7 @@ export type DataOwnerRequest =
   | QuerySymbolSubset
   | UpdateSymbolSubset
   | ResolveDepUris
+  | ResolveDependentUris
   | WorkspaceBatchIngest
   | QueryGraphData
   | DispatchDocumentOpen

--- a/packages/apex-lsp-shared/test/workerWireSchemas.test.ts
+++ b/packages/apex-lsp-shared/test/workerWireSchemas.test.ts
@@ -12,6 +12,8 @@ import {
   PingWorker,
   WorkerRemoteStdlibWarmup,
   QuerySymbolSubset,
+  ResolveDependentUris,
+  EnsureWorkspaceLoaded,
   WorkspaceBatchIngest,
   ResourceLoaderGetSymbolTable,
   DispatchDocumentOpen,
@@ -105,6 +107,61 @@ describe('workerWireSchemas', () => {
       const encoded = Schema.encodeSync(QuerySymbolSubset)(query);
       const decoded = Schema.decodeSync(QuerySymbolSubset)(encoded);
       expect(decoded.uris).toEqual(['file:///a.cls', 'file:///b.cls']);
+    });
+  });
+
+  describe('ResolveDependentUris', () => {
+    it('should encode and decode round-trip', () => {
+      const req = new ResolveDependentUris({
+        uri: 'file:///GeocodingService.cls',
+      });
+      expect(req._tag).toBe('ResolveDependentUris');
+      expect(req.uri).toBe('file:///GeocodingService.cls');
+      expect(req.symbolName).toBeUndefined();
+
+      const encoded = Schema.encodeSync(ResolveDependentUris)(req);
+      const decoded = Schema.decodeSync(ResolveDependentUris)(encoded);
+      expect(decoded._tag).toBe('ResolveDependentUris');
+      expect(decoded.uri).toBe('file:///GeocodingService.cls');
+    });
+
+    it('should round-trip with optional symbolName', () => {
+      const req = new ResolveDependentUris({
+        uri: 'file:///GeocodingService.cls',
+        symbolName: 'GeocodingAddress',
+      });
+      expect(req.symbolName).toBe('GeocodingAddress');
+
+      const encoded = Schema.encodeSync(ResolveDependentUris)(req);
+      const decoded = Schema.decodeSync(ResolveDependentUris)(encoded);
+      expect(decoded.symbolName).toBe('GeocodingAddress');
+    });
+  });
+
+  describe('EnsureWorkspaceLoaded', () => {
+    it('should encode and decode round-trip without a workDoneToken', () => {
+      const req = new EnsureWorkspaceLoaded({});
+      expect(req._tag).toBe('EnsureWorkspaceLoaded');
+      expect(req.workDoneToken).toBeUndefined();
+
+      const encoded = Schema.encodeSync(EnsureWorkspaceLoaded)(req);
+      const decoded = Schema.decodeSync(EnsureWorkspaceLoaded)(encoded);
+      expect(decoded._tag).toBe('EnsureWorkspaceLoaded');
+      expect(decoded.workDoneToken).toBeUndefined();
+    });
+
+    it('should round-trip with a string workDoneToken', () => {
+      const req = new EnsureWorkspaceLoaded({ workDoneToken: 'tok-1' });
+      const encoded = Schema.encodeSync(EnsureWorkspaceLoaded)(req);
+      const decoded = Schema.decodeSync(EnsureWorkspaceLoaded)(encoded);
+      expect(decoded.workDoneToken).toBe('tok-1');
+    });
+
+    it('should round-trip with a numeric workDoneToken', () => {
+      const req = new EnsureWorkspaceLoaded({ workDoneToken: 42 });
+      const encoded = Schema.encodeSync(EnsureWorkspaceLoaded)(req);
+      const decoded = Schema.decodeSync(EnsureWorkspaceLoaded)(encoded);
+      expect(decoded.workDoneToken).toBe(42);
     });
   });
 
@@ -348,6 +405,17 @@ describe('workerWireSchemas', () => {
       expect(isAllowedTag('enrichmentSearch', 'QuerySymbolSubset')).toBe(false);
       expect(isAllowedTag('resourceLoader', 'QuerySymbolSubset')).toBe(false);
       expect(isAllowedTag('compilation', 'QuerySymbolSubset')).toBe(false);
+    });
+
+    it('should restrict ResolveDependentUris to dataOwner', () => {
+      expect(isAllowedTag('dataOwner', 'ResolveDependentUris')).toBe(true);
+      expect(isAllowedTag('enrichmentSearch', 'ResolveDependentUris')).toBe(
+        false,
+      );
+      expect(isAllowedTag('resourceLoader', 'ResolveDependentUris')).toBe(
+        false,
+      );
+      expect(isAllowedTag('compilation', 'ResolveDependentUris')).toBe(false);
     });
 
     it('should restrict WorkspaceBatchIngest to dataOwner', () => {


### PR DESCRIPTION
## Summary

First story under epic [IDE Apex Language Support — findReferences](https://gus.lightning.force.com/lightning/r/ADM_Epic__c/a3QEE000002QrsL2AS/view). Pure type addition — adds the two tagged-request schemas that gate every later step in the Find References offload pipeline. No consumers wired yet.

- `ResolveDependentUris` (worker → data-owner): inverse of `ResolveDepUris`. Given a target URI, the data-owner returns serialized symbol tables for every file whose declared symbols reference any symbol declared in the target. Optional `symbolName` accepted now to avoid a wire-schema break when a future optimization narrows to "dependents that reference *this specific* symbol."
- `EnsureWorkspaceLoaded` (worker → coordinator): asks the coordinator to send the workspace-load notification to the LSP client. Workers have no LSP `Connection` of their own; this routes through the coordinator's primary `AssistanceHandler`.

`ResolveDependentUris` joins the dataOwner tag allowlist so `isAllowedTag` gates it correctly. Round-trip unit tests cover both schemas — `EnsureWorkspaceLoaded` exercises both string and numeric `workDoneToken` plus the no-token case; `ResolveDependentUris` exercises with and without optional `symbolName`.

Reference: [docs/design/references-offload-to-enrichment-pool.md](docs/design/references-offload-to-enrichment-pool.md) §3.2.

POC ancestor: [`feature/find-references-algorithm-POC`](https://github.com/forcedotcom/apex-language-support/tree/feature/find-references-algorithm-POC).

## Test plan

- [x] Round-trip encode/decode unit tests for both new schemas
- [x] `isAllowedTag` test for `ResolveDependentUris` on dataOwner role only
- [x] Full repo lint clean (`npm run lint`)
- [x] Full repo test suite green (4238 tests, 325 suites — `apex-lsp-shared` 429/432 incl. 7 new)
- [x] Downstream packages (`apex-ls`, `lsp-compliant-services`) typecheck — pure additive change, no consumers yet

### What issues does this PR fix or reference?

@W-22692413@