### PR TITLE
fix(ci): skip Playwright browser download in test-quality job - W-22769237

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
+    env:
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -15,6 +15,8 @@ jobs:
     uses: salesforcecli/github-workflows/.github/workflows/validatePR.yml@main
   code-quality:
     runs-on: ubuntu-latest
+    env:
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
### What does this PR do?
Adds `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` to the `test-quality` CI job, matching the `test` job.

### What issues does this PR fix or reference?
@W-22769237@

### Before/After
**Before:** test-quality hangs 3h during `npm ci` — Playwright postinstall downloads 167 MB Chromium then stalls on extraction. This blocks Dependabot automerge since the check never goes green.

**After:** Browser download skipped (quality tests are Jest-based, no browser needed). Install completes in ~30s.