### PR TITLE
build(deps): bump playwright to 1.60.0 and fix web e2e launch args

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -219,8 +219,8 @@
     }
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2",
-    "playwright": "^1.58.2",
+    "@playwright/test": "^1.60.0",
+    "playwright": "^1.60.0",
     "@types/node": "^20.19.40",
     "@vscode/test-electron": "2.5.2",
     "typescript": "^5.8.2"

--- a/e2e-tests/shared/config/createWebConfig.ts
+++ b/e2e-tests/shared/config/createWebConfig.ts
@@ -51,9 +51,7 @@ export const createWebConfig = (options: WebConfigOptions = {}) => {
       navigationTimeout: 30_000,
       launchOptions: {
         args: [
-          '--disable-web-security',
-          '--disable-features=VizDisplayCompositor',
-          '--disable-features=IsolateOrigins,site-per-process',
+          '--disable-features=VizDisplayCompositor,IsolateOrigins,site-per-process',
           '--enable-clipboard-read-write',
           ...(process.env.CI || process.env.DEBUG_MODE
             ? [

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,10 +78,10 @@
     "e2e-tests": {
       "version": "1.0.0",
       "devDependencies": {
-        "@playwright/test": "^1.58.2",
+        "@playwright/test": "^1.60.0",
         "@types/node": "^20.19.40",
         "@vscode/test-electron": "2.5.2",
-        "playwright": "^1.58.2",
+        "playwright": "^1.60.0",
         "typescript": "^5.8.2"
       }
     },
@@ -5477,27 +5477,27 @@
       }
     },
     "node_modules/@playwright/browser-chromium": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.58.2.tgz",
-      "integrity": "sha512-/HHFVVP2pzEtqBVOFRoWlDtBoO8bzIWOqS62APdm3OhYbE2+kVUs/ALpkevvAKKfY0DMDVezYN22bDBh77UQ9Q==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.60.0.tgz",
+      "integrity": "sha512-0ND2pbNWKJYwhlA1LNaDC3DP2x7eguQkQF7Ga7XAlJV0AFieqYNRw/E+gaY9BpSFr1TYwfwXQv1bHq5AK9nbvA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.60.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -22082,13 +22082,13 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -22101,9 +22101,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,9 @@
     "vscode-uri": "^3.1.0"
   },
   "overrides": {
-    "vscode-jsonrpc": "8.2.1"
+    "vscode-jsonrpc": "8.2.1",
+    "playwright": "1.60.0",
+    "@playwright/browser-chromium": "1.60.0"
   },
   "workspaces": [
     "packages/*",


### PR DESCRIPTION
## Summary

Adds the Playwright 1.58.2 → 1.60.0 bump that was excluded from #413 because it broke the web E2E suite. Stacked on top of #413; rebases onto main once that lands.

## Root cause

Playwright 1.60 ships Chromium 148, which is stricter about `--disable-web-security`. With that flag, the page loaded at `localhost:3000` fails to navigate into the COI iframe subdomain that `@vscode/test-web` uses for cross-origin isolation, and Chromium replaces the page with `chrome-error://chromewebdata/`. The Files Explorer never populates, so every web spec times out waiting for `.cls-ext-file-icon`.

## Fix

- **Drop `--disable-web-security`** from the Playwright web launch args. It was unnecessary; `--disable-features=IsolateOrigins,site-per-process` is what enables the COI iframe to load, and that flag stays.
- **Merge the two consecutive `--disable-features=...` args** into one. Chromium uses last-wins for repeated flags, so the previous config was silently dropping `VizDisplayCompositor` (latent bug that worked fine in 1.58 but had to be fixed for the diagnostic to be sound).
- **Add `playwright` + `@playwright/browser-chromium` overrides** to dedupe to 1.60.0 across `@vscode/test-web` (which still declares `^1.58.2` in its `dependencies`).

## Test plan

- [x] `npm run compile` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (4232 active, 492 pending)
- [x] `npm run test:e2e:web` — **all 88 web specs pass locally** (apex-extension-core, apex-goto-definition, apex-hover, apex-lsp-integration, apex-outline)
- [ ] CI passes on this branch

## What issues does this PR fix or reference?

Supersedes #396.

[skip-validate-pr]