### PR TITLE
fix(ci): skip husky pre-commit in generate-stubs workflow - W-22799791

### DIFF
--- a/.github/workflows/generate-stubs.yml
+++ b/.github/workflows/generate-stubs.yml
@@ -114,21 +114,10 @@ jobs:
           path: packages/apex-stubs-generator/stub-deletions-by-namespace.txt
           if-no-files-found: error
 
-      - name: Recompile apex-parser-ast (rebuild ZIP and protobuf artifacts)
-        run: npm run compile -w packages/apex-parser-ast
-
-      - name: Update empty-stub snapshot
-        # Regenerates the snapshot against the freshly compiled stubs so the PR
-        # includes an updated baseline. --forceExit prevents Jest hanging after
-        # the long compile-all-stubs test completes.
-        working-directory: packages/apex-parser-ast
-        run: npx jest emptyStubDetection.snapshot --updateSnapshot --testTimeout=300000 --forceExit
-
       - name: Check for changes
         id: changes
         run: |
-          git add packages/apex-parser-ast/src/resources/StandardApexLibrary/ \
-                  packages/apex-parser-ast/test/generator/__snapshots__/emptyStubDetection.snapshot.test.ts.snap
+          git add packages/apex-parser-ast/src/resources/StandardApexLibrary/
           if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
@@ -138,6 +127,8 @@ jobs:
       - name: Create Pull Request
         if: steps.changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
+        env:
+          HUSKY: '0'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/update-apex-stubs
@@ -150,7 +141,6 @@ jobs:
             **Changes:**
             - Updated `.cls` stub files in `packages/apex-parser-ast/src/resources/StandardApexLibrary/`
             - Updated `manifest.json` with current namespace/class counts
-            - Updated empty-stub snapshot baseline (`emptyStubDetection.snapshot.test.ts.snap`)
 
             **Triggered by:** ${{ github.event_name == 'schedule' && 'weekly schedule' || 'manual dispatch' }}
           commit-message: 'chore: update generated Apex standard library stubs'


### PR DESCRIPTION
### What does this PR do?
- Adds `HUSKY=0` env to `create-pull-request` step so the pre-commit hook doesn't fire during automated stub PRs
- Removes the recompile and snapshot update steps — only document-scraped artifacts (.cls stubs + manifest.json) belong in the generated PR
- Narrows `git add` to `StandardApexLibrary/` only

### What issues does this PR fix or reference?
@W-22799791@

### Before
`peter-evans/create-pull-request` runs `git commit` which triggers husky pre-commit (lint + full test suite). The test suite fails on integration tests that time out, blocking PR creation for 7 consecutive weeks since April 20.

### After
Husky is disabled for the automated commit. The PR contains only scraping outputs. CI on the opened PR still validates the change.