### PR TITLE
fix(infra): retry TOC fetch and exit non-zero on scraper failure - W-21313831

### DIFF
--- a/packages/apex-parser-ast/test/generator/__snapshots__/emptyStubDetection.snapshot.test.ts.snap
+++ b/packages/apex-parser-ast/test/generator/__snapshots__/emptyStubDetection.snapshot.test.ts.snap
@@ -315,7 +315,7 @@ exports[`Empty stub snapshot — known stubs with no members matches the accepte
     "namespace": "ConnectApi",
   },
   {
-    "className": "SmartDataDiscovery",
+    "className": "Smartdatadiscovery",
     "namespace": "ConnectApi",
   },
   {
@@ -407,7 +407,7 @@ exports[`Empty stub snapshot — known stubs with no members matches the accepte
     "namespace": "RichMessaging",
   },
   {
-    "className": "SOAPType",
+    "className": "SoapType",
     "namespace": "Schema",
   },
   {

--- a/packages/apex-parser-ast/test/generator/__snapshots__/emptyStubDetection.snapshot.test.ts.snap
+++ b/packages/apex-parser-ast/test/generator/__snapshots__/emptyStubDetection.snapshot.test.ts.snap
@@ -315,7 +315,7 @@ exports[`Empty stub snapshot — known stubs with no members matches the accepte
     "namespace": "ConnectApi",
   },
   {
-    "className": "Smartdatadiscovery",
+    "className": "SmartDataDiscovery",
     "namespace": "ConnectApi",
   },
   {
@@ -407,7 +407,7 @@ exports[`Empty stub snapshot — known stubs with no members matches the accepte
     "namespace": "RichMessaging",
   },
   {
-    "className": "SoapType",
+    "className": "SOAPType",
     "namespace": "Schema",
   },
   {

--- a/packages/apex-stubs-generator/src/commands/generate.ts
+++ b/packages/apex-stubs-generator/src/commands/generate.ts
@@ -49,8 +49,11 @@ const program = Effect.gen(function* () {
 
 pipe(
   program,
-  Effect.catchAll((error) =>
-    Console.log(`Error: ${JSON.stringify(error, null, 2)}`),
-  ),
+  Effect.catchAll((error) => {
+    const msg = JSON.stringify(error, null, 2);
+    return Console.error(`Error: ${msg}`).pipe(
+      Effect.andThen(Effect.sync(() => process.exit(1))),
+    );
+  }),
   Effect.runPromise,
 );

--- a/packages/apex-stubs-generator/src/scraper/json-api-scraper.ts
+++ b/packages/apex-stubs-generator/src/scraper/json-api-scraper.ts
@@ -15,25 +15,50 @@ export const setActiveDocVersion = (version: string): void => {
   activeDocVersion = version;
 };
 
-/**
- * Fetch the Apex Reference document structure (TOC)
- */
-export const fetchDocumentStructure = () =>
+const TOC_URL =
+  'https://developer.salesforce.com/docs/get_document/atlas.en-us.apexref.meta';
+
+const fetchDocumentStructureOnce = () =>
   Effect.gen(function* () {
-    yield* Console.log('Fetching document structure...');
-
-    const url =
-      'https://developer.salesforce.com/docs/get_document/atlas.en-us.apexref.meta';
-
     const response = yield* Effect.tryPromise({
-      try: () => fetch(url),
+      try: () => fetch(TOC_URL),
       catch: (error) => new ApiScrapingError(`Failed to fetch TOC: ${error}`),
     });
+
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      const body = yield* Effect.tryPromise({
+        try: () => response.text(),
+        catch: () =>
+          new ApiScrapingError('Failed to read non-JSON TOC response'),
+      });
+      return yield* Effect.fail(
+        new ApiScrapingError(
+          `TOC response was not JSON (content-type: ${contentType}). ` +
+            `Status: ${response.status}. Body prefix: ${body.slice(0, 200)}`,
+        ),
+      );
+    }
 
     const json = yield* Effect.tryPromise({
       try: () => response.json() as Promise<any>,
       catch: (error) => new ApiScrapingError(`Failed to parse JSON: ${error}`),
     });
+
+    return json;
+  });
+
+/**
+ * Fetch the Apex Reference document structure (TOC), retrying up to 3 times
+ * on transient failures (e.g. the API returns an XML error page).
+ */
+export const fetchDocumentStructure = () =>
+  Effect.gen(function* () {
+    yield* Console.log('Fetching document structure...');
+
+    const json = yield* fetchDocumentStructureOnce().pipe(
+      Effect.retry({ times: 2 }),
+    );
 
     yield* Console.log(
       `Fetched document structure: ${JSON.stringify(json).length} chars`,


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-21313831@

### What changes were made?
- `json-api-scraper`: detect non-JSON TOC responses (e.g. XML maintenance pages) and fail with a clear error; retry the TOC fetch up to 3 times on transient failures
- `generate.ts`: exit process with code 1 on any unhandled error so CI correctly marks the "Generate Apex stubs" step as failed rather than silently succeeding with 0 stubs
- Updated empty-stub snapshot for two classes renamed in the Salesforce docs (`Smartdatadiscovery` → `SmartDataDiscovery`, `SoapType` → `SOAPType`)

### Why?
The generate-stubs job (run [#27037512233](https://github.com/forcedotcom/apex-language-support/actions/runs/27037512233)) silently succeeded with 0 stubs generated because the Salesforce docs API returned an XML error page instead of JSON for the TOC fetch. The `Effect.catchAll` in `generate.ts` swallowed the error and exited 0, so the "Generate Apex stubs" step showed green while the downstream sanity check failed.