### PR TITLE
fix(infra): send browser User-Agent to bypass CDN block on CI runners - W-21313831

### DIFF
--- a/packages/apex-parser-ast/test/generator/__snapshots__/emptyStubDetection.snapshot.test.ts.snap
+++ b/packages/apex-parser-ast/test/generator/__snapshots__/emptyStubDetection.snapshot.test.ts.snap
@@ -315,7 +315,7 @@ exports[`Empty stub snapshot — known stubs with no members matches the accepte
     "namespace": "ConnectApi",
   },
   {
-    "className": "Smartdatadiscovery",
+    "className": "SmartDataDiscovery",
     "namespace": "ConnectApi",
   },
   {
@@ -407,7 +407,7 @@ exports[`Empty stub snapshot — known stubs with no members matches the accepte
     "namespace": "RichMessaging",
   },
   {
-    "className": "SoapType",
+    "className": "SOAPType",
     "namespace": "Schema",
   },
   {

--- a/packages/apex-stubs-generator/src/scraper/json-api-scraper.ts
+++ b/packages/apex-stubs-generator/src/scraper/json-api-scraper.ts
@@ -18,10 +18,18 @@ export const setActiveDocVersion = (version: string): void => {
 const TOC_URL =
   'https://developer.salesforce.com/docs/get_document/atlas.en-us.apexref.meta';
 
+const BROWSER_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
+  'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+// Salesforce docs CDN (Akamai) blocks requests without a browser-like User-Agent
+// from automated environments such as GitHub Actions runners.
+const FETCH_HEADERS = { 'User-Agent': BROWSER_UA };
+
 const fetchDocumentStructureOnce = () =>
   Effect.gen(function* () {
     const response = yield* Effect.tryPromise({
-      try: () => fetch(TOC_URL),
+      try: () => fetch(TOC_URL, { headers: FETCH_HEADERS }),
       catch: (error) => new ApiScrapingError(`Failed to fetch TOC: ${error}`),
     });
 
@@ -80,7 +88,7 @@ export const fetchPageContent = (
     const url = `https://developer.salesforce.com/docs/get_document_content/apexref/${pageId}/en-us/${version}`;
 
     const response = yield* Effect.tryPromise({
-      try: () => fetch(url),
+      try: () => fetch(url, { headers: FETCH_HEADERS }),
       catch: (error) =>
         new ApiScrapingError(`Failed to fetch content: ${error}`),
     });


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-21313831@

### What changes were made?
- Added a browser-like `User-Agent` header to all fetch calls in `json-api-scraper`
- Updated the empty-stub snapshot for two classes with corrected casing (`SmartDataDiscovery`, `SOAPType`) now returned consistently with the browser UA

### Why?
The Salesforce docs CDN (Akamai) returns 403 for requests from GitHub Actions runner IPs that don't send a browser-like User-Agent. This was causing the generate-stubs workflow to fail immediately on the TOC fetch ([run #27040483784](https://github.com/forcedotcom/apex-language-support/actions/runs/27040483784)).