### PR TITLE
test(apex-lsp-parser-ast): update empty stub snapshot for SoapType rename - W-21313831

### DIFF
--- a/packages/apex-ls/test/integration/WriteBackProtocol.debug.node.test.ts
+++ b/packages/apex-ls/test/integration/WriteBackProtocol.debug.node.test.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the
  * repo root or https://opensource.org/licenses/BSD-3-Clause
  */

--- a/packages/apex-ls/test/integration/WriteBackProtocol.debug.node.test.ts
+++ b/packages/apex-ls/test/integration/WriteBackProtocol.debug.node.test.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license.
+ * Licensed under the BSD 3-Clause license. 
  * For full license text, see LICENSE.txt file in the
  * repo root or https://opensource.org/licenses/BSD-3-Clause
  */

--- a/packages/apex-parser-ast/test/generator/__snapshots__/emptyStubDetection.snapshot.test.ts.snap
+++ b/packages/apex-parser-ast/test/generator/__snapshots__/emptyStubDetection.snapshot.test.ts.snap
@@ -19,7 +19,7 @@ exports[`Empty stub snapshot — known stubs with no members matches the accepte
     "namespace": "RichMessaging",
   },
   {
-    "className": "SOAPType",
+    "className": "SoapType",
     "namespace": "Schema",
   },
   {


### PR DESCRIPTION
### What does this PR do?

Regenerates the empty stub snapshot in `apex-parser-ast` to match the Summer '26 (262.0) stubs. The 262.0 update renamed `Schema.SOAPType` to `Schema.SoapType`, but the committed snapshot still asserted the old casing, failing `emptyStubDetection.snapshot.test.ts` across all CI test matrix jobs.

This is the only diff — a one-line snapshot update — and unblocks CI on #437.

### What issues does this PR fix or reference?

@W-21313831@