### PR TITLE
fix(infra): validate CI on nearest tested ancestor in manual-publish gate - W-22967832

### DIFF
--- a/.github/actions/check-ci-status/action.yml
+++ b/.github/actions/check-ci-status/action.yml
@@ -53,9 +53,24 @@ runs:
           IFS=',' read -ra CHECKS <<< "$REQUIRED_CHECKS"
           for CHECK in "${CHECKS[@]}"; do
             CHECK=$(echo "$CHECK" | xargs)  # trim whitespace
-            CONCLUSION=$(echo "$CHECK_RUNS" | jq -r --arg name "$CHECK" \
-              'select(.name == $name) | .conclusion' | head -1)
-            if [ "$CONCLUSION" != "success" ]; then
+
+            # Grab the latest run for this name (check-runs are newest-first per name).
+            MATCH=$(echo "$CHECK_RUNS" | jq -c --arg name "$CHECK" \
+              'select(.name == $name)' | head -1)
+
+            if [ -z "$MATCH" ]; then
+              echo "FAIL: required check '$CHECK' is absent on this commit (never ran)"
+              FAILED=1
+              continue
+            fi
+
+            STATUS=$(echo "$MATCH" | jq -r '.status')
+            CONCLUSION=$(echo "$MATCH" | jq -r '.conclusion')
+
+            if [ "$STATUS" != "completed" ]; then
+              echo "FAIL: required check '$CHECK' is not completed (status=$STATUS)"
+              FAILED=1
+            elif [ "$CONCLUSION" != "success" ]; then
               echo "FAIL: required check '$CHECK' has conclusion '$CONCLUSION' (expected 'success')"
               FAILED=1
             else

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -102,6 +102,7 @@ jobs:
       stable-version: ${{ steps.resolve.outputs.stable-version }}
       prerelease-flag: ${{ steps.resolve.outputs.prerelease-flag }}
       commit-sha: ${{ steps.resolve.outputs.commit-sha }}
+      ci-commit-sha: ${{ steps.ci-commit.outputs.ci-commit-sha }}
     steps:
       - name: Validate inputs — mutual exclusivity and bypass rules
         run: |
@@ -318,6 +319,47 @@ jobs:
           echo "stable-version=$STABLE_VERSION" >> $GITHUB_OUTPUT
           echo "prerelease-flag=false" >> $GITHUB_OUTPUT
 
+      # The resolved commit is usually a `chore: bump versions [skip ci]` commit,
+      # on which normal CI never ran (and bump commits can stack). Walk the
+      # first-parent chain to the nearest ancestor that has a successful
+      # `CI Complete` check, and validate the quality gate against THAT commit.
+      # The git tag / VSIX / GitHub Release stay on the bump commit untouched.
+      - name: Resolve nearest CI-tested ancestor
+        id: ci-commit
+        if: inputs.skip-quality-checks != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+          REPO: ${{ github.repository }}
+          START_SHA: ${{ steps.resolve.outputs.commit-sha }}
+        run: |
+          MAX_DEPTH=20
+          SHA="$START_SHA"
+          CI_SHA=""
+
+          for i in $(seq 1 "$MAX_DEPTH"); do
+            CONCLUSION=$(gh api "repos/$REPO/commits/$SHA/check-runs" --paginate \
+              --jq '[.check_runs[] | select(.name == "CI Complete")] | .[0].conclusion // empty' 2>/dev/null || echo "")
+            if [ "$CONCLUSION" = "success" ]; then
+              CI_SHA="$SHA"
+              echo "Found CI-tested ancestor at depth $((i - 1)): $CI_SHA"
+              break
+            fi
+            echo "  $SHA: no successful 'CI Complete' (conclusion='${CONCLUSION:-none}') — walking to parent"
+            PARENT=$(git rev-parse "${SHA}^" 2>/dev/null || echo "")
+            if [ -z "$PARENT" ]; then
+              echo "Reached root of history without a CI-tested commit."
+              break
+            fi
+            SHA="$PARENT"
+          done
+
+          if [ -z "$CI_SHA" ]; then
+            echo "ERROR: No ancestor with a successful 'CI Complete' check found within $MAX_DEPTH commits of $START_SHA."
+            echo "Cannot verify CI status — failing to prevent untested promotion. Use skip-quality-checks=true to bypass."
+            exit 1
+          fi
+          echo "ci-commit-sha=$CI_SHA" >> "$GITHUB_OUTPUT"
+
       - name: Upload VSIX for downstream jobs
         uses: actions/upload-artifact@v7
         with:
@@ -422,8 +464,12 @@ jobs:
       - name: Check CI status
         uses: ./.github/actions/check-ci-status
         with:
-          commit-sha: ${{ needs.prepare.outputs.commit-sha }}
+          # Validate the nearest CI-tested ancestor (resolved in `prepare`), not the
+          # [skip ci] bump commit the tag points at. required-checks scopes validation
+          # to the real CI signals so the gate never grades its own in-progress run.
+          commit-sha: ${{ needs.prepare.outputs.ci-commit-sha }}
           token: ${{ secrets.IDEE_GH_TOKEN }}
+          required-checks: 'CI Complete, Package / Package, Test Quality (ubuntu-latest, lts/*)'
 
   # ── gate ───────────────────────────────────────────────────────────────────
   # Pauses for human approval only after CI quality gate passes (or is bypassed).


### PR DESCRIPTION
### What does this PR do?

Fixes the **Manual Publish** (`manual-publish.yml`) `quality-gate` job, which always failed when run against a `main` commit.

**Root cause:** the gate called `.github/actions/check-ci-status` with no `required-checks`, so it validated **all** non-skipped check-runs on the resolved commit — including its own `quality-gate` check-run, which is `in_progress` while it runs. Result: `FAIL: check 'quality-gate' is not completed (status=in_progress)`. (Seen in [run 27425792926](https://github.com/forcedotcom/apex-language-support/actions/runs/27425792926/job/81066396216).)

Compounding it: nightly tags resolve to `chore: bump versions for release [skip ci]` commits where normal CI never ran (and these bump commits can stack), so even scoping to real checks wouldn't find a CI result on the resolved commit itself.

**Fixes:**
- **`prepare`** — new step walks the first-parent chain from the resolved commit to the nearest ancestor with a successful `CI Complete` check (`ci-commit-sha` output). The git tag, VSIX, and GitHub Release stay on the bump commit untouched, so the release-download path is unaffected.
- **`quality-gate`** — validates that ancestor with explicit `required-checks: 'CI Complete, Package / Package, Test Quality (ubuntu-latest, lts/*)'`, so it no longer grades its own in-progress run or unrelated meta-checks (Dependabot/automerge).
- **`check-ci-status`** — hardened the `required-checks` branch to report **absent** and **not-completed** required checks as distinct, clear failures.

Behavior on the bypass path (`skip-quality-checks=true`) is unchanged — the new step is gated by the same condition as `quality-gate`.

### What issues does this PR fix or reference?

@W-22967832@