### PR TITLE
ci: disable cron on promote-stable workflow (manual-only) - W-23006044

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -1,9 +1,11 @@
 name: Promote Pre-release to Stable
 
 on:
-  schedule:
-    # Wednesdays at 6 AM UTC (1 hour before pre-release promotion)
-    - cron: '0 6 * * 3'
+  # Cron schedule intentionally disabled — promotion to stable is manual only.
+  # To re-enable scheduled promotion, restore the schedule trigger below:
+  #   schedule:
+  #     # Wednesdays at 6 AM UTC (1 hour before pre-release promotion)
+  #     - cron: '0 6 * * 3'
   workflow_dispatch:
     inputs:
       dry-run:


### PR DESCRIPTION
### What does this PR do?

Comments out the `schedule` (cron) trigger in `.github/workflows/promote-stable.yml` so the **Promote Pre-release to Stable** workflow runs via `workflow_dispatch` (manual) only.

The cron block is preserved as a comment so the weekly schedule can be restored later if desired.

The workflow is currently disabled at the GitHub level (`disabled_manually`). It will be re-enabled manually via `gh workflow enable` **after this merges**, so no scheduled run can fire once it's active.

### What issues does this PR fix or reference?

@W-23006044@
