### PR TITLE
fix: remove npx -y effect-language-service from stop hook (RCE) - W-23019412

### DIFF
--- a/.claude/hooks/verify-stop.sh
+++ b/.claude/hooks/verify-stop.sh
@@ -49,18 +49,6 @@ rm -f "$SESSION_MARKER"
 run_step "compile" "npm run compile" && echo "[verify-stop] compile ok" >&2
 run_step "lint" "npm run lint" && echo "[verify-stop] lint ok" >&2
 
-# Effect LS: only uncommitted .ts files inside packages that use Effect
-ts_files=$(git diff --name-only HEAD 2>/dev/null | grep '\.ts$' | grep -v '^e2e-tests/' | grep -v '^scripts/' || true)
-if [ -n "$ts_files" ] && command -v effect-language-service >/dev/null 2>&1; then
-  for f in $ts_files; do
-    [ -f "$f" ] && run_step "effect LS ($f)" "npx -y effect-language-service diagnostics --file $f"
-  done
-elif [ -n "$ts_files" ]; then
-  echo "[verify-stop] effect LS skipped (effect-language-service not available)" >&2
-else
-  echo "[verify-stop] effect LS skipped (no uncommitted .ts in packages)" >&2
-fi
-
 run_step "test" "npm run test" && echo "[verify-stop] test ok" >&2
 run_step "bundle" "npm run bundle" && echo "[verify-stop] bundle ok" >&2
 echo "[verify-stop] all passed" >&2

--- a/.claude/hooks/verify-stop.sh
+++ b/.claude/hooks/verify-stop.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Stop hook: run compile, lint, effect LS (uncommitted .ts only), test, bundle.
+# Stop hook: run compile, lint, test, bundle.
 # On first failure, block with reason for agent to fix. Wireit cache hits = success.
 # stderr → Hooks output channel
 set -e

--- a/.claude/skills/verification/SKILL.md
+++ b/.claude/skills/verification/SKILL.md
@@ -9,9 +9,8 @@ Do each step in order; do not skip a step unless all previous are passing **exce
 
 1. `npm run compile` — [references/compile.md](references/compile.md) (TS4023: [ts4023-effect-errors](../ts4023-effect-errors/SKILL.md), TS1261: [ts1261-filename-casing](../ts1261-filename-casing/SKILL.md))
 2. `npm run lint` — fix new errors/warnings **(defer in debug mode — see [Debug mode](#debug-mode))**
-3. Effect code: `npx effect-language-service diagnostics --project tsconfig.json` (or `--file <path>`) — fix reported issues; `read_lints` does not surface Effect LS
-4. `npm run test` - See [references/unit-tests.md](references/unit-tests.md)
-5. `npm run bundle` to ensure bundles still build
+3. `npm run test` - See [references/unit-tests.md](references/unit-tests.md)
+4. `npm run bundle` to ensure bundles still build
 
 6. If working in packages that define `test:web` / `test:desktop` (e.g. `packages/apex-ls`): run from root `npm run test:web -w <package-name> -- --retries 0` / `npm run test:desktop -w <package-name> -- --retries 0` as needed. Skip if your changes are not in those packages.
 


### PR DESCRIPTION
## What

Removes the `npx -y effect-language-service diagnostics` invocation from the Claude Code stop hook ([.claude/hooks/verify-stop.sh](.claude/hooks/verify-stop.sh)) and the corresponding manual step from the verification skill ([.claude/skills/verification/SKILL.md](.claude/skills/verification/SKILL.md)).

## Why — W-23019412 (Bug Bounty / HackerOne, P0)

The stop hook ran `npx -y effect-language-service diagnostics --file $f` on every edited `.ts` file. The package name `effect-language-service` was **unclaimed on npm**, so `npx -y` would silently fetch and execute whatever a third party published under that name — with full shell access (the hook `eval`s the command) and no install prompt. That is a zero-interaction remote-code-execution / supply-chain risk that fires automatically when an agent edits TypeScript.

A researcher published a benign proof under that name (`npx -y effect-language-service` prints a banner), confirming arbitrary code execution from the registry.

## Fix

- Drop the Effect LS step from the stop hook. Verification now runs **compile → lint → test → bundle**.
- Remove the matching `npx effect-language-service diagnostics` step from the verification skill so the agent no longer points at the unowned package.

`grep` confirms zero remaining `effect-language-service` references in the repo. Bash syntax validated; full verification pipeline passed locally (4269 tests, 0 failed).

@W-23019412@