### PR TITLE
ci: strip zip extra fields in VSIX stable-promotion repack - W-23055045

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -532,8 +532,11 @@ jobs:
               sed -i "s/Version=\"$PRERELEASE_VERSION\"/Version=\"$STABLE_VERSION\"/" "$VSIX_MANIFEST"
             fi
 
+            # -X strips platform-specific extra fields (Unix UID/GID 0x7875, extended
+            # timestamps 0x5455) the `zip` CLI adds by default; OpenVSX rejects VSIXs
+            # whose zip entries carry them ("potentially harmful extra fields").
             STABLE_VSIX="./vsix-artifacts/apex-language-server-extension-${STABLE_VERSION}.vsix"
-            cd "$WORK_DIR" && zip -qr "../$STABLE_VSIX" . && cd -
+            cd "$WORK_DIR" && zip -qrX "../$STABLE_VSIX" . && cd -
             echo "vsix-path=$STABLE_VSIX" >> $GITHUB_OUTPUT
           else
             echo "vsix-path=$VSIX_FILE" >> $GITHUB_OUTPUT

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -195,10 +195,14 @@ jobs:
             echo "Warning: extension.vsixmanifest not found — skipping manifest patch"
           fi
 
-          # Rezip into a new VSIX
+          # Rezip into a new VSIX.
+          # -X strips platform-specific extra fields (Unix UID/GID 0x7875, extended
+          # timestamps 0x5455) that the `zip` CLI adds by default. OpenVSX rejects VSIXs
+          # whose zip entries carry these ("potentially harmful extra fields"), so they
+          # must be omitted for the ovsx publish to succeed.
           STABLE_VSIX="./vsix-artifacts/apex-language-server-extension-${STABLE_VERSION}.vsix"
           cd "$WORK_DIR"
-          zip -qr "../$STABLE_VSIX" .
+          zip -qrX "../$STABLE_VSIX" .
           cd -
 
           echo "Created stable VSIX: $STABLE_VSIX"


### PR DESCRIPTION
### What does this PR do?

OpenVSX blocks publishing of VSIXs whose zip entries carry platform-specific extra fields — Unix UID/GID (`0x7875`) and extended timestamps (`0x5455`) — with the error *"extension file contains zip entries with potentially harmful extra fields."*

The stable-promotion path re-zips the nightly VSIX with the Linux `zip` CLI (after patching the version in `extension/package.json` and `extension.vsixmanifest`), and that CLI adds those extra fields by default. The nightly path is unaffected because `vsce`/`yazl` writes clean entries.

This adds the `-X` flag (`zip -qr` → `zip -qrX`) to both repack steps so the extra fields are omitted:

- `.github/workflows/promote-stable.yml`
- `.github/workflows/manual-publish.yml`

A follow-up (@W-23055053@) tracks replacing the hand-rolled `zip` repack with a `vsce`-based repackage to fix this at the root.

### What issues does this PR fix or reference?

@W-23055045@