### PR TITLE
ci: repackage stable VSIX via vsce instead of zip CLI - W-23055053

### DIFF
--- a/.github/actions/repackage-vsix-stable/action.yml
+++ b/.github/actions/repackage-vsix-stable/action.yml
@@ -1,0 +1,84 @@
+name: "Repackage VSIX for Stable"
+description: >
+  Repackage a nightly/pre-release VSIX as a stable build by re-running vsce on
+  its extracted contents. vsce packs via yazl, which writes clean zip entries
+  (no Unix UID/GID 0x7875 or extended-timestamp 0x5455 extra fields) and
+  regenerates extension.vsixmanifest from package.json. This avoids the
+  `zip` CLI, whose extra fields OpenVSX rejects ("potentially harmful extra
+  fields"), and removes the brittle sed-based manifest patch.
+
+inputs:
+  source-vsix-path:
+    description: "Path to the source (pre-release) VSIX to repackage"
+    required: true
+  prerelease-version:
+    description: "Current pre-release version (for logging only)"
+    required: true
+  stable-version:
+    description: "Stable version to stamp into the repackaged VSIX"
+    required: true
+  output-dir:
+    description: "Directory to write the repackaged VSIX into"
+    required: false
+    default: "./vsix-artifacts"
+
+outputs:
+  vsix-path:
+    description: "Path to the repackaged stable VSIX"
+    value: ${{ steps.repack.outputs.vsix-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Repackage VSIX with stable version via vsce
+      id: repack
+      shell: bash
+      env:
+        SOURCE_VSIX: ${{ inputs.source-vsix-path }}
+        PRERELEASE_VERSION: ${{ inputs.prerelease-version }}
+        STABLE_VERSION: ${{ inputs.stable-version }}
+        OUTPUT_DIR: ${{ inputs.output-dir }}
+      run: |
+        set -euo pipefail
+        echo "Repackaging VSIX via vsce: $PRERELEASE_VERSION → $STABLE_VERSION"
+
+        if [ ! -f "$SOURCE_VSIX" ]; then
+          echo "::error::Source VSIX not found: $SOURCE_VSIX"
+          exit 1
+        fi
+
+        WORK_DIR="./vsix-repack"
+        rm -rf "$WORK_DIR"
+        mkdir -p "$WORK_DIR" "$OUTPUT_DIR"
+
+        # A VSIX is a ZIP whose `extension/` directory is a complete, ready-to-pack
+        # extension folder (the .vscodeignore filter was already applied when the
+        # nightly was built). Re-running vsce on it reproduces the same file set.
+        unzip -q "$SOURCE_VSIX" -d "$WORK_DIR"
+
+        PKG_JSON="$WORK_DIR/extension/package.json"
+        if [ ! -f "$PKG_JSON" ]; then
+          echo "::error::extension/package.json not found in VSIX"
+          exit 1
+        fi
+
+        # Stamp the stable version and drop the pre-release marker. vsce regenerates
+        # extension.vsixmanifest from this package.json, so no manifest sed is needed.
+        node -e "
+          const fs = require('fs');
+          const pkg = JSON.parse(fs.readFileSync('$PKG_JSON', 'utf8'));
+          pkg.version = '$STABLE_VERSION';
+          delete pkg.preRelease;
+          fs.writeFileSync('$PKG_JSON', JSON.stringify(pkg, null, 2) + '\n');
+        "
+        echo "Stamped extension/package.json version to $STABLE_VERSION"
+
+        # Resolve an absolute output path before cd-ing into the extension dir.
+        mkdir -p "$OUTPUT_DIR"
+        OUT_ABS="$(cd "$OUTPUT_DIR" && pwd)/apex-language-server-extension-${STABLE_VERSION}.vsix"
+
+        # --no-dependencies: deps are bundled by esbuild (matches the nightly package step).
+        ( cd "$WORK_DIR/extension" && npx --yes @vscode/vsce@3 package --no-dependencies --out "$OUT_ABS" )
+
+        echo "Created stable VSIX: $OUT_ABS"
+        echo "vsix-path=$OUT_ABS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -490,60 +490,56 @@ jobs:
     if: always() && needs.prepare.result == 'success' && needs.gate.result == 'success'
     runs-on: ubuntu-latest
     outputs:
-      vsix-path: ${{ steps.prepare-vsix.outputs.vsix-path }}
+      vsix-path: ${{ steps.resolve-vsix.outputs.vsix-path }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+
       - name: Download source VSIX
         uses: actions/download-artifact@v8
         with:
           name: source-vsix
           path: ./vsix-artifacts
 
-      - name: Repackage for stable (if needed)
-        id: prepare-vsix
-        env:
-          SLOT: ${{ inputs.slot }}
-          PRERELEASE_VERSION: ${{ needs.prepare.outputs.prerelease-version }}
-          STABLE_VERSION: ${{ needs.prepare.outputs.stable-version }}
+      - name: Locate source VSIX
+        id: source-vsix
         run: |
           VSIX_FILE=$(find ./vsix-artifacts -type f -name 'apex-language-server-extension-*.vsix' ! -name '*-web-*' | head -1)
           if [ -z "$VSIX_FILE" ]; then
             echo "ERROR: No VSIX found in artifact"
             exit 1
           fi
+          echo "vsix-file=$VSIX_FILE" >> $GITHUB_OUTPUT
 
-          if [ "$SLOT" = "stable" ]; then
-            echo "Repackaging VSIX: $PRERELEASE_VERSION → $STABLE_VERSION"
+      - name: Repackage for stable
+        id: repack
+        if: inputs.slot == 'stable'
+        uses: ./.github/actions/repackage-vsix-stable
+        with:
+          source-vsix-path: ${{ steps.source-vsix.outputs.vsix-file }}
+          prerelease-version: ${{ needs.prepare.outputs.prerelease-version }}
+          stable-version: ${{ needs.prepare.outputs.stable-version }}
 
-            WORK_DIR="./vsix-repack"
-            mkdir -p "$WORK_DIR"
-            unzip -q "$VSIX_FILE" -d "$WORK_DIR"
-
-            PKG_JSON="$WORK_DIR/extension/package.json"
-            node -e "
-              const fs = require('fs');
-              const pkg = JSON.parse(fs.readFileSync('$PKG_JSON', 'utf8'));
-              pkg.version = '$STABLE_VERSION';
-              delete pkg.preRelease;
-              fs.writeFileSync('$PKG_JSON', JSON.stringify(pkg, null, 2) + '\n');
-            "
-
-            VSIX_MANIFEST="$WORK_DIR/extension.vsixmanifest"
-            if [ -f "$VSIX_MANIFEST" ]; then
-              sed -i "s/Version=\"$PRERELEASE_VERSION\"/Version=\"$STABLE_VERSION\"/" "$VSIX_MANIFEST"
-            fi
-
-            STABLE_VSIX="./vsix-artifacts/apex-language-server-extension-${STABLE_VERSION}.vsix"
-            cd "$WORK_DIR" && zip -qr "../$STABLE_VSIX" . && cd -
-            echo "vsix-path=$STABLE_VSIX" >> $GITHUB_OUTPUT
+      - name: Resolve publish-ready VSIX path
+        id: resolve-vsix
+        run: |
+          # For stable, use the repackaged VSIX; otherwise publish the source as-is.
+          if [ "${{ inputs.slot }}" = "stable" ]; then
+            echo "vsix-path=${{ steps.repack.outputs.vsix-path }}" >> $GITHUB_OUTPUT
           else
-            echo "vsix-path=$VSIX_FILE" >> $GITHUB_OUTPUT
+            echo "vsix-path=${{ steps.source-vsix.outputs.vsix-file }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Upload publish-ready VSIX
         uses: actions/upload-artifact@v7
         with:
           name: publish-vsix
-          path: ${{ steps.prepare-vsix.outputs.vsix-path }}
+          path: ${{ steps.resolve-vsix.outputs.vsix-path }}
 
   # ── publish ────────────────────────────────────────────────────────────────
   publish:

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -137,8 +137,16 @@ jobs:
     needs: [find-prerelease-candidate, quality-gate]
     runs-on: ubuntu-latest
     outputs:
-      stable-vsix-path: ${{ steps.repack.outputs.stable-vsix-path }}
+      stable-vsix-path: ${{ steps.repack.outputs.vsix-path }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+
       - name: Download VSIX from nightly GitHub release
         env:
           GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
@@ -160,55 +168,17 @@ jobs:
 
       - name: Repackage VSIX with stable version
         id: repack
-        env:
-          PRERELEASE_VERSION: ${{ needs.find-prerelease-candidate.outputs.prerelease-version }}
-          STABLE_VERSION: ${{ needs.find-prerelease-candidate.outputs.stable-version }}
-        run: |
-          echo "Repackaging VSIX: $PRERELEASE_VERSION → $STABLE_VERSION"
-
-          WORK_DIR="./vsix-repack"
-          mkdir -p "$WORK_DIR"
-
-          # Unzip the VSIX (it is a ZIP archive)
-          unzip -q "$VSIX_FILE" -d "$WORK_DIR"
-
-          # Patch extension/package.json
-          PKG_JSON="$WORK_DIR/extension/package.json"
-          if [ ! -f "$PKG_JSON" ]; then
-            echo "extension/package.json not found in VSIX"
-            exit 1
-          fi
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('$PKG_JSON', 'utf8'));
-            pkg.version = '$STABLE_VERSION';
-            fs.writeFileSync('$PKG_JSON', JSON.stringify(pkg, null, 2) + '\n');
-          "
-          echo "Patched extension/package.json version to $STABLE_VERSION"
-
-          # Patch extension.vsixmanifest
-          VSIX_MANIFEST="$WORK_DIR/extension.vsixmanifest"
-          if [ -f "$VSIX_MANIFEST" ]; then
-            sed -i "s/Version=\"$PRERELEASE_VERSION\"/Version=\"$STABLE_VERSION\"/" "$VSIX_MANIFEST"
-            echo "Patched extension.vsixmanifest version to $STABLE_VERSION"
-          else
-            echo "Warning: extension.vsixmanifest not found — skipping manifest patch"
-          fi
-
-          # Rezip into a new VSIX
-          STABLE_VSIX="./vsix-artifacts/apex-language-server-extension-${STABLE_VERSION}.vsix"
-          cd "$WORK_DIR"
-          zip -qr "../$STABLE_VSIX" .
-          cd -
-
-          echo "Created stable VSIX: $STABLE_VSIX"
-          echo "stable-vsix-path=$STABLE_VSIX" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/repackage-vsix-stable
+        with:
+          source-vsix-path: ${{ env.VSIX_FILE }}
+          prerelease-version: ${{ needs.find-prerelease-candidate.outputs.prerelease-version }}
+          stable-version: ${{ needs.find-prerelease-candidate.outputs.stable-version }}
 
       - name: Upload stable VSIX as artifact
         uses: actions/upload-artifact@v7
         with:
           name: stable-vsix
-          path: ${{ steps.repack.outputs.stable-vsix-path }}
+          path: ${{ steps.repack.outputs.vsix-path }}
 
   publish:
     needs: [find-prerelease-candidate, repackage]


### PR DESCRIPTION
### What does this PR do?

Root-cause fix for **two** bugs in the VSIX stable-promotion path, both caused by the hand-rolled `unzip` → `sed` → `zip` repackaging.

The old repack unzipped the nightly VSIX, patched the version, and re-zipped with the Linux `zip` CLI. This had two problems:

1. **OpenVSX rejection** — the `zip` CLI injects Unix extra fields (UID/GID `0x7875`, extended timestamps `0x5455`) into every entry, which OpenVSX blocks with *"extension file contains zip entries with potentially harmful extra fields."* (The nightly path is unaffected because `vsce`/`yazl` writes clean entries.)
2. **Wrong release channel** — the repack only patched *versions*. It left the nightly manifest property `Microsoft.VisualStudio.Code.PreRelease="true"` untouched, so promoted stable builds (e.g. 0.6.0) shipped to the **pre-release** channel even though `vsce publish` was invoked without `--pre-release`. The marketplace reads the channel from that manifest property, not the publish flag.

This replaces the hand-rolled repackaging with a shared composite action (`.github/actions/repackage-vsix-stable`) that re-runs `vsce package` on the extracted `extension/` directory. vsce:
- packs via yazl → clean zip entries, no extra fields (fixes #1)
- regenerates `extension.vsixmanifest` from `package.json` without `--pre-release` → no stale `PreRelease` property (fixes #2)

This also removes the brittle `sed`-based manifest patch. Both call sites — `promote-stable.yml` and `manual-publish.yml` — now share one action, fixing prior drift between them.

**Verified locally** against nightly `v0.5.102`:
- Repackaged VSIX is identical in file set to the vsce-built original (39/39 files), with **0 zip extra fields**.
- Old repack retains `Microsoft.VisualStudio.Code.PreRelease="true"`; vsce repack **drops it** → lands in stable.

> Note: the `0.6.0` build promoted by [run 27715597374](https://github.com/forcedotcom/apex-language-support/actions/runs/27715597374) is already live on the marketplace mislabeled as pre-release. After this lands we'll need to re-promote (or bump to a stable patch) to correct it.

### What issues does this PR fix or reference?

@W-23055053@
