### PR TITLE
chore(repo): skill rules + cache Playwright browsers for web e2e

### DIFF
--- a/.claude/skills/language-server-architecture/SKILL.md
+++ b/.claude/skills/language-server-architecture/SKILL.md
@@ -77,6 +77,17 @@ When modifying resolution code in `apex-parser-ast/src/symbols/ops/`:
 - Do not remove GlobalTypeRegistry usage — it provides cross-file resolution on the coordinator
 - Ensure enrichment worker fallback paths work correctly (they bypass the empty registry)
 
+## Separation of Concerns (Data Ownership Boundaries)
+
+Keep data-handling logic siloed within the component whose responsibility it is. Each layer of the topology has one job:
+
+- **Coordinator** — routing and message passing only. It dispatches requests to the right worker and relays responses. It does NOT transform, enrich, parse, or reshape symbol data; that belongs to the worker that owns the data.
+- **Data owner worker** — owns the symbol graph for workspace + faux SObject files. All mutation, merging, and write-back reconciliation of those symbols lives here.
+- **Request/enrichment workers** — process LSP requests against symbols they fetch from the data owner; transformation of request results lives here, not in the coordinator.
+- **Resource loader worker** — owns all stdlib access and any reshaping of stdlib artifacts.
+
+Rule of thumb: if you're adding data transformation logic to the coordinator, it's in the wrong place — push it down to the owning worker. A component should only manipulate data it owns.
+
 ## LSP Request Routing (DISPATCH_ROUTING)
 
 Defined in `apex-ls/src/server/WorkerCoordinator.ts`.

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -14,6 +14,7 @@ description: TypeScript coding standards and conventions including file naming r
 - avoid `any`
 - no enums or namespaces (enums compile to weird JS; use string union types instead; exception: interfaces defined outside this repo that we can't change)
 - no runtime errors for developer mistakes (use types to ensure exhaustive switch/case; don't throw for null/undefined when input/consumer is within our control)
+- avoid fallbacks unless absolutely necessary — a fallback path is usually a bandaid on a bug that should be fixed upstream. Fix the root cause; don't paper over it with a default/alternate path that hides the real failure. If a fallback is genuinely required, comment why the upstream fix isn't possible.
 - .ts filenames: camelCase, no hyphens, no leading capitals
 - preserve comments when refactoring; remove if wrong/obsolete
 - exported functions: single-line jsdoc /\*_ foo _/ if name unclear; no params/return (TS provides types)

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -69,8 +69,24 @@ jobs:
           fi
           echo "✅ Extension build verified"
 
-      - name: Install Playwright browsers
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers (cache miss)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Run E2E tests - ${{ matrix.test_file }}
         id: parallel-run


### PR DESCRIPTION
### What does this PR change?

**Skill rules** (`.claude/skills/`):
- **`typescript` SKILL** — avoid fallbacks unless absolutely necessary; a fallback path is usually a bandaid on a bug that should be fixed upstream. Fix the root cause; if a fallback is genuinely required, comment why the upstream fix isn't possible.
- **`language-server-architecture` SKILL** — new "Separation of Concerns (Data Ownership Boundaries)" section: keep data-handling logic siloed in the owning worker. The coordinator does routing/message-passing only — no data transformation, enrichment, or reshaping.

**CI fix** (`.github/workflows/e2e-tests.yml`):
- Cache Playwright browsers for the web e2e jobs. These jobs were hitting the 15m job timeout (surfacing as "cancelled" on PRs, e.g. #472) because `playwright install --with-deps` re-downloaded the browser + system fonts from the apt mirror every run — sometimes >13m before any test ran.
- Cache `~/.cache/ms-playwright` keyed on the resolved Playwright version. On a cache hit, install only system deps (`install-deps`) instead of the full browser+font download, keeping setup off the test-time budget.

### What issues does this PR fix or reference?

None. Repo tooling/CI only — no `src/` changes.

[skip-validate-pr]
