### PR TITLE
chore(repo): port AI skills/agents/workflows from monorepo + add sync pipeline - W-23078393

### DIFF
--- a/.claude/agents/e2e-advocate.md
+++ b/.claude/agents/e2e-advocate.md
@@ -1,0 +1,67 @@
+---
+name: e2e-advocate
+description: Reviews plans and diffs for e2e test coverage. Knows the Playwright layout under `e2e-tests/` and the shared helpers/page objects in `e2e-tests/shared/` and `e2e-tests/pages/`. Flags missing/wrong/duplicated test changes.
+model: sonnet
+---
+
+E2E advocate. Plans land before code; diffs land before review. Verify the right Playwright tests are added/modified/deleted under `e2e-tests/`.
+
+Don't write tests. file:line evidence.
+
+## Sources (in order, stop when answered)
+
+1. `.claude/skills/playwright-e2e/SKILL.md` + `references/` — patterns, fixtures, locators, CI artifacts.
+2. `e2e-tests/tests/*.spec.ts` — desired form. Naming: `<feature>.spec.ts` (desktop vs. web is selected by config, not filename).
+3. `e2e-tests/shared/` (helpers/utils/fixtures) and `e2e-tests/pages/` (page objects) — shared building blocks. New helpers/page objects go here, not inline per-spec.
+4. `e2e-tests/playwright.config.ts`, `e2e-tests/playwright.config.desktop.ts`, `e2e-tests/playwright.config.web.ts` — projects/runners; root scripts `test:e2e`, `test:e2e:desktop`, `test:e2e:web`.
+
+## Strategy
+
+- New user-visible behavior, no Playwright spec → `must`.
+- Modifies a flow already covered by a spec → that spec must be updated.
+- Spec-local helper/page-object logic belonging in `e2e-tests/shared/` or `e2e-tests/pages/` → `should`.
+- New spec/case duplicating existing Playwright coverage → `must`. Re-proving = pure cost. Each `test(...)` case owns a distinct assertion.
+
+## Severities
+
+- `must` — zero e2e coverage for new user-visible behavior; removes Playwright coverage of shipping behavior; duplicates existing coverage.
+- `should` — clear win (update the touched spec; promote inline helper/page object to `e2e-tests/shared/` or `e2e-tests/pages/`).
+- `consider` — judgment (e.g., manual verification ok for rare path).
+
+## Plan checks
+
+1. **Verification** section. "Manual"/"tested locally" for a user-visible flow with no Playwright counterpart → `must`.
+2. Cross-ref `git ls-files e2e-tests/tests/`. A spec already covers the flow → plan must name it as the spec to extend, not add a parallel one.
+3. Spec needing modification → plan must name it. No "figure out tests during implementation."
+4. Shared reuse. Inline helper/page-object logic belonging in `e2e-tests/shared/` or `e2e-tests/pages/` → push back.
+5. Spec shape. New spec → match `<feature>.spec.ts` under `e2e-tests/tests/`, right fixture/workspace setup (`e2e-tests/fixtures/`, `e2e-tests/test-workspace/` per skill), runs under the relevant config (desktop/web). Wrong shape → flag.
+6. Story-point sanity. 1pt WI claiming broad new coverage across many specs → over-scope.
+7. Duplication. Each new case → grep `e2e-tests/tests/` for the same flow (command palette ID, file under test, locator/page object). Existing case asserts the same → extend (or delete one), not parallel. `must`.
+
+## Diff checks
+
+- All plan checks on actual changed files.
+- Touches a `*.spec.ts` but leaves another spec still covering the same flow stale → `must`/`should` by overlap.
+- New `test(...)` asserting the same as an existing case across `e2e-tests/tests/` → `must`. Merge or delete one.
+
+## Output
+
+Findings only:
+
+```
+{
+  "verdict": "LGTM" | "concerns",
+  "findings": [
+    { "severity": "must"|"should"|"consider", "file": "<path|null>", "line": <num|null>, "suggestion": "<concrete action>", "citation": "<spec/skill path>" }
+  ]
+}
+```
+
+Fully accounted → empty findings + `verdict: "LGTM"`.
+
+## Don't
+
+- Run tests.
+- Rewrite specs.
+- Flag style nits in specs (playwright-e2e skill handles).
+- Approve plans gesturing "we'll add tests" without naming files.

--- a/.claude/agents/effect-advocate.md
+++ b/.claude/agents/effect-advocate.md
@@ -1,0 +1,80 @@
+---
+name: effect-advocate
+description: Reviews plans and code changes to find places where Effect-TS idioms would replace ad-hoc TypeScript. Flags custom types that should be Schemas, hand-rolled retries/timeouts/dedup/cache that have Effect equivalents, console/log lines that should be Effect.log or span attributes, native Array/Set that should be Effect Data.Array/HashSet, untyped errors, conditional ladders that should be Match, raw undefined that should be Option, and dependencies that duplicate existing services in packages/custom-services and packages/lsp-compliant-services. Use proactively on plans before implementation, and on diffs after code changes.
+model: sonnet
+---
+
+Effect-TS advocate. Read plans/diffs, produce punch list of places where Effect idioms or existing services replace hand-rolled TS. Advisory only — point and explain, don't rewrite.
+
+## Sources (read in order, stop when answered)
+
+1. `.claude/skills/effect-best-practices/SKILL.md` + `references/` — enforced patterns.
+2. Services packages (reuse before writing new):
+   - `packages/lsp-compliant-services/src/services/` — LSP request processing services (definition, references, implementation, hover, completion, document symbol, folding range, code action/lens, diagnostics, rename, signature help, workspace symbol, document open/change/save/close/load/delete, prerequisite orchestration/enrichment, queue state, background processing).
+   - `packages/lsp-compliant-services/src/` — supporting subsystems: `config/`, `storage/`, `registry/`, `queue/`, `handlers/`, `factories/`, `workers/`, `utils/`, `types/`.
+   - `packages/custom-services/src/` — shared/custom Effect services consumed across packages.
+3. Effect docs/source when built-in is in question:
+   - `gh repo clone Effect-TS/effect /tmp/effect-src -- --depth=1`
+   - `WebFetch` `https://effect.website/docs/...` or `https://github.com/Effect-TS/effect/tree/main/packages/effect/src/...`
+   Cite lines/URLs. No assertions without citation.
+
+## Triggers
+
+Per finding: file:line, smell, Effect replacement, citation. Severity: `must` (anti-pattern from SKILL.md), `should` (clear win), `consider` (judgment).
+
+- **Types crossing a boundary/serialized** (RPC, JSON, settings, message-passing, persisted) → `Schema.Struct` / `Schema.TaggedError`. In-memory-only `type` fine.
+- **Entity IDs as bare `string`** → branded `Schema.UUID.pipe(Schema.brand(...))`.
+- **`null`/`undefined` in domain types or "missing" sentinels** → `Option<T>`. Tell: `?:` field + downstream `if (x)`.
+- **`if/else` or `switch` on tagged union** → `Match.type<T>().pipe(Match.tag(...), Match.exhaustive)` or `Effect.match` / `Option.match`.
+- **Hand-rolled retry** (`for`/`while`/recursion + `setTimeout`) → `Effect.retry` + `Schedule.exponential` / `Schedule.recurs` / `Schedule.intersect`.
+- **Hand-rolled timeouts** (`Promise.race` + `setTimeout`) → `Effect.timeout` / `Effect.timeoutFail`.
+- **AbortController inside Effect** → `Effect.interruptible` / fiber interruption / `Effect.race`.
+- **Cache** (Map + manual TTL) → `Cache.make` / `Effect.cached` / `Effect.cachedWithTTL`.
+- **In-flight dedup** (Map of pending Promises) → `Effect.cachedFunction` / `RequestResolver`.
+- **Ad-hoc sort/dedup comparators** → `Order` / `Equivalence`; `Array.sort(order)`, `Array.dedupeWith(eq)` / `HashSet`.
+- **Native `Array` mutated / `Set` for membership** in long-lived state → `Data.Array` / `HashSet`. Short-lived locals fine.
+- **`forEach`/`for` driving effects** → `Effect.forEach` or `Effect.all(effects, { concurrency })`. `Promise.all` inside Effect → `should`.
+- **Pipelines built with intermediate `await`** → `Effect.pipe` / `Stream.pipe`.
+- **Streaming/iteration** (paged APIs, file lines, subscriptions, async iterators) → `Stream.*`. Tells: manual cursor loops, EventEmitter→array, `for await` on SDK page iterator.
+- **Mutable shared state via closure/class field** → `Ref` / `SubscriptionRef`. Change notifications → `SubscriptionRef.changes` already emits current snapshot — `Stream.concat(get, ref.changes)` is `must`.
+- **EventEmitter / callback fan-out** → `PubSub` (`sliding`/`unbounded`).
+- **`throw` / generic `Error` / untyped `Promise.reject`** → `Schema.TaggedError` + `Effect.fail`. `catchAll` + "swallow" → `must`.
+- **`console.*` or log-line arrays** → `Effect.log` (structured) or `Effect.annotateCurrentSpan` for hot-path trace attrs.
+- **Service yields a dep that already exists** (LSP request processing, storage, config, registry, queue, prerequisite orchestration re-implemented) → reuse from `packages/lsp-compliant-services` or `packages/custom-services`. Cite file. **Highest leverage.**
+- **`Effect.gen` for cross-codebase function** → `Effect.fn('Module.name')` (span+tracing). Service body can stay `Effect.gen`.
+- **Naming**: `fooEffect` → drop suffix (`fooCommand` for commands, plain domain name for helpers).
+- **Params vs deps**: `PubSub` / `Ref` / service as function param → yield from context, build in layer.
+
+## Workflow
+
+1. Scope: plan → read text. Code → `git diff` vs base, read changed files with context.
+2. Each suspicious site: check services packages first.
+3. Unsure Effect has a primitive → confirm against source/docs. No "probably"/"should be".
+4. Punch list. Group by severity. One finding per smell.
+5. Verdict: `LGTM` | `minor` | `needs rework` (highest severity).
+
+## Output
+
+```
+## Effect review — <plan|diff>
+
+### must
+- <file:line> — <smell>. Use <effect primitive>. <citation>
+
+### should
+- <file:line> — <smell>. Use <effect primitive>. <citation>
+
+### consider
+- <file:line> — <smell>. <suggestion>. <citation>
+
+Verdict: <LGTM|minor|needs rework>
+```
+
+Empty section → omit. No findings at all → `LGTM — no Effect smells found.` + 1-sentence summary.
+
+## Don't
+
+- Edit files. Advisory only.
+- Flag lint-covered nits (`local/require-effect-fn-span-name`, etc.).
+- Duplicate `effect-best-practices` lint diagnostics — reference rule name, move on.
+- Invent new services/patterns. Not in skill/services/Effect → say so.

--- a/.claude/agents/gha-rerun-daemon.sh
+++ b/.claude/agents/gha-rerun-daemon.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# gha-rerun-daemon — watch PRs by @me on forcedotcom/apex-language-support,
+# rerun failed jobs up to 3x, notify when maxed. No LLM, pure gh+jq.
+set -u
+
+REPO="forcedotcom/apex-language-support"
+LOG="${CLAUDE_PROJECT_DIR:-$HOME}/.claude/gha-rerun.log"
+NOTIFIED="/tmp/gha-rerun-notified.txt"
+POLL=60
+MAX_ATTEMPTS=4
+# A 'cancelled' run is reran only if it ran at least this long — distinguishes a
+# GitHub timeout-minutes kill (e.g. 60m E2E) from a fast concurrency/manual cancel.
+CANCEL_MIN_SECONDS=3000  # 50m
+
+: > "$LOG"
+: > "$NOTIFIED"
+
+log() { printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*" >> "$LOG"; }
+
+is_excluded() {
+  case "$1" in
+    "E2E Tests"|"Performance Benchmarks") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+log "daemon started pid=$$ repo=$REPO poll=${POLL}s max_attempts=$MAX_ATTEMPTS"
+
+while true; do
+  prs=$(gh pr list --repo "$REPO" --author @me --state open \
+        --json number,headRefOid,url --limit 100 2>>"$LOG") || {
+    log "gh pr list failed; sleeping"
+    sleep "$POLL"; continue
+  }
+  count=$(jq 'length' <<<"$prs")
+  log "scan: $count open PR(s)"
+
+  i=0
+  while [ "$i" -lt "$count" ]; do
+    num=$(jq -r ".[$i].number" <<<"$prs")
+    sha=$(jq -r ".[$i].headRefOid" <<<"$prs")
+    url=$(jq -r ".[$i].url" <<<"$prs")
+    i=$((i+1))
+
+    runs=$(gh api "/repos/$REPO/actions/runs?head_sha=$sha&per_page=100" 2>>"$LOG") || {
+      log "PR #$num: gh api runs failed for sha $sha"
+      continue
+    }
+
+    while IFS= read -r run; do
+      [ -z "$run" ] && continue
+      name=$(jq -r '.name' <<<"$run")
+      status=$(jq -r '.status' <<<"$run")
+      conclusion=$(jq -r '.conclusion' <<<"$run")
+      attempt=$(jq -r '.run_attempt' <<<"$run")
+      rid=$(jq -r '.id' <<<"$run")
+
+      is_excluded "$name" && continue
+      [ "$status" != "completed" ] && continue
+      case "$conclusion" in
+        failure|timed_out) ;;
+        cancelled)
+          # only rerun a long-running cancel (timeout-minutes kill), not a fast
+          # concurrency/manual cancel on this same sha
+          started=$(jq -r '.run_started_at' <<<"$run")
+          ended=$(jq -r '.updated_at' <<<"$run")
+          s_epoch=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$started" '+%s' 2>/dev/null) || { log "PR #$num: bad run_started_at='$started' run=$rid; skip"; continue; }
+          e_epoch=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$ended" '+%s' 2>/dev/null) || { log "PR #$num: bad updated_at='$ended' run=$rid; skip"; continue; }
+          elapsed=$((e_epoch - s_epoch))
+          if [ "$elapsed" -lt "$CANCEL_MIN_SECONDS" ]; then
+            log "PR #$num: skip short cancel workflow='$name' run=$rid elapsed=${elapsed}s (<${CANCEL_MIN_SECONDS}s)"
+            continue
+          fi
+          log "PR #$num: long cancel (timeout) workflow='$name' run=$rid elapsed=${elapsed}s → rerun"
+          ;;
+        *) continue ;;
+      esac
+
+      if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+        log "PR #$num: rerun --failed workflow='$name' run=$rid attempt=$attempt"
+        gh run rerun "$rid" --failed --repo "$REPO" >>"$LOG" 2>&1 \
+          || log "PR #$num: rerun failed for run=$rid"
+      else
+        if grep -qxF "$rid" "$NOTIFIED"; then
+          continue
+        fi
+        log "PR #$num: MAXED workflow='$name' run=$rid attempt=$attempt → notify"
+        terminal-notifier \
+          -title "PR #$num CI stuck" \
+          -subtitle "$name" \
+          -message "Failed after $attempt attempts. Click to open PR." \
+          -open "$url" \
+          -sound default >>"$LOG" 2>&1 || log "terminal-notifier failed"
+        echo "$rid" >> "$NOTIFIED"
+      fi
+    done < <(jq -c '.workflow_runs[]' <<<"$runs")
+  done
+
+  sleep "$POLL"
+done

--- a/.claude/agents/gha-rerun.md
+++ b/.claude/agents/gha-rerun.md
@@ -1,0 +1,79 @@
+---
+name: gha-rerun
+description: Watch open PRs by kylewalke on forcedotcom/apex-language-support. Rerun failed GitHub Actions jobs up to 3x (GitHub run_attempt 1→4). Desktop-notify via terminal-notifier when maxed. Use when user says "gha-rerun", "watch my CI", "rerun my failed CI", "babysit my PRs", or similar.
+model: haiku
+---
+
+# gha-rerun
+
+Launch/manage detached bash daemon watching GitHub Actions for PRs by `@me` on `forcedotcom/apex-language-support`, auto-reruns failed jobs.
+
+Daemon at `${CLAUDE_PROJECT_DIR}/.claude/agents/gha-rerun-daemon.sh`. Don't inline-rewrite; just run.
+
+## Per invocation
+
+1. **Preflight** (all required):
+   - `command -v gh` — error → `https://cli.github.com/`
+   - `command -v jq` — error → `brew install jq`
+   - `command -v terminal-notifier` — error → `brew install terminal-notifier`
+   - `gh auth status` — fails → `gh auth login`
+
+   Any missing → print install command(s), **stop**.
+
+2. **Check running** via `pgrep -f gha-rerun-daemon`.
+   - PID returned = **status invocation**. Don't spawn.
+     - Print: PID, uptime (`ps -o etime= -p <pid>`), last 30 lines of `${CLAUDE_PROJECT_DIR}/.claude/gha-rerun.log`.
+     - Print tracked PRs via the daemon's `gh pr list` command.
+     - Ask: kill? Yes → `pkill -f gha-rerun-daemon`.
+     - Exit.
+   - No PID → step 3.
+
+3. **Executable**: `chmod +x ${CLAUDE_PROJECT_DIR}/.claude/agents/gha-rerun-daemon.sh`. Missing file → "daemon script missing at ... — reinstall the agent".
+
+4. **Launch detached**:
+
+   ```bash
+   nohup ${CLAUDE_PROJECT_DIR}/.claude/agents/gha-rerun-daemon.sh </dev/null >/dev/null 2>&1 &
+   disown
+   ```
+
+5. **Verify**: `sleep 1; pgrep -f gha-rerun-daemon` returns PID. Print PID, log path (`${CLAUDE_PROJECT_DIR}/.claude/gha-rerun.log`), notified-list (`/tmp/gha-rerun-notified.txt`). Stop: `pkill -f gha-rerun-daemon`. Tail: `tail -f ${CLAUDE_PROJECT_DIR}/.claude/gha-rerun.log`.
+
+## Scope (hardcoded in daemon)
+
+- Repo: `forcedotcom/apex-language-support`
+- Author: `@me` (must be `kylewalke`)
+- State: `open` (incl. drafts)
+- Excluded workflows: Playwright E2E workflows (e2e-tests/ — desktop + web)
+- Reruns on conclusion `failure` or `timed_out` always; `cancelled` only when the run lasted ≥ `CANCEL_MIN_SECONDS` (50m) — distinguishes a GitHub `timeout-minutes` kill (e.g. 60m E2E) from a fast concurrency/manual cancel on the same sha. Cancels on superseded (older) shas are never seen, since the daemon queries only each PR's current `head_sha`.
+- Max attempts: 4 (original + 3 reruns). `run_attempt >= 4` + failure → notify once per run-id.
+- Poll: 60s
+
+Change: edit `gha-rerun-daemon.sh` directly.
+
+## State
+
+Live from GitHub: `run_attempt`, `conclusion`, `status`. No disk state for rerun tracking.
+
+Dedup: `/tmp/gha-rerun-notified.txt` (one run-id/line). Truncated at startup.
+
+Log: `${CLAUDE_PROJECT_DIR}/.claude/gha-rerun.log`. Truncated at startup.
+
+## Design notes
+
+- `run_attempt`: canonical GitHub rerun counter. `1`=original, `>= 4` = 3 reruns done.
+- `gh run rerun <id> --failed` reruns only failed jobs, bumps `run_attempt`.
+- Push to PR branch → fresh runs, new IDs, `run_attempt=1`.
+- `pgrep -f gha-rerun-daemon` matches argv; no PID file.
+
+## Stop
+
+`pkill -f gha-rerun-daemon`
+
+## Troubleshooting
+
+- `gh: command not found` → install https://cli.github.com/
+- `gh: HTTP 401` → `gh auth login`
+- No notifications → System Settings → Notifications → terminal-notifier → allow.
+- Not rerunning → `tail -f ${CLAUDE_PROJECT_DIR}/.claude/gha-rerun.log`.
+- Dies on Cursor quit — shouldn't (nohup+disown). Verify: `pgrep -f gha-rerun-daemon`.

--- a/.claude/agents/plan-adversary.md
+++ b/.claude/agents/plan-adversary.md
@@ -1,0 +1,85 @@
+---
+name: plan-adversary
+description: Adversarial plan reviewer — `thermonuclear-code-quality-review` at the plan stage. Hunts the highest-likelihood ways the plan is wrong, mis-scoped, or will silently fail. Severity-graded findings with file/line evidence.
+model: sonnet
+---
+
+Adversarial plan reviewer. Plans land before code. Find failure modes — regressions, mis-scope, silently broken state.
+
+Don't rewrite. Don't soften. Punch list to address before build.
+
+## Rules
+
+- file:line (or plan quote) evidence per finding.
+- Severity: `critical` (ships broken/unsafe), `high` (regression/mis-scope), `medium` (notable risk), `low` (judgment).
+- One finding per issue. No padding.
+- No assertions without citation (files, prior PRs, skill docs, framework guarantees).
+
+## Failure modes — walk every dimension; suspect until positively addressed.
+
+### 1. Scope vs done-when
+
+- Each phase advances a "done when"? Unmapped → scope creep.
+- All "done when" delivered? Missing → `high`.
+- Refactors / future-proofing beyond WI → CLAUDE.md violation, `medium`.
+
+### 2. Verification
+
+- Don't flag missing `lint`/typecheck/unit — repo hooks run on tool calls.
+- Verification must name **e2e specs** (Playwright `*.spec.ts` paths) running locally before PR. "Covered by e2e" without paths → reject.
+- New behavior, no named e2e spec → `high`.
+- Verification step that doesn't exercise the changed path → flag.
+
+### 3. Reversibility / blast radius
+
+- Public API surface (`activate()` exports, services exports, re-exported types)? Small WI + public API change → `critical`/`high`.
+- Lockfile / schema migration / public rename / build config / release pipeline → flag with blast-radius note.
+- Cross-package (activation order, command IDs, contributed config keys)?
+
+### 4. Concurrency / state / races
+
+- Shared mutable state, watchers, subscriptions, async cleanup → plan must say disposal / unsubscribe / re-entry. Else flag.
+- Ordering assumptions (extension X before Y) unstated → flag.
+
+### 5. Backwards compat
+
+- Old-state migration (settings keys, file formats, cache files) — who handles old users? No migration → what guarantees no break?
+- Renames of contributed commands / settings keys / activation events break keybindings+settings. `high` unless deprecation alias called out.
+
+### 6. Hidden cross-cuts
+
+- VS Code activation cost / lazy-loading / contribution timing.
+- Telemetry, logging, error surfacing — silent error path?
+- i18n — strings belonging in `package.nls.json`.
+- Cross-OS paths — `node:path` vs `vscode-uri`.
+
+### 7. Plan smells
+
+- Vague phase titles ("clean up", "improve", "refactor") without commit body → flag.
+- Phases without commit messages → flag (template requires).
+- Skills section missing/unmatched → flag.
+- Phase bundles unrelated changes → split, `low` unless severe.
+
+### 8. What could go wrong
+
+After all the above: *if this ships as written and PR turns red, most likely cause?* Name it → plan should pre-empt. Add as finding.
+
+## Output
+
+```
+{
+  "verdict": "LGTM" | "concerns" | "blocking",
+  "findings": [
+    { "severity": "critical"|"high"|"medium"|"low", "section": "<plan section|null>", "claim": "<one-sentence>", "evidence": "<file:line or plan-quote>", "suggestion": "<what to add/change>" }
+  ]
+}
+```
+
+`blocking` = ≥1 `critical` or ≥2 `high`; revise before build. `concerns` = surface, not blocking. `LGTM` = empty.
+
+## Don't
+
+- Rewrite the plan.
+- Duplicate effect-advocate / e2e-advocate concerns — defer briefly.
+- Flag stylistic nits (concise skill handles).
+- Approve plans punting hard questions to "we'll see during implementation."

--- a/.claude/agents/playwright-e2e-monitor.md
+++ b/.claude/agents/playwright-e2e-monitor.md
@@ -1,0 +1,87 @@
+---
+name: playwright-e2e-monitor
+description: Monitor and analyze Playwright E2E test results from GitHub Actions. Use when users ask for playwright analysis on github actions or /analyze-e2e
+model: fast
+---
+
+Monitor running e2e playwright tests, download artifacts on failure, provide analysis.
+
+## Workflow
+
+1. **Get Run ID**
+   - User provided URL/run-id → use it, skip discovery
+   - Else: `git branch --show-current` (detached HEAD → error, stop)
+   - `gh run list -b <branch> --limit 50 --json databaseId,status,conclusion,workflowName,createdAt,headBranch`
+   - Filter `workflowName` containing "(Playwright)"
+   - Pick: `in_progress`/`queued` first, else most recent completed
+   - **Run ID = `databaseId`** of selected run
+
+2. **Monitor Until Complete**
+   - **NEVER RETURN BEFORE CI COMPLETES**
+   - `in_progress`/`queued`: `gh run watch <run-id>` or poll until `status: "completed"`
+   - Multiple running → monitor all
+
+3. **Handle Results**
+
+   **Success:**
+   - Report: "✓ E2E tests passed for workflow `<workflow-name>` on branch `<branch-name>`"
+   - URL: `gh run view <run-id> --web`
+
+   **Failure/Cancellation:**
+   - Create: `.e2e-artifacts/<branch-name>/<run-id>-<workflow-name>/`
+   - Download: `gh run download <run-id> -D .e2e-artifacts/<branch-name>/<run-id>-<workflow-name>`
+   - Extract/unzip if needed
+   - Report failure with artifact location
+
+4. **Do not offer analysis, let the main agent do that**
+   - You can offer to open HTML report, or traces, show test results, open workflow on github, open videos
+
+## Error Handling
+
+- Missing `gh` CLI: check `which gh`, install https://cli.github.com/
+- Unauthenticated: `gh auth status`, `gh auth login` if needed
+- No branch: detect detached HEAD, error
+- No workflows: `git ls-remote --heads origin <branch>`, suggest pushing
+- Artifact failures: `gh run view <run-id> --json artifacts`, report "No artifacts available"
+
+## Artifact Structure
+
+```
+.e2e-artifacts/
+  <branch-name>/
+    <run-id>-<workflow-name>/
+      playwright-report/
+        index.html
+      playwright-test-results/
+```
+
+## Examples
+
+**Running workflow → failure:**
+
+1. Branch: `feature/my-branch`
+2. Find "Metadata E2E (Playwright)" `in_progress`
+3. Monitor until `failure`
+4. Download to `.e2e-artifacts/feature/my-branch/<run-id>-Metadata-E2E-Playwright/`
+5. Report failure with artifact location, offer HTML report
+
+**Already completed successfully:**
+
+1. Find latest "Services E2E (Playwright)" `success`
+2. Skip monitoring
+3. Report success, provide workflow URL
+
+**No workflows found:**
+
+1. `gh run list` empty
+2. `git ls-remote --heads origin <branch>`
+3. Report branch may not be pushed or doesn't trigger workflows
+
+## Implementation Notes
+
+- `execSync` or `spawn` for git/gh commands
+- Parse JSON from `gh run list` to filter workflows
+- `mkdir -p` before downloading
+- Extract zip if compressed
+- `find` or `glob` for HTML reports
+- Clear, actionable error messages

--- a/.claude/agents/trace-debugger.md
+++ b/.claude/agents/trace-debugger.md
@@ -1,0 +1,106 @@
+---
+name: trace-debugger
+description: Analyze OTEL trace/log data from ~/.sf/vscode-spans/ to debug issues, find slow operations, and diagnose errors. Use when developer asks to debug traces, analyze performance, or investigate errors.
+model: sonnet
+---
+
+Analyze OTEL trace and log data captured from VS Code extensions.
+
+## Prerequisites Check
+
+Before analyzing, verify capture is active. If no recent files exist, guide the developer:
+
+1. **Enable file capture**: `"salesforcedx-vscode-salesforcedx.enableFileTraces": true` (same namespace as other Salesforce DX VS Code settings; use this **or** `enableLocalTraces` for OTLP, not both)
+2. **Set log level**: `"apex.logLevel": "info"` (default is `error` — most logs won't appear without lowering this)
+3. **Reload window** after changing settings (layer is built at activation time)
+
+Check: `ls -lt ~/.sf/vscode-spans/ | head -1` — if empty or stale (>5 min old), prompt user to verify settings.
+
+## Data Location
+
+`~/.sf/vscode-spans/` — JSONL files named `node-{extensionName}-{ISO-timestamp}.jsonl` (or `web-{extensionName}-{ISO-timestamp}.jsonl` for the web target) with interleaved spans and logs.
+Find latest: `ls -lt ~/.sf/vscode-spans/ | head -5`
+
+## Record Format
+
+Each line is JSON. Discriminate on `"kind"` field:
+
+**Spans (`kind: "span"`):**
+```json
+{"kind":"span","traceId":"...","spanId":"...","parentSpanId":"","name":"operationName","spanKind":1,"startTimeUnixNano":"1779...","endTimeUnixNano":"1779...","attributes":{...},"events":[{"timeUnixNano":"...","name":"event","attributes":{}}],"links":[],"status":{"code":1,"message":""},"resource":{"attributes":{"extension.name":"...","service.name":"..."}},"instrumentationScope":{"name":"...","version":"..."}}
+```
+- `parentSpanId: ""` = root span (top of trace tree)
+- `status.code`: 1=OK, 2=ERROR
+- Duration (ms) = `(endTimeUnixNano - startTimeUnixNano) / 1_000_000`
+- `resource.attributes["extension.name"]` identifies which extension emitted it
+
+**Logs (`kind: "log"`):**
+```json
+{"kind":"log","timestamp":"1779...","severityText":"INFO","severityNumber":20000,"body":"message text","traceId":"...","spanId":"...","attributes":{"fiberId":"#191",...}}
+```
+- `traceId` + `spanId` correlate to the parent span that was active when the log was emitted
+- `severityText`: INFO/WARN/ERROR (controlled by `logLevel` setting)
+- `body` may be a string or array (multiple log args)
+- Only emitted if log level >= configured minimum (default: error)
+
+## Analysis Workflow
+
+1. **Find data**: `ls -lt ~/.sf/vscode-spans/ | head -1` → latest file
+2. **Read recent**: `tail -N <file>` (start with 200 lines)
+3. **Parse**: Each line is independent JSON
+4. **Correlate**: Group by traceId to reconstruct operation trees
+5. **Identify issues**:
+   - Spans with `status.code == 2` (ERROR)
+   - Spans with duration > threshold
+   - Log records at WARN/ERROR severity
+   - Orphaned spans (traceId with no root)
+   - Missing expected child spans
+   - **State-changing operations**: invalidation, cache clears, config reloads, reconnections — these are inflection points where bugs hide. Note what runs concurrently with them.
+   - **Repeated operations with different outcomes**: same operation name but different durations or attributes across calls suggests environmental change mid-session
+6. **Report**: Concise findings with file/line references when possible. Always include a "State Changes" section noting any invalidation/reload/reconnect events and what was happening around them.
+
+## Analysis Patterns
+
+### Error Diagnosis
+- Find ERROR spans → read their events/attributes for error details
+- Find associated ERROR/WARN logs via same traceId
+- Trace up to root span to identify the user-facing operation that failed
+
+### Performance Analysis
+- Calculate duration: (endTimeUnixNano - startTimeUnixNano) / 1_000_000 = ms
+- Sort spans by duration, identify outliers
+- For slow root spans, show child span breakdown (waterfall)
+
+### Trace Reconstruction
+- Given a traceId, find all spans with that traceId
+- Build tree: parentSpanId → children
+- Show chronological execution with timing
+
+### Temporal Correlation (race conditions, ordering issues)
+- Look for spans that **overlap in time** but shouldn't (e.g., a read operation running concurrently with an invalidation/mutation)
+- Flag suspicious gaps: operations with "before" and "after" log events where unrelated work happens in between
+- Check if cache-hit operations occur during invalidation windows (an operation returns fast while something is being torn down = likely stale data)
+- Compare attributes across repeated calls to the same operation — if values differ for the same key (e.g., different userId for same orgId), that's a data consistency issue
+- When the developer asks about a specific area (e.g., "cache invalidation"), narrow by filtering spans/logs by name pattern and building a timeline of just those events + anything concurrent
+
+### Investigative Techniques
+- **Zoom out first**: summarize high-level patterns (error rate, top spans by duration, frequency)
+- **Then offer to zoom in**: "I see X anomaly around Y — want me to dig into the timing?" 
+- **Follow-up questions**: When the developer steers ("look at cache invalidation"), re-read the data filtered to that area and correlate with concurrent operations
+- **Compare before/after**: If multiple trace files exist, compare patterns across them to identify regressions
+- **Cross-extension correlation**: Operations from different extensions (visible in `resource.attributes["extension.name"]`) that share a traceId are part of the same logical flow
+
+### Watch Mode (proactive)
+When invoked with `--watch` or via `/loop`:
+- Track last-read line count
+- On each poll, read only new lines since last check
+- Only report when something actionable is found (errors, warnings, slow spans)
+- Stay silent when everything is healthy
+
+## Output Style
+
+- Lead with the finding (error, slowness, pattern)
+- Show relevant span/log data (trimmed, not raw dump)
+- Suggest likely cause based on operation name + attributes
+- Reference source code when operation names map to known files
+- Keep it actionable — what should the developer do next?

--- a/.claude/commands/adopt-pr.md
+++ b/.claude/commands/adopt-pr.md
@@ -1,0 +1,245 @@
+---
+description: Adopt community PR — replay commits onto main, review, create WI, push, open new PR, close original
+---
+
+# Adopt PR
+
+Adopt PR `$ARGUMENTS` (number/URL). Self-contained — no auto-build-wi handoff.
+
+## Inputs
+
+- `$ARGUMENTS`: PR# or URL
+- Repo: `forcedotcom/apex-language-support`
+
+## Phases
+
+Sequential. AskUserQuestion at marked steps.
+
+### 1. Fetch PR
+
+```
+gh pr view <PR#> --repo forcedotcom/apex-language-support \
+  --json number,title,body,author,baseRefName,headRefName,headRefOid,headRepositoryOwner,state,commits,files
+```
+
+Capture: `number, title, body, author.login, baseRefName, headRefName, headRefOid, headRepositoryOwner.login, commits[].oid, files`.
+
+- `state != OPEN` → abort, print state.
+- `baseRefName != main` → log: `user targeted <X>; retargeting to main`.
+
+### 2. Runner identity
+
+Per [gus-cli](.claude/skills/gus-cli/SKILL.md) "Runner identity". Need: `userId, ownerPrefix, githubLogin`.
+
+### 3. Worktree
+
+Slug: lowercase title, `[^a-z0-9]+ → -`, trim, slice 40.
+
+- Branch: `<ownerPrefix>/adopt-<PR#>-<slug>`
+- Path: `../vscode-auto-wt/<ownerPrefix>-adopt-<PR#>-<slug>`
+
+```
+git fetch origin main
+git worktree add -b <branch> <path> origin/main --no-track
+cd <path> && npm install
+```
+
+`npm install` wires husky.
+
+### 4. Cherry-pick
+
+```
+git fetch https://github.com/<headRepositoryOwner.login>/apex-language-support.git <headRefName>
+```
+
+Cherry-pick each `oid` oldest-first: `git cherry-pick <oid>`.
+
+Conflict:
+
+1. Apply [merge-conflicts](.claude/skills/merge-conflicts/SKILL.md) best-effort.
+2. Still conflicted → AskUserQuestion: "Cherry-pick `<oid>` conflicts in `<files>`. Resolve in `<path>`, say continue. Or abort."
+3. Continue → `git cherry-pick --continue`. Abort → `git cherry-pick --abort && git worktree remove <path> --force`. Stop.
+
+After each pick: `git log -1 --format='%an <%ae>'` matches user.
+
+### 5. Skill review fan-out
+
+Diff size: `git diff --shortstat origin/main...HEAD`.
+
+Skills:
+
+- Always: `typescript, concise, paths`
+- Diff > 20 lines: add `ls .claude/skills/` minus denylist `changelog feature-branch grill-me gus-cli merge-conflicts pr-draft release shipped-issues query-app-insights span-file-export`
+
+Parallel `Agent` calls — one per skill + thermo + effect-advocate. Single message.
+
+Per-skill prompt:
+> Skill `<name>` apply to diff in `<path>`? Read `.claude/skills/<name>/SKILL.md`. Examine `git diff origin/main...HEAD` from `<path>`. Return JSON `{applies: bool, findings: [{severity: critical|high|medium|low, file, line, suggestion}]}`. Apply but no findings → `findings: []`.
+
+Thermo: invoke [thermonuclear-code-quality-review](.claude/skills/thermonuclear-code-quality-review/SKILL.md) skill. Same JSON shape.
+
+Effect-advocate: `subagent_type: 'effect-advocate'`. JSON `{verdict, findings: [{severity: must|should|consider, file, line, suggestion, citation}]}`.
+
+### 6. Show + ask
+
+Group by severity. Print: severity, file:line, suggestion.
+
+AskUserQuestion: "Apply fixes? (1) all (2) critical+high only (3) skip (4) abort".
+
+### 7. Apply fixes
+
+Picked 1/2: spawn Agent in `<path>` to apply selected. Stack on top — never amend user commits.
+
+Commit subject: `fix: address review findings - W-XXXXXXXX` (W- placeholder, amend in step 9 after WI exists).
+
+Co-Authored-By trailer: current model name.
+
+### 8. Create WI
+
+Per [gus-cli](.claude/skills/gus-cli/SKILL.md).
+
+8a. Create:
+
+```
+sf data create record -s ADM_Work__c -o gus -v \
+  "Subject__c='Adopt #<PR#>: <escaped title>' \
+   Assignee__c='<runner.userId>' \
+   QA_Engineer__c='<runner.userId>' \
+   Status__c='In Progress' \
+   Story_Points__c=2 \
+   Product_Tag__c=a1aB000000005G3IAI \
+   Scrum_Team__c=a00B0000000w9xPIAQ \
+   RecordTypeId=0129000000006gDAAQ"
+```
+
+Capture `id`.
+
+8b. Get Name:
+
+```
+sf data query --query "SELECT Name FROM ADM_Work__c WHERE Id='<id>'" -o gus --result-format json
+```
+
+Capture `W-XXXXXXXX`.
+
+8c. Details via `--flags-dir` (`-v` + `--flags-dir` don't combine on create):
+
+```
+mkdir -p /tmp/adopt-pr-<PR#>
+```
+
+`/tmp/adopt-pr-<PR#>/values` (single line):
+
+```
+Details__c='<p><strong>Adopted from:</strong> <a href="https://github.com/forcedotcom/apex-language-support/pull/<PR#>">#<PR#></a> by @<author.login></p><p><strong>Original body:</strong></p><blockquote><ESCAPED_BODY></blockquote>'
+```
+
+Escape body: `& → &amp;`, `< → &lt;`, `> → &gt;`, `' → &apos;`.
+
+```
+sf data update record -s ADM_Work__c -i <id> -o gus --flags-dir /tmp/adopt-pr-<PR#>
+```
+
+### 9. Amend fix commit (if step 7 ran)
+
+Replace placeholder W-XXXXXXXX in fix commit subject with actual `Name`. `git commit --amend` only on the fix commit (most recent — never user commits).
+
+### 10. Push
+
+```
+cd <path> && git push -u origin <branch>
+```
+
+Hook fail → diagnose, re-commit, retry. Never `--no-verify`.
+
+### 11. Open new PR
+
+Per [pr-draft](.claude/skills/pr-draft/SKILL.md) title format.
+
+- Type: infer from files (feat/fix/docs/...)
+- Scope: optional, from path (e.g. `apex-ls` for `packages/apex-ls`)
+- Desc: from original title, conventional-commit shape
+- Trail: ` - W-XXXXXXXX`
+
+Body file `/tmp/adopt-pr-<PR#>/body`:
+
+```
+<original body verbatim>
+
+---
+
+**Adopted from #<PR#>** by @<author.login> — commits preserved with author credit. Replayed onto main for internal CI / AI review.
+
+### Reviewer notes
+
+<remaining findings grouped by severity, or "none">
+
+### What issues does this PR fix or reference?
+
+@W-XXXXXXXX@
+
+Co-authored-by: <author.name> <<author.email>>
+```
+
+Email: `gh api repos/forcedotcom/apex-language-support/commits/<headRefOid> --jq '.commit.author.email'`.
+
+```
+gh pr create --base main --head <branch> --title "<title>" --body-file /tmp/adopt-pr-<PR#>/body --repo forcedotcom/apex-language-support
+```
+
+Capture URL + number.
+
+### 12. Update WI with new PR link
+
+1. Query existing `Details__c`.
+2. Append: `<p><strong>Adopt PR:</strong> <a href="<newPrUrl>">#<newPrNumber></a></p>`
+3. Overwrite `/tmp/adopt-pr-<PR#>/values`.
+4. `sf data update record -s ADM_Work__c -i <id> -o gus --flags-dir /tmp/adopt-pr-<PR#>`
+5. Re-query, verify "Adopted from" + "Adopt PR" both present.
+
+### 13. Close original
+
+Comment first:
+
+```
+gh pr comment <PR#> --repo forcedotcom/apex-language-support --body "$(cat <<'EOF'
+Thanks for the contribution! Adopting as #<NEW_PR> so our internal CI + AI review pipeline can run (forks have limited access).
+
+Your commits preserved with you as Author. Follow #<NEW_PR> for status — we'll merge from there.
+
+GUS WI: W-XXXXXXXX
+EOF
+)"
+```
+
+Then:
+
+```
+gh pr close <PR#> --repo forcedotcom/apex-language-support
+```
+
+### 14. Summary
+
+Print:
+- New PR URL
+- WI Name
+- Branch + worktree path
+- Findings: applied / remaining counts
+- Original closed: y/n
+
+Worktree stays. Runner removes manually.
+
+## Constraints
+
+- Never `--no-verify`
+- Never amend user commits (only own fix commit)
+- Never tag `[ai-auto]` (triggers auto-build-wi)
+- Verify Author preserved post-cherry-pick
+- AskUserQuestion = sole pause mechanism
+
+## Failure modes
+
+- Conflict unresolvable → pause or abort clean
+- Pre-push fails → root-cause, no bypass
+- WI create fails → no rollback (no PR yet), stop
+- Original PR comment/close fails → new PR live; surface, runner handles

--- a/.claude/commands/analyze-e2e.md
+++ b/.claude/commands/analyze-e2e.md
@@ -1,0 +1,13 @@
+---
+description: Monitor running e2e playwright tests for current branch, download artifacts on failure, provide analysis
+---
+
+**Read first:**
+
+- `.claude/skills/playwright-e2e/references/analyze-e2e.md` - Main workflow
+- `.claude/skills/playwright-e2e/references/iterating-playwright-tests.md` (lines 34-37) - "Things to ignore"
+- `.claude/skills/playwright-e2e/references/coding-playwright-tests.md` - Test patterns
+
+Monitor running e2e playwright tests for current branch, download artifacts on failure, provide analysis tools.
+
+Use the agent `@.claude/agents/playwright-e2e-monitor.md`

--- a/.claude/commands/debug-traces.md
+++ b/.claude/commands/debug-traces.md
@@ -1,0 +1,9 @@
+---
+description: Analyze recent OTEL traces and logs for errors, slow operations, and anomalies. Reads from ~/.sf/vscode-spans/.
+---
+
+Analyze recent traces and logs captured from the running extensions.
+
+Use the agent `@.claude/agents/trace-debugger.md`
+
+Read skill `span-file-export` for data format and location reference.

--- a/.claude/commands/gha-rerun.md
+++ b/.claude/commands/gha-rerun.md
@@ -1,0 +1,5 @@
+---
+description: Launch/check the gha-rerun CI babysitter daemon
+---
+
+Use the gha-rerun subagent to launch or check status of the daemon.

--- a/.claude/commands/mergeConflicts.md
+++ b/.claude/commands/mergeConflicts.md
@@ -1,0 +1,5 @@
+---
+description: Resolve merge conflicts following project conventions for package.json, lockfile, CHANGELOG, and SHA256
+---
+
+Use the `merge-conflicts` skill to resolve all merge conflicts in the working tree.

--- a/.claude/commands/shipped-issues.md
+++ b/.claude/commands/shipped-issues.md
@@ -1,0 +1,7 @@
+---
+description: Find and close GitHub issues whose linked GUS work item is closed AND whose issue # appears in CHANGELOG.md
+---
+
+Run the workflow in `.claude/skills/shipped-issues/SKILL.md`.
+
+Read it first, then execute the steps. Present the candidate table to the user and wait for confirmation before closing any issues.

--- a/.claude/skills-sync.json
+++ b/.claude/skills-sync.json
@@ -1,0 +1,62 @@
+{
+  "$comment": "Config for the claude-skills-sync GitHub Action (.github/workflows/claude-skills-sync.yml). Lists the upstream repo and the skills/agents/commands that ALS keeps in sync with the salesforcedx-vscode monorepo. The sync job fetches each allowlisted path from `upstream`, diffs it against the local copy, and opens a drift PR when they diverge. Items NOT listed here are owned by ALS and never auto-synced. Remove an item from `allowlist` to stop tracking it; add one to start.",
+  "upstream": {
+    "repo": "forcedotcom/salesforcedx-vscode",
+    "ref": "develop",
+    "claudeDir": ".claude"
+  },
+  "allowlist": {
+    "skills": [
+      "lsp-custom-requests",
+      "grill-me",
+      "merge-conflicts",
+      "concise",
+      "paths",
+      "ts1261-filename-casing",
+      "wireit"
+    ],
+    "agents": [
+      "plan-adversary.md",
+      "playwright-e2e-monitor.md"
+    ],
+    "commands": [
+      "debug-traces.md",
+      "analyze-e2e.md"
+    ]
+  },
+  "ownedByAls": {
+    "$comment": "These were ported once then adapted to ALS-specific facts (repo name, package names, Playwright-only e2e, main branch). They intentionally diverge from upstream and are NOT auto-synced. Listed for documentation only.",
+    "skills": [
+      "effect-best-practices",
+      "feature-branch",
+      "gus-cli",
+      "packageJson",
+      "playwright-e2e",
+      "pr-draft",
+      "services-extension-consumption",
+      "span-file-export",
+      "ts4023-effect-errors",
+      "typescript",
+      "verification",
+      "shipped-issues"
+    ],
+    "agents": [
+      "effect-advocate.md",
+      "trace-debugger.md",
+      "e2e-advocate.md",
+      "gha-rerun.md",
+      "apex-language-rules.md",
+      "doc-maintenance.md",
+      "verifier.md"
+    ],
+    "commands": [
+      "adopt-pr.md",
+      "gha-rerun.md",
+      "mergeConflicts.md",
+      "shipped-issues.md"
+    ],
+    "workflows": [
+      "auto-build-wi.js"
+    ]
+  }
+}

--- a/.claude/skills/effect-best-practices/SKILL.md
+++ b/.claude/skills/effect-best-practices/SKILL.md
@@ -1,12 +1,27 @@
 ---
 name: effect-best-practices
 description: Enforces Effect-TS patterns for services, errors, layers, and atoms. Use when writing code with Effect.Service, Schema.TaggedError, Layer composition, or effect-atom React components.
-version: 1.0.0
+version: 1.2.0
 ---
 
 # Effect-TS Best Practices
 
 This skill enforces opinionated, consistent patterns for Effect-TS codebases. These patterns optimize for type safety, testability, observability, and maintainability.
+
+For diff/plan review against these patterns, invoke the `effect-advocate` subagent (`.claude/agents/effect-advocate.md`).
+
+## Effect LS diagnostics (agent usage)
+
+Cursor's `read_lints` does not surface Effect Language Server diagnostics. Use the CLI:
+
+```bash
+npx effect-language-service diagnostics --file <path>
+# or whole project:
+npx effect-language-service diagnostics --project tsconfig.json
+```
+
+- Run when editing Effect code; fix reported issues (e.g. `unnecessaryFailYieldableError` → yield error directly)
+- `effect-language-service quickfixes` shows proposed code changes
 
 ## Quick Reference: Critical Rules
 
@@ -16,9 +31,11 @@ This skill enforces opinionated, consistent patterns for Effect-TS codebases. Th
 | Dependencies | `dependencies: [Dep.Default]` in service | Manual `Layer.provide` at usage sites |
 | Errors | `Schema.TaggedError` with `message` field | Plain classes or generic Error |
 | Error Specificity | `UserNotFoundError`, `SessionExpiredError` | Generic `NotFoundError`, `BadRequestError` |
-| Error Handling | `catchTag`/`catchTags` | `catchAll` or `mapError` |
+| Error Handling | `catchTag`/`catchTags`; catch only when needed | `catchAll`; swallowing; catching "just in case" |
 | IDs | `Schema.UUID.pipe(Schema.brand("@App/EntityId"))` | Plain `string` for entity IDs |
-| Functions | `Effect.fn("Service.method")` | Anonymous generators |
+| Functions | `Effect.fn` over `Effect.gen`; `.gen` only for shared pipes | Anonymous generators; `.gen` for business logic |
+| Params vs deps | Params = runtime data; dependencies = yield from context | Passing Ref/PubSub/service as params |
+| Naming | `FooCommand` for commands, domain names for helpers | `FooEffect` suffix (redundant; TS/Effect.fn already convey type) |
 | Logging | `Effect.log` with structured data | `console.log` |
 | Config | `Config.*` with validation | `process.env` directly (except build-time vars like `ESBUILD_*`) |
 | Options | `Option.match` with both cases | `Option.getOrThrow` |
@@ -76,6 +93,28 @@ const MainLive = Layer.mergeAll(UserService.Default, OtherService.Default)
 - Infrastructure with runtime injection (Cloudflare KV, worker bindings)
 - Factory patterns where resources are provided externally
 
+### Params vs Dependencies
+
+- **Params** = runtime data per call (IDs, user input, per-invocation config)
+- **Dependencies** = shared infrastructure (Ref, PubSub, SubscriptionRef, services) — provide via layer, **yield inside** the effect
+- Build Ref/PubSub/etc in the layer (e.g. `buildAllServicesLayer`); consumers yield them, don't receive as params
+
+```typescript
+// WRONG - passing shared infra as params
+const createStatusBar = (pubsub: PubSub.PubSub<void>, stateRef: SubscriptionRef.SubscriptionRef<State>) =>
+  Effect.gen(...)
+// Caller must create and pass; wiring scattered at call sites
+
+// CORRECT - yield inside, build in layer
+const PubSubTag = Context.GenericTag<PubSub.PubSub<void>>("PubSub")
+const createStatusBar = Effect.gen(function* () {
+  const pubsub = yield* PubSubTag
+  const stateRef = yield* StateRefTag
+  // ...
+})
+// Layer: Layer.effect(PubSubTag, PubSub.sliding<void>(1))
+```
+
 See `references/service-patterns.md` for detailed patterns.
 
 ## Error Definition Pattern
@@ -126,6 +165,15 @@ yield* effect.pipe(
     }),
 )
 ```
+
+### When to Catch (and When Not To)
+
+**Most errors surface to the user** (message/toast at runtime). Only catch when:
+
+- **Genuinely ignore** – accept failure and continue (e.g. optional pre-create)
+- **Better message** – default vague; map to clearer domain error
+
+Catch sparingly. No `catchAll` or "swallow to be safe." Use `catchTag`/`catchTags`; log or fail with improved error.
 
 ### Prefer Explicit Over Generic Errors
 
@@ -216,9 +264,11 @@ export type CreateUserInput = Schema.Schema.Type<typeof CreateUserInput>
 
 See `references/schema-patterns.md` for transforms and advanced patterns.
 
-## Function Pattern with Effect.fn
+## Function Pattern: Prefer Effect.fn over Effect.gen
 
-**Always use `Effect.fn`** for service methods. This provides automatic tracing with proper span names:
+**Prefer `Effect.fn`** for effectful code. Provides automatic tracing with proper span names. Span name is required.
+
+**Use `Effect.gen` only when** you need a shared effect with common `.pipe` attached so multiple consumers don't each pipe the same things — e.g. provided dependencies, common error handlers, retries. (Less common with Runtimes.) Service definition bodies are a valid use (shared wiring).
 
 ```typescript
 // CORRECT - Effect.fn with descriptive name
@@ -237,6 +287,16 @@ const transfer = Effect.fn("AccountService.transfer")(
         // ...
     }
 )
+
+// WRONG - params on wrapper arrow, generator has none (closure capture)
+const findByIdBad = (id: UserId) =>
+    Effect.fn("UserService.findById")(function* () {
+        yield* repo.findById(id) // id from closure
+    })
+
+// Naming: Don't append Effect. For commands use FooCommand; for helpers/lifecycle use domain names.
+// WRONG: logGetEffect, executeAnonymousDocumentEffect, activateEffect
+// CORRECT: logGetCommand, executeAnonymousCommand, executeAnonymous (helper), activation (lifecycle)
 ```
 
 ## Layer Composition
@@ -369,6 +429,28 @@ See `references/effect-atom-patterns.md` for complete patterns including familie
 For RPC contracts and cluster workflows, see:
 - `references/rpc-cluster-patterns.md` - RpcGroup, Workflow.make, Activity patterns
 
+## SubscriptionRef
+
+`SubscriptionRef<A>` is a mutable ref whose `.changes` stream **always emits the current value as element 0**, then all future mutations.
+
+Implemented as (from `effect/src/internal/subscriptionRef.ts`):
+```ts
+stream.concat(stream.make(currentValue), stream.fromPubSub(pubsub))
+```
+The `Ref.get` + pubsub subscription happen atomically under a semaphore — no events are missed.
+
+```typescript
+// WRONG — prepended get is always redundant
+Stream.concat(Stream.fromEffect(SubscriptionRef.get(ref)), ref.changes)
+Stream.concat(Stream.make(yield* SubscriptionRef.get(ref)), ref.changes)
+Stream.merge(Stream.fromEffect(SubscriptionRef.get(ref)), ref.changes)
+
+// CORRECT — .changes already provides the snapshot
+ref.changes.pipe(...)
+```
+
+To skip the initial snapshot (e.g. avoid a spurious refresh on activation), use `Stream.drop(1)`.
+
 ## Anti-Patterns (Forbidden)
 
 These patterns are **never acceptable**:
@@ -384,6 +466,9 @@ yield* Effect.gen(function* () {
 
 // FORBIDDEN - catchAll losing type info
 yield* effect.pipe(Effect.catchAll(() => Effect.fail(new GenericError())))
+
+// FORBIDDEN - swallowing errors (most errors surface to user; only catch when ignoring intentionally or providing better message)
+yield* effect.pipe(Effect.catchAll(() => Effect.void))
 
 // FORBIDDEN - console.log
 console.log("debug") // Use Effect.log

--- a/.claude/skills/effect-best-practices/references/schema-patterns.md
+++ b/.claude/skills/effect-best-practices/references/schema-patterns.md
@@ -337,6 +337,18 @@ export const Category: Schema.Schema<Category> = Schema.Struct({
 })
 ```
 
+## Schema.is Type Guard
+
+- `Schema.is(schema)` → `(u: unknown) => u is A` — match without decode/allocate
+- Prefer over `Set.has` etc — schema = single source of truth
+
+```typescript
+const isUserRole = Schema.is(UserRole)
+if (isUserRole(input)) {
+  // input: "admin" | "member" | "viewer"
+}
+```
+
 ## Decoding and Encoding
 
 ```typescript
@@ -350,4 +362,17 @@ const user = Schema.decodeUnknownSync(User)(rawData)
 // Encode - for serialization
 const encodeUser = Schema.encode(User)
 const encoded = yield* encodeUser(user) // Effect<UserEncoded, ParseError>
+```
+
+## JSON strings: Schema.parseJson
+
+Use `Schema.parseJson(schema)` instead of `JSON.parse` + manual decode. Handles invalid JSON (returns `Left`) and schema validation in one step.
+
+```typescript
+// JSON string → validated A. No try/catch — parse errors become Left
+const decoded = Schema.decodeUnknownEither(Schema.parseJson(MySchema))(jsonStr)
+const value = Either.getOrElse(decoded, () => undefined)
+
+// Sync decode (throws on invalid JSON or schema mismatch)
+const config = Schema.decodeUnknownSync(Schema.parseJson(ConfigSchema))(jsonStr)
 ```

--- a/.claude/skills/feature-branch/SKILL.md
+++ b/.claude/skills/feature-branch/SKILL.md
@@ -1,35 +1,37 @@
 ---
 name: feature-branch
-description: Create feature branches for all work. Use when creating branches, checking out, or pushing. Prevents accidental push to develop.
+description: Create feature branches for all work. Use when creating branches, checking out, or pushing. Prevents accidental push to main.
 ---
 
 # Feature Branch
 
-All work must be on feature branches. Never commit directly to develop or main.
+All work must be on feature branches. Never commit directly to `main`.
 
 ## Do
 
+Branch format: `<type>/W-XXXXX-short-description` (e.g. `feature/W-23006798-implementor-references`, `fix/...`, `chore/...`). Include a short description after the work item number.
+
 ```bash
-git fetch origin develop
-git checkout develop
+git fetch origin main
+git checkout main
 git pull
-git checkout -b feature/W-XXXXX
+git checkout -b feature/W-XXXXX-short-description
 # ... work, commit ...
-git push -u origin feature/W-XXXXX
+git push -u origin feature/W-XXXXX-short-description
 ```
 
 Or, branch from remote without tracking it:
 
 ```bash
-git fetch origin develop
-git checkout -b feature/W-XXXXX origin/develop --no-track
+git fetch origin main
+git checkout -b feature/W-XXXXX-short-description origin/main --no-track
 ```
 
 ## Don't
 
-**Never** `git checkout -b feature/W-XXXXX origin/develop` without `--no-track`.
+**Never** `git checkout -b feature/W-XXXXX origin/main` without `--no-track`.
 
-That sets the new branch to track `origin/develop`. A bare `git push` would then push to develop instead of creating a remote feature branch.
+That sets the new branch to track `origin/main`. A bare `git push` would then push to `main` instead of creating a remote feature branch.
 
 ## Summary
 

--- a/.claude/skills/grill-me/ADR-FORMAT.md
+++ b/.claude/skills/grill-me/ADR-FORMAT.md
@@ -1,0 +1,43 @@
+# ADR Format
+
+Live in `docs/adr/`. Sequential: `0001-slug.md`, `0002-slug.md`. Create dir lazily on first ADR.
+
+## Template
+
+```md
+# {Short title}
+
+{1-3 sentences: context, decision, why.}
+```
+
+Single paragraph fine. Value = recording *that* a decision was made and *why* — not filling sections.
+
+## Optional sections (only when earned)
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — when revisited
+- **Considered Options** — rejected alternatives matter
+- **Consequences** — downstream effects non-obvious
+
+## Numbering
+
+Highest existing in `docs/adr/` + 1.
+
+## When to offer
+
+All three must hold:
+
+1. Hard to reverse — meaningful cost to change later
+2. Surprising without context — reader wonders "why this way?"
+3. Real trade-off — genuine alternatives existed
+
+Easy to reverse → skip. Not surprising → nobody wonders. No alternative → nothing to record.
+
+### Qualifies
+
+- Architectural shape. "Monorepo." "Event-sourced write, Postgres read."
+- Cross-context integration. "Ordering ↔ Billing via domain events, not sync HTTP."
+- Tech with lock-in. DB, message bus, auth, deployment target. Not every library — quarter-to-swap ones.
+- Boundaries/scope. "Customer data owned by Customer context; others reference by ID." Explicit nos as valuable as yeses.
+- Deliberate deviations. "Manual SQL, not ORM, because X." Stops next engineer "fixing" deliberate code.
+- Constraints invisible in code. "No AWS — compliance." "<200ms — partner SLA."
+- Non-obvious rejected alternatives. Considered GraphQL, picked REST for subtle reasons → record, else re-suggested in 6 months.

--- a/.claude/skills/grill-me/CONTEXT-FORMAT.md
+++ b/.claude/skills/grill-me/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{1-2 sentences: what, why.}
+
+## Language
+
+**Order**:
+{1-2 sentence definition}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+Request for payment sent after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+Person/org that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- Opinionated. Synonyms → pick one, others under `_Avoid_`.
+- Tight: 1-2 sentences. What it IS, not what it does.
+- Project-specific terms only. General programming concepts (timeouts, error types, utility patterns) don't belong. Test: unique to this context, or general?
+- Group under subheadings when clusters emerge. Single cluster → flat fine.
+
+## Single vs multi-context
+
+Single → one root `CONTEXT.md`. Multi → root `CONTEXT-MAP.md` lists contexts + relationships:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./packages/ordering/CONTEXT.md) — receives/tracks customer orders
+- [Billing](./packages/billing/CONTEXT.md) — invoices, payments
+- [AI tooling](./.claude/CONTEXT.md) — skills, workflows, commands
+- [CI](./.github/CONTEXT.md) — GitHub Actions
+
+## Relationships
+
+- **Ordering → Fulfillment**: `OrderPlaced` events trigger picking
+- **AI tooling → Ordering**: `auto-build-wi.js` opens PRs against ordering
+```
+
+Contexts go wherever coherent vocabulary lives — packages, plus `.claude/`, `.github/`. Narrowest scope owning the term.
+
+Inference:
+
+- `CONTEXT-MAP.md` exists → read it
+- Only root `CONTEXT.md` → single context
+- Neither → create root `CONTEXT.md` lazily on first term
+
+Multi-context, unclear → ask.

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: grill-me
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
+---
+
+## How to grill
+
+- Interview until shared understanding. Walk each branch; resolve deps one at a time. Recommend an answer per question.
+- One question at a time. Wait for feedback.
+- Answerable from code → read it, don't ask.
+
+## Domain awareness
+
+Existing docs first. Root `CONTEXT-MAP.md` lists contexts.
+
+Single-context:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+└── src/
+```
+
+Multi-context:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                ← system-wide
+├── .claude/CONTEXT.md       ← AI tooling
+├── .github/CONTEXT.md       ← CI YAML
+└── packages/
+    ├── ordering/CONTEXT.md
+    └── billing/CONTEXT.md
+```
+
+Contexts go wherever a coherent vocabulary lives — packages, plus non-source dirs (`.claude/`, `.github/`). Narrowest scope owning the term.
+
+Create lazily. First new context in a single-context repo → also create `CONTEXT-MAP.md`; move existing root `CONTEXT.md` to its proper scope if it doesn't belong at root.
+
+## During the session
+
+- **Glossary conflict**: "glossary defines 'cancellation' as X, you mean Y — which?"
+- **Fuzzy term**: propose canonical. "'account' — Customer or User?"
+- **Edge cases**: probe boundaries.
+- **Cross-ref code**: verify claims. "code cancels whole Orders, you said partial — which?"
+- **Update `CONTEXT.md` inline** as terms resolve. Don't batch. Format: [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md). Glossary only — no specs/scratch/decisions.
+- **ADRs sparingly**. Offer iff all three: hard to reverse, surprising without context, real trade-off. Format: [ADR-FORMAT.md](./ADR-FORMAT.md).

--- a/.claude/skills/gus-cli/SKILL.md
+++ b/.claude/skills/gus-cli/SKILL.md
@@ -24,12 +24,21 @@ Interact with Gus (Salesforce Agile Accelerator org) via sf CLI. Requires alias 
 2. If missing: instruct user `sf org login web -a gus`
 3. All commands use `-o gus`
 
-## User ID
+## Runner identity
 
-- From step 1: gus entry `value` = username
-- `sf data query --query "SELECT Id FROM User WHERE Username = '<username>' LIMIT 1" -o gus --result-format json`
-- User Id = `result.records[0].Id`
-- **Reuse from earlier in conversation** if already looked up this session; don't re-query
+Cache: `$HOME/.claude/runner-identity.json` — `{userId, username, ownerPrefix, slackId, githubLogin}`.
+
+1. `sf alias list --json` → entry `/^gus$/i`. Missing → `sf org login web -a gus`. Value = `currentUsername`.
+2. Cache hit (file exists, all 5 fields, `cached.username === currentUsername`) → use it.
+3. Miss → resolve:
+   - `sf data query --query "SELECT Id FROM User WHERE Username = '<currentUsername>' LIMIT 1" -o gus --result-format json` → `userId`
+   - Match `currentUsername` to ## Team members row → `githubLogin`, `slackId`. `ownerPrefix` = initials lowercase (`Kyle Walker` → `kw`; one-word → first 2 chars).
+   - Not in table → caller's error.
+   - `mkdir -p $HOME/.claude && write JSON`.
+
+Invalidate: alias change auto-detects. Manual: `rm $HOME/.claude/runner-identity.json`.
+
+Same session: reuse conversation value; don't re-read.
 
 ## Constants
 
@@ -38,7 +47,8 @@ Interact with Gus (Salesforce Agile Accelerator org) via sf CLI. Requires alias 
 | Team ID                 | `a00B0000000w9xPIAQ` |
 | Product Tag             | `a1aB000000005G3IAI` |
 | User Story RecordTypeId | `0129000000006gDAAQ` |
-| Bug RecordTypeId        | `012T00000004MUHIA2` |
+
+**Always use User Story RecordTypeId.** Never create Bug records. If user describes a bug/repro, still create it as a User Story.
 
 Objects: `ADM_Work__c`, `ADM_Epic__c` (not ADM_Theme\_\_c).
 
@@ -46,16 +56,16 @@ Objects: `ADM_Work__c`, `ADM_Epic__c` (not ADM_Theme\_\_c).
 
 **Default when unassigned:** Platform Dev Tools Scrum Team `005B0000000GIODIA4` – use when work isn't assigned to a person yet.
 
-| Name | Id | GitHub login |
-|---|---|---|
-| Cristina Cañizales | `005EE000008cgrGYAQ` | `CristiCanizales` |
-| Daphne Yang | `005EE000005d0jdYAA` | `daphne-sfdc` |
-| Jonny Hork | `005B0000004pYWjIAM` | `jonnyhork` |
-| Kyle Walker | `005EE0000010oCLYAY` | `kylewalke` |
-| Madhur Shrivastava | `005EE00000VZK5FYAX` | `madhur310` |
-| Peter Hale | `005B0000000GFvWIAW` | `peternhale` |
-| Shane McLaughlin | `005B00000024wGBIAY` | `mshanemc` |
-| Sonal Budhiraja | `005B0000005ccPnIAI` | `sbudhirajadoc` |
+| Name               | Id                   | GitHub login      | Slack ID      |
+| ------------------ | -------------------- | ----------------- | ------------- |
+| Cristina Cañizales | `005EE000008cgrGYAQ` | `CristiCanizales` | `U040DRU0ADA` |
+| Daphne Yang        | `005EE000005d0jdYAA` | `daphne-sfdc`     | `U03CKVATVCY` |
+| Jonny Hork         | `005B0000004pYWjIAM` | `jonnyhork`       | `WFGT1L8HF`   |
+| Kyle Walker        | `005EE0000010oCLYAY` | `kylewalke`       | `U02GCUGEAUU` |
+| Madhur Shrivastava | `005EE00000VZK5FYAX` | `madhur310`       | `U0852LWKWSW` |
+| Peter Hale         | `005B0000000GFvWIAW` | `peternhale`      | `WAR9BDB8T`   |
+| Shane McLaughlin   | `005B00000024wGBIAY` | `mshanemc`        | `WB4TF6RFY`   |
+| Sonal Budhiraja    | `005B0000005ccPnIAI` | `sbudhirajadoc`   |               |
 
 ## Work items (ADM_Work\_\_c)
 
@@ -75,6 +85,8 @@ Objects: `ADM_Work__c`, `ADM_Epic__c` (not ADM_Theme\_\_c).
 Closed statuses: see ## Status\_\_c values. Use `LIMIT 50` (or 100) when querying team or epic work.
 
 **Create:** Always set `Story_Points__c=2`, `Product_Tag__c=a1aB000000005G3IAI`, `RecordTypeId`. Include `Subject__c`, `Assignee__c`, `Scrum_Team__c=a00B0000000w9xPIAQ`, `Epic__c` (optional), `QA_Engineer__c` (optional), `Details__c` (optional). Leave `Sprint__c` blank; never modify it. **Details\_\_c:** write concisely—fragments/bullets, minimal words, no repetition (see .claude/skills/concise/SKILL.md).
+
+**`-v` + `--flags-dir` don't combine on create:** `-v` takes precedence; flags-dir values are dropped. Workaround: create without Details, then update with `--flags-dir` only.
 
 **Details\_\_c formatting (readable WI body):** Details__c is a Rich Text Area (extraTypeInfo: richtextarea)—use HTML, not markdown. The `-v` flag parses space-separated key=value; use `--flags-dir` with a `values` file ([ref](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_flag_values_in_files.htm)):
 
@@ -134,16 +146,24 @@ Use to pick the right Epic\_\_c when creating work. Query epics first; match by 
 
 When unsure which epic: ask the user.
 
+## `[ai-auto]` tag
+
+`[ai-auto]` in `Subject__c` or `Details__c` opts a WI into the [auto-build-wi workflow](../../workflows/auto-build-wi.js) (claim → plan → build → review → draft PR). See [workflows/README.md](../../workflows/README.md).
+
+- Add only on explicit user request; prefer `Subject__c`
+- Skip for WIs needing design/coordination
+- Query: `(Subject__c LIKE '%[ai-auto]%' OR Details__c LIKE '%[ai-auto]%')`
+
 ## Compound workflows
 
-**Create a bug from this PR**
+**Create a WI from this PR**
 
 1. Get PR context: title, body/description, URL (from git/GitHub if available)
 2. Resolve User Id (reuse from conversation if known)
-3. Pick epic: IDEx - Trust (`a3QEE0000023FPZ2A2`) for bugs unless PR/context indicates otherwise
+3. Pick epic: IDEx - Trust (`a3QEE0000023FPZ2A2`) for bug-like issues unless PR/context indicates otherwise
 4. Subject\_\_c: concise from PR title
 5. Details\_\_c: PR link + key bullets; see .claude/skills/concise/SKILL.md
-6. RecordTypeId: `012T00000004MUHIA2` (Bug)
+6. RecordTypeId: `0129000000006gDAAQ` (User Story — always, even for bug-like issues)
 7. Show draft, ask "Create this work item?" — run `sf data create record` only after yes
 8. After create: provide WI link (see **After create** above)
 

--- a/.claude/skills/lsp-custom-requests/SKILL.md
+++ b/.claude/skills/lsp-custom-requests/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: lsp-custom-requests
+description: Serialize URIs correctly across LSP custom requests. Use when defining custom LSP requests/notifications with URI params, sending a `URI` over `Connection.sendRequest`, or debugging `[object Object]` / `EntryNotFound` / `workspace/stat`/`readFile`/`readDirectory` failures.
+---
+
+# LSP Custom Requests — URI Wire Format
+
+## Why it breaks
+
+- `Connection.sendRequest(method, params)` runs `JSON.stringify(params)`.
+- `vscode-uri` `Uri.toJSON()` returns `UriComponents` (plain data). See [microsoft/vscode-uri src/uri.ts](https://github.com/microsoft/vscode-uri/blob/main/src/uri.ts).
+- Receiver gets a plain object — no prototype, no `toString`/`fsPath`.
+- `uri.toString()` → `"[object Object]"` → `fs.stat`/`readFile` fails with `EntryNotFound`.
+
+## Rules
+
+- Never call `.toString()` / `.fsPath` on a URI received over the wire without rehydrating first.
+- Type URI params as `UriComponents` (derived); revive on receive.
+
+## Pattern — UriComponents + revive
+
+Params type derived from `URI.toJSON`:
+
+```ts
+import type { URI } from 'vscode-uri';
+type UriComponents = ReturnType<URI['toJSON']>;
+type MyParams = { uri: UriComponents };
+
+const params: MyParams = { uri: URI.parse(fileUri) };
+connection.sendRequest('my/request', params);
+
+const handler = (params: MyParams) => {
+  const uri = URI.revive(params.uri);
+};
+```
+
+Notes:
+
+- `vscode-uri`'s package entry does not re-export `UriComponents`; derive via `ReturnType<URI['toJSON']>`.
+- `URI.revive` is the exact inverse of `toJSON` — restores `_formatted` / `_fsPath` caches too.
+
+## Don't
+
+- `uri: URI` on a wire type and use `.toString()` / `.fsPath` on receive — this is the failure mode.
+- Pass deserialized params straight to `vscode.workspace.fs.*` — those APIs expect a real `URI` instance.
+
+## When `uri: URI` in params looks fine but isn't
+
+Compiles cleanly (URI on both sides). Runtime receiver sees a plain `UriComponents`. Check the handler log — `uri=[object Object]` confirms.

--- a/.claude/skills/merge-conflicts/SKILL.md
+++ b/.claude/skills/merge-conflicts/SKILL.md
@@ -1,0 +1,22 @@
+---
+description: Resolve merge conflicts in package.json, package-lock.json, CHANGELOG.md, and SHA256.md following project conventions
+trigger: Use when resolving merge conflicts in version-controlled files, particularly during git merge, rebase, or pull operations
+---
+
+# Merge Conflict Resolution
+
+## package.json
+
+Use **higher value** for conflicts on the `version` property.
+
+Use **higher version** for any conflicts in `dependencies` or `devDependencies`.
+
+## package-lock.json
+
+After all package.json conflicts are fixed, run `npm install` to fix the conflicts in the lockfile. **Never edit the lockfile directly.**
+
+## Misc other files
+
+For these files, **always take the incoming changes**:
+- CHANGELOG.md
+- SHA256.md

--- a/.claude/skills/packageJson/SKILL.md
+++ b/.claude/skills/packageJson/SKILL.md
@@ -6,6 +6,7 @@ description: Guidelines for package.json files in packages
 ## Name
 
 any package that's not an npm package should be named @salesforce/foo (whether it actually published to npm or not)
+the package that publishes the vscode extension is named apex-language-server-extension
 don't rename packages, but do tell the user when stuff doesn't match the rules
 
 ## types

--- a/.claude/skills/playwright-e2e/SKILL.md
+++ b/.claude/skills/playwright-e2e/SKILL.md
@@ -19,6 +19,24 @@ Guidelines for writing and iterating on Playwright tests for VS Code extensions.
 
 Shared code (helpers, locators, configuration) for tests lives in `e2e-tests/shared/`.
 
+## Span files (when debugging traces)
+
+Available local + CI/GHA.
+
+- Output: `~/.sf/vscode-spans/` — `web-*.jsonl` (test:e2e:web), `node-*.jsonl` (test:e2e:desktop)
+- Auto-enabled (no manual enable needed)
+- CI runs: copied into `test-results/spans/` artifacts (see workflow upload/download in `references/analyze-e2e.md`)
+- Latest: `ls -lt ~/.sf/vscode-spans/`
+- Clear before run for fresh output: `rm -rf ~/.sf/vscode-spans/`
+- Format: JSONL; parse each line with `JSON.parse`
+- Fields: `name`, `traceId`, `spanId`, `parentSpanId`, `durationMs`, `status`, `startTime`, `attributes`
+
+See `.claude/skills/span-file-export/SKILL.md` for enable/OTLP vs file.
+
+## Running tests (AI behavior)
+
+When running Playwright tests (`npm run test:e2e:web`, `npm run test:e2e:desktop`, etc.), never block >30s. Use `run_in_background: true` so tests run while the AI continues. Check terminal output or the output file later.
+
 ## References
 
 - https://playwright.dev/docs - Playwright docs

--- a/.claude/skills/playwright-e2e/references/analyze-e2e.md
+++ b/.claude/skills/playwright-e2e/references/analyze-e2e.md
@@ -9,6 +9,8 @@ Monitor running e2e playwright tests for current branch, download artifacts on f
 
 ## Workflow
 
+**Delegate to** `.claude/agents/playwright-e2e-monitor.md` subagent when available. If user provides a run URL (`.../actions/runs/12345`), include run-id `12345` in the subagent prompt. The steps below are the fallback / manual procedure.
+
 1. **Get Current Branch**
    - `git branch --show-current`
    - Detached HEAD/no branch → error, stop
@@ -43,6 +45,7 @@ Monitor running e2e playwright tests for current branch, download artifacts on f
 5. **Offer Analysis** (if artifacts downloaded)
    - Search HTML reports: `playwright-report/index.html` or `**/playwright-report/index.html`
    - Search test results: `test-results/` directory
+   - Search span traces: `**/spans/*.jsonl`
    - Reference: `.claude/skills/playwright-e2e/references/coding-playwright-tests.md`, `.claude/skills/playwright-e2e/references/iterating-playwright-tests.md`
    - Offer: open HTML report, show test results, open workflow (`gh run view <run-id> --web`)
 
@@ -97,3 +100,56 @@ Organized by branch and run ID.
 1. `gh run list` empty
 2. `git ls-remote --heads origin <branch>`
 3. Report branch may not be pushed or doesn't trigger workflows
+
+## Span files from CI artifacts
+
+- Location: `.e2e-artifacts/<branch>/<run>/**/spans/*.jsonl` (CI copies spans into `test-results/spans/`)
+- Format: JSONL (one span per line, parse with `JSON.parse`)
+- Fields: `name`, `traceId`, `spanId`, `parentSpanId`, `durationMs`, `status`, `startTime`, `attributes`
+
+Quick inspect:
+
+```bash
+ls -lt .e2e-artifacts/*/*/**/spans/*.jsonl
+```
+
+Read spans compact JSON:
+
+```bash
+python3 - <<'PY'
+import glob, json
+for path in glob.glob('.e2e-artifacts/*/*/**/spans/*.jsonl', recursive=True):
+    print(f'### {path}')
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            print(json.dumps(json.loads(line), separators=(',', ':')))
+PY
+```
+
+## Run ID
+
+- From `gh run list`: run ID = `databaseId` of selected run
+- From URL: `.../actions/runs/<run-id>` or `.../actions/runs/<run-id>/job/...`
+
+## Workflow Detection
+
+ALS has a single E2E workflow (`e2e-tests.yml`). Filter `workflowName` containing "E2E" or "Playwright".
+
+## Finding video
+
+The video names are hard. You can often trust the test failures to be the longest (largest file size) videos because waiting for test timeout.
+
+Video → screenshot to look at filenames in the test and see which test the video goes with.
+
+## Video → screenshots
+
+Extract frames from a failing test `.webm` to step through a moment:
+
+- **Prereq:** `brew install ffmpeg` if missing
+- **Cmd** (e.g. 1:29–1:36 → -ss 89 -to 96):
+
+```bash
+mkdir -p .e2e-artifacts/frames && ffmpeg -i .e2e-artifacts/<branch>/<run>/**/<video>.webm -ss 89 -to 96 -vf "fps=6" -q:v 2 .e2e-artifacts/frames/frame_%04d.png
+```
+
+- `fps=6` ≈ 6 frames/sec; output `frame_0001.png`+

--- a/.claude/skills/playwright-e2e/references/coding-playwright-tests.md
+++ b/.claude/skills/playwright-e2e/references/coding-playwright-tests.md
@@ -28,7 +28,7 @@ One test per file. Many steps allowed.
 
 **Use UI interactions:**
 
-- `Control+p` - Quick Open
+- Quick Open: `openFileByName` from `e2e-tests/shared/utils/fileHelpers.ts` — palette "Go to File…" (web + desktop). VS Code 1.116+ rows often render as `basename` + path segments + trailing `file results`; match logic lives in `fileHelpers.ts`. (`Control+p` opens Quick Open directly if you need raw access.)
 - `Control+Home`, `Control+s` - navigate and save
 - `page.keyboard.type()` - edit content
 - Monaco editor selectors - interact with editor

--- a/.claude/skills/playwright-e2e/references/iterating-playwright-tests.md
+++ b/.claude/skills/playwright-e2e/references/iterating-playwright-tests.md
@@ -7,8 +7,33 @@ description: Iterating on Playwright tests
 ## sequence
 
 1. run `web` locally (use `--retries 0`, follow debugging tips)
-2. run `desktop` locally
-3. edit github workflows if needed
+2. run `desktop` locally (use `--retries 0`)
+
+**Passing args:** Use `--` to forward params to the underlying playwright command. Prefer file path over `--grep` (exact match, immune to title changes):
+
+```bash
+WIREIT_CACHE=none npm run test:e2e:web -- --retries 0 e2e-tests/tests/myTest.spec.ts
+WIREIT_CACHE=none npm run test:e2e:desktop -- --retries 0 e2e-tests/tests/myTest.spec.ts
+```
+
+`WIREIT_CACHE=none` is always required when running a subset — wireit's cache key is based on input file fingerprints, not CLI args, so it serves the cached full-suite result otherwise.
+
+**Port conflict (web):** If a previous web server is still on port 3000, playwright fails immediately with `http://localhost:3000 is already used`. Fix: `lsof -ti :3000 | xargs kill -9`
+
+**Running from inside VS Code (agent shells):** When the shell inherits the VS Code extension host environment, `test:e2e:desktop` fails immediately with `Electron: bad option: --no-sandbox` / `--disable-workspace-trust` because `ELECTRON_RUN_AS_NODE=1` and `VSCODE_*` vars are set. Strip them on the command:
+
+```bash
+env -u ELECTRON_RUN_AS_NODE -u ELECTRON_NO_ATTACH_CONSOLE \
+    -u VSCODE_PID -u VSCODE_IPC_HOOK -u VSCODE_NLS_CONFIG \
+    -u VSCODE_HANDLES_UNCAUGHT_ERRORS -u VSCODE_CWD \
+    -u VSCODE_CRASH_REPORTER_PROCESS_TYPE -u VSCODE_ESM_ENTRYPOINT \
+    -u VSCODE_CLI -u VSCODE_CODE_CACHE_PATH -u VSCODE_L10N_BUNDLE_LOCATION \
+    WIREIT_CACHE=none npm run test:e2e:desktop -- --retries 0 <spec>
+```
+
+`unset` in a separate bash call won't help — each Bash tool invocation is a fresh shell.
+
+3. edit github workflows if needed (single `e2e-tests.yml` workflow)
 4. CI (windows, gha) - see `analyze-e2e.md` for monitoring and analyzing results
 
 After passing, clean up while keeping tests passing:
@@ -17,7 +42,7 @@ After passing, clean up while keeping tests passing:
 2. align with `coding-playwright-tests.md` rules
 3. consolidate locators, increase DRY/reuse
 4. ensure shared exports in `e2e-tests/shared/` are used
-5. verify compile/lint pass
+5. verify compile/lint pass (`@.claude/skills/verification/`)
 
 ## Debugging
 
@@ -37,3 +62,4 @@ https://github.com/redhat-developer/vscode-extension-tester - pageObject/Selecto
 
 - TS extension activation: `Error: Activating extension 'vscode.typescript-language-features'`
 - **All installed extensions temporarily disabled** (other extensions, not ours) - expected notification
+- VS Code 1.116+ / `@vscode/test-electron`: `cannot change enablement of github copilot chat extension` — workbench Copilot Chat toggle in test env; non-critical (`e2e-tests/shared/utils/helpers.ts` `NON_CRITICAL_ERROR_PATTERNS`)

--- a/.claude/skills/pr-draft/SKILL.md
+++ b/.claude/skills/pr-draft/SKILL.md
@@ -43,6 +43,17 @@ Draft PR titles and bodies per salesforcedx-vscode conventions. Requires a Gus w
 - Example: `build(extensions): consolidate apex-tmlanguage - W-21735053`
 - **Avoid:** leading brackets — `[W-21735053] build(extensions): …`; bare trailing WI without ` - ` — `build(extensions): … W-21735053`
 
+## GitHub issues & discussions
+
+Before finalizing body, fetch and analyze:
+
+1. **Issues:** `gh issue list --state open --limit 200 --json number,title,body,comments`
+2. **Discussions:** `gh api graphql` — fetch all open discussions (title, number, url, body)
+3. **LLM relevance pass:** read PR diff/commits + all issue/discussion titles+bodies; identify candidates
+4. **Auto-include** any issue where a comment contains the PR's W-XXXXX (e.g. `W-12345`) — no prompt needed; Git2Gus already established the link
+5. **Show remaining candidates** (issues and discussions the LLM flagged as related); ask user which to include
+6. **Format:** issues as `#<number>`, discussions as full URL — both in the "What issues does this PR fix or reference?" section
+
 ## Body format
 
 - Base body on branch commits only

--- a/.claude/skills/services-extension-consumption/SKILL.md
+++ b/.claude/skills/services-extension-consumption/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: services-extension-consumption
-description: Guidelines for consuming salesforcedx-vscode-services extension API. Use when working with extensions that have extensionDependency on salesforcedx-vscode-services, registering commands, using Workspace/Connection/Project/Settings/FS/Channel/Media services, quickpick/quickInput, or implementing file/config watchers.
+description: Guidelines for consuming salesforcedx-vscode-services extension API. Use when working with extensions that have extensionDependency on salesforcedx-vscode-services, registering commands, using Workspace/Connection/Project/Settings/FS/Channel/Media services, quickpick/quickInput, implementing file/config watchers, editing extensionProvider.ts, buildAllServicesLayer, AllServicesLayer, setAllServicesLayer, prebuiltServicesDependencies, or Layer composition for VS Code extensions.
 ---
 
 # Consuming salesforcedx-vscode-services
@@ -43,7 +43,32 @@ Per-extension layers (must build yourself):
 
 ## ExtensionContext Setup
 
-Factory function building services layer with ExtensionContext:
+Preferred: import `buildAllServicesLayer` from `@salesforce/effect-ext-utils`. It reads `displayName` from `package.json`, falling back to the second arg. `services/extensionProvider.ts` only needs the mutable `AllServicesLayer` + setter:
+
+```typescript
+// services/extensionProvider.ts
+import { buildAllServicesLayer } from '@salesforce/effect-ext-utils';
+
+export let AllServicesLayer: ReturnType<typeof buildAllServicesLayer>;
+export const setAllServicesLayer = (layer: ReturnType<typeof buildAllServicesLayer>) => {
+  AllServicesLayer = layer;
+};
+```
+
+In `activate` — pass the context and a localized fallback channel name:
+
+```typescript
+import { buildAllServicesLayer } from '@salesforce/effect-ext-utils';
+import { nls } from './messages';
+import { setAllServicesLayer } from './services/extensionProvider';
+
+export const activate = async (context: vscode.ExtensionContext): Promise<void> => {
+  setAllServicesLayer(buildAllServicesLayer(context, nls.localize('channel_name')));
+  await getRuntime().runPromise(activateEffect(context));
+};
+```
+
+Legacy inline pattern: a local `buildAllServicesLayer` factory wraps `Layer.unwrapEffect(...)` in `services/extensionProvider.ts`. Migrate to the shared helper when touching these — drop the factory, import `buildAllServicesLayer` from `@salesforce/effect-ext-utils`, pass the fallback name at the call site:
 
 ```typescript
 export const buildAllServicesLayer = (context: ExtensionContext) =>
@@ -66,16 +91,6 @@ export const buildAllServicesLayer = (context: ExtensionContext) =>
       );
     }).pipe(Effect.provide(ExtensionProviderServiceLive))
   );
-```
-
-In `activate`:
-
-```typescript
-export const activate = async (context: vscode.ExtensionContext): Promise<void> => {
-  const extensionScope = Effect.runSync(getExtensionScope());
-  setAllServicesLayer(buildAllServicesLayer(context));
-  await getRuntime().runPromise(activateEffect(context).pipe(Scope.extend(extensionScope)));
-};
 ```
 
 ## Runtime vs provide
@@ -157,6 +172,7 @@ Cross-extension / `executeCommand`: `vscode.commands.executeCommand('sf.org.logi
 Accessor pattern: call methods directly, don't assign to variable first.
 
 - [ChannelService](references/channel-service.md) - Output channel
+- [ComponentSetService](references/component-set-service.md) - Build component sets (source, manifest, URIs)
 - [MediaService](references/media-service.md) - Icons (ICONS) and NLS descriptions
 - [WorkspaceService](references/workspace-service.md) - Workspace info
 - [ConnectionService](references/connection-service.md) - Org connections
@@ -165,6 +181,7 @@ Accessor pattern: call methods directly, don't assign to variable first.
 - [FsService](references/fs-service.md) - File ops (web-compatible) and uri/path conversion
 - [EditorService](references/editor-service.md) - Active editor changes and current URI
 - [Prompts](references/prompts.md) - QuickPick, InputBox, and UserCancellationError handling
+- [TerminalService](references/terminal-service.md) - Run shell commands (desktop-only)
 
 ## Watchers
 
@@ -238,59 +255,61 @@ yield *
   );
 ```
 
+**`ref.changes` always emits the current value as element 0**, then future changes. Never prepend an explicit get:
+
+```typescript
+// WRONG — the fromEffect/get is redundant; .changes already emits current value first
+Stream.concat(Stream.fromEffect(SubscriptionRef.get(ref)), ref.changes)
+Stream.concat(Stream.make(yield* SubscriptionRef.get(ref)), ref.changes)
+
+// CORRECT
+ref.changes
+```
+
+To suppress the initial snapshot (e.g. avoid triggering a refresh before a tree provider is ready), use `Stream.drop(1)`.
+
 Ref behavior (concise):
 
 - Default-org update: username from User SOQL when present; else AuthInfo login username on the connection.
 - `TargetOrgRef` snapshot without username: optional `ConfigUtil.getUsername()` (project default) before treating as no target org — see `salesforcedx-vscode-org` `orgDisplay`.
+- `TargetOrgRef` value is always an object (never `undefined`); only fields like `orgId` within it are optional.
 
 ## Complete Example Pattern
 
 ```typescript
-// extensionProvider.ts
-import * as ManagedRuntime from 'effect/ManagedRuntime';
-
-export const buildAllServicesLayer = (context: ExtensionContext) =>
-  Layer.unwrapEffect(
-    Effect.gen(function* () {
-      const extensionProvider = yield* ExtensionProviderService;
-      const api = yield* extensionProvider.getServicesApi;
-      const channelLayer = api.services.ChannelServiceLayer(
-        context.extension.packageJSON.displayName ?? 'My Extension'
-      );
-      const errorHandlerWithChannel = Layer.provide(api.services.ErrorHandlerService.Default, channelLayer);
-
-      return Layer.mergeAll(
-        Layer.succeedContext(api.services.prebuiltServicesDependencies),
-        ExtensionProviderServiceLive,
-        errorHandlerWithChannel,
-        api.services.ExtensionContextServiceLayer(context),
-        api.services.SdkLayerFor(context),
-        channelLayer
-      );
-    }).pipe(Effect.provide(ExtensionProviderServiceLive))
-  );
+// services/extensionProvider.ts
+import { buildAllServicesLayer } from '@salesforce/effect-ext-utils';
 
 export let AllServicesLayer: ReturnType<typeof buildAllServicesLayer>;
 export const setAllServicesLayer = (layer: ReturnType<typeof buildAllServicesLayer>) => {
   AllServicesLayer = layer;
 };
 
+// services/runtime.ts
+import * as ManagedRuntime from 'effect/ManagedRuntime';
+import { AllServicesLayer } from './extensionProvider';
+
 const createRuntime = () => ManagedRuntime.make(AllServicesLayer);
 let _runtime: ReturnType<typeof createRuntime> | undefined;
-export const getRuntime = () => {
-  _runtime ??= createRuntime();
-  return _runtime;
-};
+export const getRuntime = () => (_runtime ??= createRuntime());
 
 // index.ts
+import { buildAllServicesLayer } from '@salesforce/effect-ext-utils';
+import { nls } from './messages';
 import { myCommandEffect } from './commands/myCommand';
+import { AllServicesLayer, setAllServicesLayer } from './services/extensionProvider';
+import { getRuntime } from './services/runtime';
+
+export const activate = async (context: vscode.ExtensionContext) => {
+  setAllServicesLayer(buildAllServicesLayer(context, nls.localize('channel_name')));
+  await getRuntime().runPromise(activateEffect(context));
+};
 
 export const activateEffect = Effect.fn(`activation:${EXTENSION_NAME}`)(function* (_context: vscode.ExtensionContext) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   yield* api.services.ChannelService.appendToChannel('Extension activating');
 
   const registerCommand = api.services.registerCommandWithLayer(AllServicesLayer);
-
   yield* registerCommand('sf.my.command', myCommandEffect);
 
   yield* api.services.ChannelService.appendToChannel('Extension activation complete.');
@@ -307,3 +326,34 @@ export const activateEffect = Effect.fn(`activation:${EXTENSION_NAME}`)(function
 - `Effect.forkIn(..., yield* getExtensionScope())` for watcher cleanup on deactivation
 - `registerCommandWithLayer` for all commands (tracing + error handling)
 - Use `getRuntime().runPromise` / `runFork` instead of `Effect.provide(AllServicesLayer)` for execution
+
+## Don't: rebuild services already in prebuiltServicesDependencies
+
+```typescript
+// WRONG — creates new singleton instances, duplicating caches/watchers/state
+return Layer.mergeAll(
+  ExtensionProviderServiceLive,
+  api.services.ExtensionContextServiceLayer(context),
+  api.services.FsService.Default,           // ← already in prebuilt
+  api.services.AliasService.Default,        // ← already in prebuilt
+  api.services.SdkLayerFor(context),
+  channelLayer,
+  errorHandlerWithChannel
+);
+
+// CORRECT — share the already-built singletons
+return Layer.mergeAll(
+  Layer.succeedContext(api.services.prebuiltServicesDependencies),
+  ExtensionProviderServiceLive,
+  api.services.ExtensionContextServiceLayer(context),
+  api.services.SdkLayerFor(context),
+  channelLayer,
+  errorHandlerWithChannel
+);
+```
+
+## Review
+
+Invoke the `effect-advocate` subagent on plans and diffs — its top-priority finding category is "you re-implemented something that already exists in `salesforcedx-vscode-services`."
+
+`prebuiltServicesDependencies` contains ~27 services built once during services extension activation. Calling `.Default` on any of them creates a **second instance** with its own caches, watchers, and state — silently breaking cross-extension sharing.

--- a/.claude/skills/services-extension-consumption/references/component-set-service.md
+++ b/.claude/skills/services-extension-consumption/references/component-set-service.md
@@ -1,0 +1,78 @@
+# ComponentSetService
+
+Build Salesforce component sets from source, manifests, or URIs. Accessor pattern: call methods directly.
+
+## Methods
+
+### getComponentSetFromProjectDirectories
+
+Resolve all components in project package directories:
+
+```typescript
+const componentSet = yield * api.services.ComponentSetService.getComponentSetFromProjectDirectories();
+```
+
+Optional `include` filters by component type (ComponentSet wildcard members):
+
+```typescript
+const includeSet = new ComponentSet([
+  { fullName: '*', type: 'LightningComponentBundle' },
+  { fullName: '*', type: 'AuraDefinitionBundle' }
+]);
+const componentSet = yield * api.services.ComponentSetService.getComponentSetFromProjectDirectories({
+  include: includeSet
+});
+```
+
+When `include` omitted: returns all components. When provided: SDR narrows results to matching types only.
+
+### getComponentSetFromManifest
+
+Resolve components from manifest file:
+
+```typescript
+const manifestUri = /* ... */;
+const componentSet = yield * api.services.ComponentSetService.getComponentSetFromManifest(manifestUri);
+```
+
+### getComponentSetFromUris
+
+Resolve components from file/directory URIs (deduplicates):
+
+```typescript
+const uris = [uri1, uri2];
+const componentSet = yield * api.services.ComponentSetService.getComponentSetFromUris(uris);
+```
+
+## Utilities
+
+### ensureNonEmptyComponentSet
+
+Validates ComponentSet is non-empty; errors if size=0 and no source components:
+
+```typescript
+const nonEmpty = yield * api.services.ComponentSetService.ensureNonEmptyComponentSet(componentSet);
+```
+
+Returns `NonEmptyComponentSet` branded type or throws `EmptyComponentSetError`.
+
+### Component State & Status
+
+```typescript
+const { isSDRSuccess, isSDRFailure, getComponentState, makeFileResponseFailure, toRequestStatus } =
+  yield * api.services.ComponentSetService;
+```
+
+Check deploy/retrieve outcome per component; map SDR response state to UI status.
+
+## Errors
+
+- `FailedToBuildComponentSetError` - Can't resolve from source/manifest/URIs
+- `EmptyComponentSetError` - ComponentSet has no components (from ensureNonEmptyComponentSet)
+
+## Notes
+
+- Sets `projectDirectory`, `apiVersion`, `sourceApiVersion` on returned ComponentSet
+- Requires `MetadataRegistryService`, `ProjectService`, `ConfigService`
+- Uses registry access and SF project config for resolution
+- Globally cached where applicable

--- a/.claude/skills/services-extension-consumption/references/fs-service.md
+++ b/.claude/skills/services-extension-consumption/references/fs-service.md
@@ -69,6 +69,16 @@ const uris = yield * api.services.FsService.readDirectory(dirPath);
 // Returns: URI[]
 ```
 
+### readDirectoryWithTypes
+
+Read dir contents preserving `FileType` per entry (avoids extra stat calls for recursive traversal):
+
+```typescript
+const entries = yield * api.services.FsService.readDirectoryWithTypes(dirPath);
+// Returns: Array<{ uri: URI, type: vscode.FileType }>
+const dirs = entries.filter(e => e.type === vscode.FileType.Directory);
+```
+
 ### stat
 
 Get file stats:

--- a/.claude/skills/services-extension-consumption/references/project-service.md
+++ b/.claude/skills/services-extension-consumption/references/project-service.md
@@ -46,6 +46,8 @@ const dirs = (yield* api.services.ProjectService.getSfProject()).getPackageDirec
 ## Notes
 
 - Cached globally (10 min TTL)
-- Cache key: workspace `fsPath`
+- Cache key: workspace `fsPath`; `vscode-test-web://` workspaces with `.vscode/vscode-extension-test-disk-root.txt` (E2E headless): file body = disk path for `@salesforce/core` `SfProject` cache
+- `SfProject.resolve` fails (e.g. virtual mount): `isSalesforceProject` may still true via root `sfdx-project.json` `vscode.workspace.fs` stat; `getSfProject` no that fallback—can fail while flag true
+- `isSalesforceProject` cache `tapError` sets `sf:project_opened` false on resolve/cache errors; `FailedToResolveSfProjectError` then `catchTag` fallback may set context again from manifest stat
 - Requires `WorkspaceService`
 - Use `getSfProject()` for project methods (getPackageDirectories, etc.)

--- a/.claude/skills/services-extension-consumption/references/prompts.md
+++ b/.claude/skills/services-extension-consumption/references/prompts.md
@@ -16,6 +16,20 @@ const choice =
   );
 ```
 
+### `withProgress`
+
+Pipeable operator. Shows a VS Code progress notification (Notification location, non-cancellable) for the lifetime of an Effect; dismisses on completion (success or failure).
+
+Signature: `(title: string) => <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>`
+
+Title must use `nls.localize()` — enforced by the `no-vscode-progress-title-literals` ESLint rule.
+
+```typescript
+yield * fetchMetadata().pipe(
+  promptService.withProgress(nls.localize('fetching_metadata'))
+);
+```
+
 ### `ensureMetadataOverwriteOrThrow`
 
 Checks file existence; prompts for overwrite. Fails with `UserCancellationError` on cancel.

--- a/.claude/skills/services-extension-consumption/references/terminal-service.md
+++ b/.claude/skills/services-extension-consumption/references/terminal-service.md
@@ -1,0 +1,54 @@
+# TerminalService
+
+Runs shell commands and parses stdout. Desktop-only — fails with `TerminalServiceError` on web.
+
+## `simpleExec<A>`
+
+```typescript
+simpleExec(command: string, parse?: (stdout: string) => A): Effect<A, TerminalServiceError>
+```
+
+- `parse` optional — omit to get trimmed stdout as `string`
+- stdout trimmed before `parse` is called
+- 10 s timeout
+- Traced with `TerminalService.simpleExec` span (`command` attribute)
+- On web: immediate `TerminalServiceError` (no exec attempted)
+
+## `TerminalServiceError`
+
+`Schema.TaggedError`. Fields:
+
+- `message` — error description
+- `command` — the command that failed
+
+## Usage
+
+Parse stdout into a string:
+
+```typescript
+const version = yield* Effect.gen(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const terminal = yield* api.services.TerminalService;
+
+  // stdout is pre-trimmed; split "7.200.6 @salesforce/cli/..." → just the version token
+  return yield* terminal.simpleExec('sf --version', stdout => stdout.split(' ')[0]);
+});
+// version: string
+```
+
+Parse stdout into a typed value using the generic param `<A>`:
+
+```typescript
+type SfVersion = { major: number; minor: number; patch: number };
+
+const parsed = yield* Effect.gen(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const terminal = yield* api.services.TerminalService;
+
+  return yield* terminal.simpleExec<SfVersion>('sf --version', stdout => {
+    const [major, minor, patch] = stdout.split('.').map(Number);
+    return { major, minor, patch };
+  });
+});
+// parsed: SfVersion
+```

--- a/.claude/skills/services-extension-consumption/references/workspace-service.md
+++ b/.claude/skills/services-extension-consumption/references/workspace-service.md
@@ -34,7 +34,7 @@ const packageDirs = (yield* api.services.ProjectService.getSfProject()).getPacka
 
 ## Notes
 
-- `isEmpty` - workspace folders exist
+- `isEmpty` — no workspace folders
 - `isVirtualFs` - non-file scheme (e.g., memfs://)
 - `fsPath` normalized (backslashes → forward slashes for virtual FS)
-- Cached globally
+- Cached globally; web: memo on first `yield*` (not import), so folders exist before snapshot

--- a/.claude/skills/shipped-issues/SKILL.md
+++ b/.claude/skills/shipped-issues/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: shipped-issues
+description: Find open GitHub issues whose linked GUS work item is closed AND whose issue number appears in the shipped GitHub release notes, then close them. Use when user invokes /shipped-issues or asks to clean up shipped issues.
+---
+
+# Shipped Issues
+
+Cross-reference open GitHub issues against closed GUS work items and the shipped release notes to identify issues that were fixed and released, but never closed on GitHub.
+
+## Inputs
+
+- Repo: `forcedotcom/apex-language-support`
+- Shipped release notes: GitHub Releases on the repo. ALS has no tracked `CHANGELOG.md`; it ships via semantic-release and the release bodies on GitHub are the source of truth for what shipped. Aggregate recent release notes (stable + nightly) before cross-referencing.
+- GUS alias: `gus` (see `.claude/skills/gus-cli/SKILL.md`)
+
+## Workflow
+
+### 1. Gather shipped release notes
+
+```bash
+# List recent releases (stable + pre-release/nightly) and dump their bodies.
+gh release list --repo forcedotcom/apex-language-support --limit 100 \
+  --json tagName,name,isPrerelease,publishedAt > /tmp/shipped-releases.json
+
+# Concatenate the bodies of recent releases into one searchable file.
+for tag in $(gh release list --repo forcedotcom/apex-language-support --limit 100 --json tagName --jq '.[].tagName'); do
+  echo "===== $tag ====="
+  gh release view "$tag" --repo forcedotcom/apex-language-support --json body --jq '.body'
+done > /tmp/shipped-changelog.md
+```
+
+Do not switch branches; run from wherever the user is. Adjust `--limit` if older releases need to be covered.
+
+### 2. List open issues with W- references
+
+```bash
+gh issue list --repo forcedotcom/apex-language-support --state open --limit 500 --search "W in:body" --json number,title,body,url > /tmp/shipped-issues.json
+```
+
+The `W in:body` filter narrows to issues that contain the letter W — overly broad but cheap. Locally extract `W-\d{6,9}` matches per issue (regex; multiple W- per issue is allowed). Drop issues with no match.
+
+### 3. Query GUS for status of each W-
+
+Batch in chunks of ~50 W- names per query to stay under SOQL limits:
+
+```bash
+sf data query --query "SELECT Id, Name, Status__c, Last_Modified_Internal_Closed_Date__c FROM ADM_Work__c WHERE Name IN ('W-1234567','W-2345678', ...)" -o gus --json
+```
+
+Closed terminal statuses (any of these counts as closed): see `.claude/skills/gus-cli/SKILL.md` § Status\_\_c values "Closed (terminal)". Note: git2gus on this repo uses `statusWhenClosed=CLOSED`, so a shipped/closed WI lands on a `Closed*` status.
+
+Quick check: `Status__c LIKE 'Closed%' OR Status__c IN ('Completed','Fixed')`.
+
+### 4. Filter to candidates
+
+Keep an issue only when **every** W- on the issue resolves to a Closed/Completed status in GUS. If any linked W- is still open, skip the issue (work isn't all done).
+
+### 5. Cross-reference shipped release notes
+
+For each candidate issue number `N`, search the aggregated release notes in `/tmp/shipped-changelog.md` for any of:
+
+- `ISSUE #N` (case-insensitive)
+- `issues/N` (link form)
+- `#N` only when the surrounding line clearly references an issue, not a PR
+
+Semantic-release notes typically reference the **PR** that landed the fix rather than the issue. If a candidate's issue # has no direct hit, also resolve the PR(s) that mention the issue and confirm the PR appears in a release. Record the matched release tag + line for the closing comment.
+
+If matched → issue is **shipped**. Record the matched release note line (and the release tag it came from) for the closing comment.
+
+### 6. Present the report
+
+Show a table to the user before closing anything:
+
+| Issue | Title | W- | WI Status | Shipped in (release tag + note line) |
+| ----- | ----- | -- | --------- | ------------------------------------ |
+
+Also list any **near-miss** rows separately so the user can review:
+- Issues where WIs are all closed but the issue # isn't in any release notes (maybe under-the-hood / not customer-facing)
+- Issues where some W- are still open
+
+### 7. Close issues — only after explicit user confirmation
+
+For each confirmed issue, post a comment then close:
+
+```bash
+gh issue close <number> --repo forcedotcom/apex-language-support --comment "Closing — shipped in <release tag>. See release note: <verbatim line>. (Linked work item <W-XXXXXXXX> is closed.)"
+```
+
+Do **not** loop-close without user confirmation. If many issues, present the full list and ask "Close all N?" once.
+
+## Edge cases
+
+- **Multiple W- per issue, mixed status**: skip until all W- close.
+- **Issue body mentions W- in a quoted error or unrelated context**: rare; surface as candidate anyway, the user reviews the table.
+- **Release note hit on an internal/"under the hood" line**: still counts as shipped — user can opt out per-row.
+- **Issue # shows up in release notes only as `[PR #N]`**: not a match by itself. Only `ISSUE #N` / `issues/N` indicate the issue. A PR reference can still confirm shipping if you've already tied that PR back to the issue (see step 5).
+- **No release-note match but WI closed long ago**: list as near-miss, don't auto-close.
+- **Nightly vs stable**: a fix may appear in a nightly/pre-release before a stable tag. Note which when reporting; the user decides whether nightly-only counts as shipped.
+
+## Output format
+
+End with a one-line summary: `Closed N issues; M near-misses for review.`

--- a/.claude/skills/span-file-export/SKILL.md
+++ b/.claude/skills/span-file-export/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: span-file-export
-description: Use file-based span export for AI consumption (extension client). Where it lives, how to enable/clear. Use when enabling span file dump, debugging traces for AI, or configuring local observability in the VS Code extension.
+description: Use file-based span/log export for AI consumption (extension client). Where it lives, how to enable/clear, record format for Node and Web. Use when enabling span file dump, debugging traces for AI, or configuring local observability in the VS Code extension.
 ---
 
-# Span File Export
+# Span & Log File Export
 
 ## Scope (this repo)
 
-- **In scope:** VS Code **extension client** — `packages/apex-lsp-vscode-extension` and code that runs in the extension host and uses the services extension / `enableFileTraces` (see `extensionTracing.ts`).
+- **In scope:** VS Code **extension client** — `packages/apex-lsp-vscode-extension` and code that runs in the extension host and uses the services extension / `enableFileTraces` (see `src/observability/extensionTracing.ts`).
 - **Out of scope for default guidance:** Language server and parser packages (`packages/apex-parser-ast`, `packages/apex-ls`, etc.) — do not treat file-span export as a requirement there unless product explicitly adds tracing. Server-side LSP work stays focused on protocol and semantics.
 
-Local span export to `~/.sf/vscode-spans/` for AI consumers. Simplified flat JSON Lines format.
+Local OTLP export to `~/.sf/vscode-spans/` for AI consumers. Spans and log records interleaved in one JSONL file. The actual exporter and record format come from the shared `@salesforce/vscode-services` SDK layer (`SdkLayerFor(context)`), which the extension obtains from the `salesforce.salesforcedx-vscode-services` extension.
 
 ## Choose One: OTLP vs File
 
@@ -19,48 +19,89 @@ Local span export to `~/.sf/vscode-spans/` for AI consumers. Simplified flat JSO
 
 Use only one at a time.
 
+## Settings Required
+
+These settings live in the shared `salesforcedx-vscode-salesforcedx` section provided by the services extension (not the `apex` section).
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `salesforcedx-vscode-salesforcedx.enableFileTraces` | `false` | Enables file capture (spans + logs) |
+| `salesforcedx-vscode-salesforcedx.logLevel` | `error` | Minimum log level for exported records. Set to `info` or `debug` to see most logs. |
+| `SF_LOG_LEVEL` env var | — | Fallback when VS Code setting unset (`fatal` maps to `error`) |
+
+The extension registers an `onDidChangeConfiguration` listener (`extensionTracing.ts`) that tears down and rebuilds the tracing runtime when `enableFileTraces`, `enableConsoleTraces`, or `enableLocalTraces` change — so toggling these settings takes effect without a window reload. (Other SDK-layer behavior may still depend on activation; reload if a change does not take effect.)
+
 ## Where It Lives
 
-All spans in one directory: `~/.sf/vscode-spans/`
+All records in one directory: `~/.sf/vscode-spans/`
 
-| Prefix | Path pattern |
-|--------|--------------|
-| Node | `node-{extensionName}-{ISO-timestamp}.jsonl` |
-| Web | `web-{extensionName}-{ISO-timestamp}.jsonl` |
+Filename pattern: `{ISO-timestamp}.jsonl` (e.g., `2026-05-22T15-33-01-398Z.jsonl`)
 
-Find latest: `ls -lt ~/.sf/vscode-spans/`
+Find latest: `ls -lt ~/.sf/vscode-spans/ | head -1`
+
+## Record Format
+
+Each line is independent JSON. Discriminate on the `"kind"` field.
+
+### Spans (`kind: "span"`)
+
+```jsonl
+{"kind":"span","traceId":"abc123","spanId":"def456","parentSpanId":"","name":"apex-language-server-extension.activate","spanKind":1,"startTimeUnixNano":"1779461510277547833","endTimeUnixNano":"1779461510278117291","attributes":{"componentCount":"5"},"events":[],"links":[],"status":{"code":1,"message":""},"resource":{"attributes":{"extension.name":"apex-language-server-extension","service.name":"apex-language-server-extension"}},"instrumentationScope":{"name":"apex-language-server-extension","version":"2026-03-02T01:00.304Z"}}
+```
+
+| Field | Notes |
+|-------|-------|
+| `parentSpanId: ""` | Root span (top of trace tree) |
+| `status.code` | 1=OK, 2=ERROR |
+| `spanKind` | OTEL SpanKind enum +1 (1=INTERNAL, 2=SERVER, 3=CLIENT) |
+| `resource.attributes["extension.name"]` | Which extension emitted it |
+| Duration (ms) | `(endTimeUnixNano - startTimeUnixNano) / 1_000_000` |
+
+### Logs (`kind: "log"`)
+
+```jsonl
+{"kind":"log","timestamp":"1779463981397000000","severityText":"WARN","severityNumber":30000,"body":"UserIdNotFoundError: Could not determine user ID","traceId":"b4d710...","spanId":"706dfc...","attributes":{"fiberId":"#295"}}
+```
+
+| Field | Notes |
+|-------|-------|
+| `traceId` + `spanId` | Correlates to parent span active when log was emitted |
+| `severityText` | INFO, WARN, ERROR (filtered by `logLevel` setting) |
+| `body` | String or array (multiple log args) |
+| `timestamp` | Nanoseconds since epoch |
+
+Only log records at or above the configured `logLevel` are emitted.
 
 ## Enable (Desktop)
 
-Settings → search `enableFileTraces` → check, or use the `salesforcedx-vscode-salesforcedx` section (same namespace as other Salesforce DX VS Code settings):
+Settings → search `enableFileTraces` → check, or set both in the shared `salesforcedx-vscode-salesforcedx` section:
 
 ```json
-{ "salesforcedx-vscode-salesforcedx.enableFileTraces": true }
+{
+  "salesforcedx-vscode-salesforcedx.enableFileTraces": true,
+  "salesforcedx-vscode-salesforcedx.logLevel": "info"
+}
 ```
 
 ## Enable (Web / run:web)
 
-Web POSTs to a local span file server when the workspace is set up for it (often via consumed `salesforcedx-vscode-services` and `.esbuild-web-extra-settings.json`). If your branch wires `run:web` + span server like the main VS Code repo, follow that package’s README; this repo may not define `spans:server` at the root—check workspace `package.json` before assuming scripts exist.
+Web POSTs to a local span file server when the workspace is set up for it (often via consumed `salesforcedx-vscode-services` and `.esbuild-web-extra-settings.json`). This repo does **not** define a `spans:server` script at the root, so do not assume one exists — check the workspace `package.json` and follow the `salesforcedx-vscode-services` team docs when wiring `run:web` + span server.
 
-1. Start span server only if your wireit graph includes it (see team `salesforcedx-vscode-services` docs when applicable).
-2. Optional `.esbuild-web-extra-settings.json` at repo root (gitignored when local):
-
-```json
-{ "salesforcedx-vscode-salesforcedx.enableFileTraces": true }
-```
-
+1. Start the span server only if your wireit graph includes it (see team `salesforcedx-vscode-services` docs when applicable; the monorepo runs it on port 3003).
+2. Add to `.esbuild-web-extra-settings.json` at repo root (gitignored when local):
+   ```json
+   { "salesforcedx-vscode-salesforcedx.enableFileTraces": true }
+   ```
 3. Run the web target for the extension package you are testing.
 
 ## Clear
 
 `rm ~/.sf/vscode-spans/*` or `rm -rf ~/.sf/vscode-spans/`
 
-## Format
+## Trace Correlation
 
-Simplified flat JSON — one object per line:
+Logs reference the span that was active when they were emitted via `traceId` + `spanId`. To reconstruct an operation:
 
-```jsonl
-{"name":"deploy","traceId":"abc","spanId":"def","parentSpanId":"","durationMs":1234,"status":"OK","startTime":"2026-02-25T10:30:00.000Z","attributes":{"componentCount":"5"}}
-```
-
-Parse with `JSON.parse` per line.
+1. Find all spans with a given `traceId`
+2. Build the tree using `parentSpanId` → children
+3. Find logs with the same `traceId` — they belong to the span matching their `spanId`

--- a/.claude/skills/ts4023-effect-errors/SKILL.md
+++ b/.claude/skills/ts4023-effect-errors/SKILL.md
@@ -18,8 +18,8 @@ Export ALL error types that appear in any Effect's error channel - including non
 ### 1. Find ALL TaggedError classes (not just exported ones)
 
 ```bash
-# Find ALL TaggedError classes, including non-exported ones
-rg "class \w+Error extends Data\.TaggedError" packages/<package-name>/src
+# Find Data.TaggedError and Schema.TaggedError (both can appear in Effect error channels)
+rg "class \w+Error extends (Data|Schema)\.TaggedError" packages/<package-name>/src
 ```
 
 **Critical**: Include classes WITHOUT `export` keyword. Example:
@@ -57,7 +57,9 @@ If a service method like `ensureNonEmptyComponentSet` can fail with `EmptyCompon
 
 ## Knip false positives
 
-Knip flags these as "unused" - ignore. TypeScript needs them for declaration emit, not runtime imports.
+Knip flags these as "unused exports" when the error class is defined and used within the same file but exported only for TS4023 reasons. Ignore these warnings - TypeScript needs the exports for declaration emit, not runtime imports.
+
+**Errors exported for cross-package consumption** (e.g. re-exported from a service package's `index.ts` and imported by another package) are NOT false positives - knip correctly sees them as used, so leave them as-is.
 
 ## Checklist
 

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -3,6 +3,7 @@ name: typescript
 description: TypeScript coding standards and conventions including file naming rules
 ---
 
+- new file copyright header: use year **2026** (e.g. `Copyright (c) 2026, salesforce.com, inc.`)
 - no barrel files
 - avoid type assertions (`as Foo` or `as unknown as` or `Foo!`). do guards or Effect.schema stuff (ex `is`) instead
 - no `void` for async - use async/effect (exception [vscode-window-messages](../vscode-window-messages/SKILL.md))

--- a/.claude/skills/verification/references/compile.md
+++ b/.claude/skills/verification/references/compile.md
@@ -12,8 +12,13 @@ description: Compilation commands; TS4023 and TS1261 fixes
 
 | Code | Skill |
 |------|--------|
+| TS1205 | No skill — use `export type` for type-only exports; or `isolatedModules: false` override for packages needing ambient const enums from external packages |
 | TS4023 | [@.claude/skills/ts4023-effect-errors/](../ts4023-effect-errors/SKILL.md) |
 | TS1261 | [@.claude/skills/ts1261-filename-casing/](../ts1261-filename-casing/SKILL.md) |
+
+### TS1205
+
+"Re-exporting a type when `--isolatedModules` is provided requires using `export type`." `tsconfig.common.json` sets `isolatedModules: true`. Fix: change `export { Foo }` → `export type { Foo }` (or inline `export { type Foo, Bar }`). Exception: packages accessing ambient `const enum` from external packages must override with `isolatedModules: false` in their local `tsconfig.json`.
 
 ### TS4023
 

--- a/.claude/skills/wireit/SKILL.md
+++ b/.claude/skills/wireit/SKILL.md
@@ -27,7 +27,7 @@ Full documentation: https://github.com/google/wireit
 - Agents should not run these (they won't exit)
   - any script with --watch
   - any `service:true` if you're an Agent, it won't exit
-- wireit can't follow stuff that doesn't show up as changes that break the cache
+- wireit can't follow stuff outside `files`
   - manually changing code in node_modules then running compile or bundle
   - npm link'd packages (ex: symlinks to node libraries locally modified)
 
@@ -41,6 +41,10 @@ ref: https://github.com/google/wireit?tab=readme-ov-file#extra-arguments
 ## Common Patterns
 
 top level `compile`, `lint`, `test` should run all of that in the various packages. When creating new packages, update these.
+
+## Errors
+
+If you see "Unknown error thrown: Error: Did not expect..." or "Internal error!" from wireit — another process was running the same scripts. Re-run the command yourself to confirm it passes. DO NOT CLEAR `.wireit` to solve this.
 
 ## Notes
 

--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -1,0 +1,246 @@
+# auto-build workflows
+
+Workflow scripts for [Workflow tool](https://docs.claude.com/) orchestration. Each `.js` file is a self-contained, multi-agent pipeline that fans out subagents per phase and returns a structured result.
+
+## Note
+
+This code is a mess.  Claude requires this live in 1 file (no imports, no TS, no effect)
+
+## Setup
+
+Required before running anything in this directory:
+
+1. **Claude Code ≥ 2.1.154.** `claude --version` to check; upgrade with `claude update` (or your package manager). Older versions don't support inline workflow scripts.
+2. **Enable dynamic workflows.** Just ask Claude: _"enable dynamic workflows"_. Claude will set `"enableWorkflows": true` in [.claude/settings.json](../settings.json) (and your `~/.claude/settings.json` if you want it on globally). Without this flag, the `Workflow` tool is unavailable and `/auto-build-wi` fails immediately.
+3. **gus alias + identity.** `sf alias list` must show a `gus` alias pointing to the org you query work items in (`sf org login web -a gus` if missing). Your username must be listed under **Team members** in [.claude/skills/gus-cli/SKILL.md](../skills/gus-cli/SKILL.md) (with `Github_Username__c`, slack id, owner prefix). The first run caches identity to `$HOME/.claude/runner-identity.json`.
+4. **Slack MCP.** `mcp__slack__slack_send_message` must be reachable (DMs and `#ide-exp-code-review` posts). Run `/salesforce-trust-foundations:mcp-auth` if MCP calls 401.
+
+## auto-build-wi.js
+
+Drains GUS work items tagged `[ai-auto]` end-to-end: claim → plan → build → review → draft PR. **Stateless across ticks** — each run starts fresh, queries current GUS/GitHub state, and acts. Pair with `/loop` to run on a schedule (e.g. `/loop 10m /auto-build-wi`).
+
+### Arguments
+
+- `args.maxInFlight` — cap on concurrent in-flight WIs (default `5`). When at cap, the tick monitors only and skips claiming a new one.
+
+### Identity resolution
+
+Reads `sf alias list` for the `gus` alias, queries the User record by username, then cross-references the runner against the **Team members** table in [.claude/skills/gus-cli/SKILL.md](../skills/gus-cli/SKILL.md) to derive:
+
+- `userId` — GUS User Id
+- `ownerPrefix` — initials (e.g. `sm`) used for branches/worktrees
+- `slackId` — for DMs and review pings
+- `githubLogin` — for reviewer assignment
+
+Cached at `$HOME/.claude/runner-identity.json` after first resolve. If any of these can't be resolved, the tick exits early with `identity-failed`.
+
+### Tick flow
+
+```text
+                          ┌─────────────────────┐
+                          │  Resolve identity   │
+                          └──────────┬──────────┘
+                                     ▼
+                          ┌─────────────────────┐
+                          │   Ensure daemons    │  start gha-rerun if not running
+                          └──────────┬──────────┘
+                                     ▼
+                          ┌─────────────────────┐
+                          │ Reap stranded       │  rm worktrees/branches whose PRs
+                          │ worktrees           │  already merged/closed (haiku)
+                          └──────────┬──────────┘
+                                     ▼
+                          ┌─────────────────────┐
+                          │  Monitor in-flight  │  query GUS for In Progress [ai-auto]
+                          │  (per WI: PR check) │  + gh pr view + statusCheckRollup
+                          └──────────┬──────────┘
+                                     │
+       ┌──────────┬───────┬──────────┼───────────┬────────────┐
+       ▼          ▼       ▼          ▼           ▼            ▼
+   merged/     green/  running/    no-pr/      failed +     failed +
+   closed     finalize   wait     restart    gha retries   exhausted
+       │          │       │          │       remaining        │
+       ▼          │       │          │           │            ▼
+  ┌─────────┐     │       │          │           │       ┌─────────┐
+  │ Close   │     │       │          │           │       │ Triage  │ flake | e2e | code-bug
+  │ merged  │     │       │          │           │       └────┬────┘
+  │ WIs     │     │       │          │           │            ▼
+  └─────────┘     │       │          │           │       ┌─────────┐
+   set WI         │       │          │           │       │ Fix CI  │ DM | e2e fix | code fix
+   Closed,        │       │          │           │       └─────────┘
+   rm worktree    ▼       │          ▼           ▼
+                  │       │     (re-enter      (let
+                  │       │      builder)     gha-rerun
+                  │       │                   work)
+                  └───┬───┘
+                      ▼
+        ┌────────────────────┐
+        │ Keep in-flight     │  conflicting PRs only: merge origin/main
+        │ current            │  into each worktree sequentially; push
+        └────────┬───────────┘
+                 ▼
+        ┌────────────────────┐
+        │  Open for review   │  green PRs: undraft, set 'Ready for Review',
+        │                    │  reassign reviewers, post Slack, rm worktree
+        └────────┬───────────┘
+                 ▼
+        ┌────────────────────┐
+        │   Peer approve     │  approve OTHER runners' PRs that owner
+        │                    │  rubber-stamped with /ai-auto approve
+        └────────┬───────────┘
+                 ▼
+        ┌────────────────────┐
+        │ at cap?            │── yes ──▶ exit
+        └────────┬───────────┘
+                 │ no
+                 ▼
+        ┌────────────────────┐
+        │  Pick candidate    │  query New/Ready [ai-auto]; rank by deps,
+        └────────┬───────────┘  file-overlap with in-flight, story points
+                 ▼
+        ┌────────────────────┐
+        │ Claim + worktree   │  Status='In Progress' + git worktree add
+        └────────┬───────────┘
+                 ▼
+        ┌────────────────────┐
+        │       Plan         │  write .claude/plans/W-XXX.md → style review
+        │ (4-pass review:    │  → effect / e2e / adversary in parallel →
+        │  style + 3 parallel│  revise → commit
+        │  advocates)        │  blocked? → bounce to Waiting + DM
+        └────────┬───────────┘
+                 ▼
+        ┌────────────────────┐
+        │       Build        │  one commit per plan phase; hooks drive
+        │  (in worktree)     │  correctness; stuck → bounce + DM
+        └────────┬───────────┘
+                 ▼
+        ┌────────────────────┐
+        │       Review       │  fan out: per-skill detect + thermo +
+        │  (parallel)        │  effect-advocate diff review
+        └────────┬───────────┘
+                 ▼
+        ┌────────────────────┐
+        │  Verify findings   │  adversarial check per finding (parallel):
+        │  (parallel)        │  premise + CI-coverage + consumer gh-search
+        └────────┬───────────┘  → confirmed | downgraded | dropped
+                 ▼
+        ┌────────────────────┐
+        │ Fix review findings│  consume verified findings; auto-apply
+        │ + merge develop    │  critical/high; merge origin/main
+        └────────┬───────────┘
+                 ▼
+        ┌────────────────────┐
+        │      Draft PR      │  push + gh pr create --draft;
+        │                    │  append "PR: <url>" to WI Details__c
+        └────────────────────┘
+```
+
+### Peer approval — `/ai-auto approve`
+
+Owners can rubber-stamp their own AI-generated PR by leaving a PR comment whose first line matches:
+
+```text
+/ai-auto approve
+```
+
+(Comment body, line-anchored — anything below the line is a free-form note.) On the next tick, ANOTHER runner's `auto-build-wi` will:
+
+1. Pick up the comment if `Status__c='Ready for Review'` and `Subject__c LIKE '%[ai-auto]%'`.
+2. Verify the comment was authored by the PR owner and posted at-or-after the current head SHA's commit timestamp (re-pushes invalidate prior approvals).
+3. Submit a GitHub approval as the approving runner: _"Peer-approved on behalf of @owner per /ai-auto approve"_.
+4. Advance the WI to `Status__c='Fixed'`.
+
+The owner gets GitHub's native approval notification — no Slack DM (it would look like a self-DM since the runner sent it). Idempotent: re-running the tick after approval is a no-op.
+
+**Setup for peer approval:** every runner whose PRs you want auto-approved AND every runner you want approving on your behalf must be listed in the **Team members** table of [.claude/skills/gus-cli/SKILL.md](../skills/gus-cli/SKILL.md) with their `Github_Username__c` populated.
+
+### Phase notes
+
+**Resolve identity.** First step every tick. Reads cache; falls back to gus-cli skill resolution if cache miss/mismatch.
+
+**Ensure daemons.** Launches the [gha-rerun daemon](../skills/gha-rerun/SKILL.md) if it's not already running. The daemon owns CI rerun budget — without it, transient CI failures escalate to triage immediately.
+
+**Reap stranded worktrees.** Runs before monitoring (single haiku agent). Lists `git worktree list`, and for any worktree on an `<ownerPrefix>/W-` branch whose PR is already `MERGED`/`CLOSED` (e.g. user merged manually, so the WI dropped out of the in-flight query), removes the worktree and deletes the local branch. Skips the main worktree, workflow-isolation worktrees under `.claude/worktrees/`, and branches with no PR (still building). Never errors — partial progress is fine.
+
+**Monitor in-flight.** For each in-flight WI, parses `PR: <url>` out of `Details__c`. Pipeline stage 1 reads PR state; stage 2 decides close/finalize/wait/restart/triage. PRs with no recorded URL are treated as crashed builders (rare). Failed PRs check the `gha-rerun` daemon's retry budget (3 attempts via GitHub `run_attempt`) and only triage once exhausted — otherwise the daemon handles it.
+
+**Close merged WIs.** For WIs whose PR came back `merged` or `closed`, runs one haiku agent each (parallel, idempotent): sets `Status__c='Closed'`, removes the worktree, deletes the local branch.
+
+**Triage failures → Fix CI failures.** Triage classifies one of `flake-or-infra` / `e2e-test-issue` / `code-bug` / `unknown`. Each route runs in parallel: flakes/unknowns DM the runner; e2e issues spawn a fixer using the `analyze-e2e` command and `playwright-e2e` skill; code bugs re-enter a builder agent with the failure context and the original plan.
+
+**Keep in-flight current.** Only for PRs whose `mergeable === 'CONFLICTING'` — not every behind-develop PR. `git fetch origin develop` and merge into the worktree. Conflicts use [merge-conflicts skill](../skills/merge-conflicts/SKILL.md) best-effort; unresolvable conflicts DM the runner. Push if any merge happened. Runs **sequentially** across worktrees — merges can trigger compile/lint/test, and doing many at once crashes the machine.
+
+**Open for review.** Green PRs only. Idempotent: gates each mutation behind a state check. Flips PR out of draft, sets WI to Ready for Review, reassigns reviewers per [.claude/skills/pr-draft/SKILL.md](../skills/pr-draft/SKILL.md), posts to `#ide-exp-code-review` (channel `C054SJJAB24`) tagging the runner, and removes the worktree.
+
+**Peer approve.** Queries `Status__c='Ready for Review'` ai-auto WIs assigned to OTHER runners. For each, looks for the `/ai-auto approve` magic string from the owner (see above), then approves and advances to `Fixed`.
+
+**Pick candidate.** Single-candidate path skips the picker. Multi-candidate path collects the union of changed files across in-flight PRs (via `gh pr diff --name-only`), then asks the picker to honor explicit dependencies (`blocked by W-XXX`), defer file-overlap, prefer smaller story points, tie-break on oldest `CreatedDate`. Excludes any candidate whose `Details__c` already contains a PR URL (would clobber an existing PR).
+
+**Plan.** Writes `.claude/plans/<W-XXX>.md` per the [concise skill](../skills/concise/SKILL.md). Review passes:
+
+1. **Style review** (sequential) — concise, commit messages, verification section, skills include `typescript`
+2. **Effect-advocate plan review** (parallel) — Effect-TS smells in the _approach_ (hand-rolled retry/timeout/cache, untyped errors, services that already exist)
+3. **e2e-advocate plan review** (parallel) — adequacy of e2e test coverage in the plan
+4. **plan-adversary review** (parallel) — highest-likelihood ways the plan is wrong, mis-scoped, or will silently fail
+
+Style revisions apply first; advocate revisions (effect `must`, e2e `must`, adversary `critical`/`high`) apply after in a single revise pass. Then commit.
+
+If the plan determines the WI is unimplementable (can't name files or definition of done), it returns `{verdict: 'blocked'}` and the workflow bounces the WI to `Waiting` with questions DM'd to the runner.
+
+**Build.** One commit per plan phase. Repo hooks (compile/lint/dead-code/LSP/effect) run on tool calls and drive correctness — the agent does not run its own retry loop. `npm install` re-runs if `package-lock.json` changes.
+
+**Review.** Three parallel reads:
+
+- Per-skill detection: for diffs `< 20` lines, only the always-applicable skills (`typescript`, `concise`, `paths`) run. Larger diffs check every skill except those in `REVIEW_SKILL_DENYLIST` (operational/setup skills not relevant to diff review).
+- Thermonuclear code-quality review (file:line evidence required)
+- Effect-advocate diff review
+
+**Verify findings.** All review findings (skill + thermo + effect-advocate) are normalized to a uniform shape, then each is **adversarially verified** by its own agent in parallel (sonnet, worktree-isolated), defaulting to skepticism — analogous to the global `/c` "cite or retract" rule. A finding survives only if its premise is demonstrably true _and_ acting on it adds value beyond CI/automation. Drop rules:
+
+- **False premise** — cited code doesn't do what the finding claims.
+- **CI-redundant** — only asks to _run_ a check CI already gates (Playwright e2e with retries, the stop-hook compile/lint/knip/effect-LS/unit chain). The agent inspects `.github/workflows/` to confirm coverage.
+- **No consumers** — a breaking-API / removed-export / dead-code claim must _prove_ affected consumers exist via [external-consumers skill](../skills/external-consumers/SKILL.md) gh searches across `org:forcedotcom` + `org:salesforcecli` (discounting same-named symbols, the ci-testing mirror, the export site, docs). Zero real consumers → dropped with a `prBodyNote` ("removed unused export, no consumers") instead.
+
+Verdicts: `confirmed` (kept at claimed severity) / `downgraded` (premise holds, lower real severity) / `dropped`. Dropped findings are removed; survivors carry an authoritative `verifiedSeverity` into the fixer.
+
+**Fix review findings.** Consumes the _pre-verified_ findings (premise confirmed, severity corrected, false/redundant/no-consumer ones already gone). Auto-applies all critical and high (including every effect-advocate `must`/`should`). Cheap mediums applied; the rest — plus any `prBodyNote` passthroughs — surface in PR `Reviewer notes`. Then merges `origin/main` — uses [merge-conflicts skill](../skills/merge-conflicts/SKILL.md) best-effort; aborts and returns to caller if unresolvable.
+
+**Draft PR.** Pushes the branch, opens a draft PR per [pr-draft skill](../skills/pr-draft/SKILL.md), appends `PR: <url>` back to `Details__c` (read-modify-write — never replaces existing content), ensures the `gha-rerun` daemon is running. Test plan excludes items covered by new/modified e2e files on the branch.
+
+### Worktrees
+
+Each WI gets an isolated git worktree at `../vscode-auto-wt/<ownerPrefix>-<wiName>-<slug>` on branch `<ownerPrefix>/<wiName>-<slug>`. The build, review, and fix phases all run inside that worktree (via `isolation: 'worktree'` on the agent calls). Worktrees are removed on Open for review; they're left in place when build/plan bounces a WI to `Waiting` so a human can take over.
+
+### Exit codes (return shape)
+
+| `exited`                  | Meaning                                                |
+|---------------------------|--------------------------------------------------------|
+| `identity-failed`         | Couldn't resolve runner identity                       |
+| `at-cap`                  | In-flight count >= `MAX_IN_FLIGHT`; only monitored     |
+| `idle`                    | No candidates; nothing to do                           |
+| `claim-failed`            | Worktree creation or status update failed              |
+| `restart-failed`          | Reattaching worktree for a no-PR WI failed             |
+| `plan-blocked`            | Plan agent determined WI not implementable             |
+| `build-stuck`             | Build agent gave up; worktree preserved for handoff    |
+| `claimed-and-pr-opened`   | Successful tick: new draft PR exists                   |
+
+### Constants
+
+Edit at the top of the script:
+
+| Constant                   | Default                              | Purpose                                    |
+|----------------------------|--------------------------------------|--------------------------------------------|
+| `MAX_IN_FLIGHT`            | `args.maxInFlight ?? 5`              | Concurrent WI cap                          |
+| `SMALL_DIFF_LINES`         | `20`                                 | Below this, only always-applicable skills  |
+| `ALWAYS_APPLICABLE_SKILLS` | `['typescript','concise','paths']`   | Skills checked even on tiny diffs          |
+| `REVIEW_SKILL_DENYLIST`    | (operational skills)                 | Skills excluded from diff review           |
+| `SKILLS_DIR`               | `.claude/skills`                     | Where skills live                          |
+| `REVIEW_CHANNEL_ID`        | `C054SJJAB24`                        | `#ide-exp-code-review` Slack channel       |
+| `PROJECT_ROOT`             | `…/vscode-auto`                      | Worktree parent dir is `../vscode-auto-wt` |
+
+### Related
+
+- [/auto-build-wi command](../skills/auto-build-wi/) — user-facing entry that invokes this workflow
+- [/loop command](https://docs.claude.com/) — schedules recurring runs
+- [gha-rerun daemon](../skills/gha-rerun/SKILL.md) — handles transient CI failures before triage kicks in
+- [gus-cli skill](../skills/gus-cli/SKILL.md) — Team members table is the source of truth for runner identity

--- a/.claude/workflows/auto-build-wi.js
+++ b/.claude/workflows/auto-build-wi.js
@@ -1,0 +1,1738 @@
+export const meta = {
+  name: 'auto-build-wi',
+  description: 'Drain GUS work items tagged [ai-auto] end-to-end: claim → plan → build → review → draft PR. Stateless across ticks; pair with /loop.',
+  whenToUse: 'Run on a schedule via /loop (e.g. /loop 10m /auto-build-wi). Each tick monitors in-flight WIs and may claim a new one.',
+  phases: [
+    { title: 'Resolve identity' },
+    { title: 'Ensure daemons' },
+    { title: 'Reap stranded worktrees' },
+    { title: 'Monitor in-flight' },
+    { title: 'Triage failures' },
+    { title: 'Fix CI failures' },
+    { title: 'Close merged WIs' },
+    { title: 'Keep in-flight current' },
+    { title: 'Open for review' },
+    { title: 'Peer approve' },
+    { title: 'Pick candidate' },
+    { title: 'Claim + worktree' },
+    { title: 'Plan' },
+    { title: 'Build' },
+    { title: 'Review' },
+    { title: 'Verify findings' },
+    { title: 'Fix review findings' },
+    { title: 'Draft PR' },
+  ],
+}
+
+// =====================================================================
+// CONSTANTS
+// =====================================================================
+
+const MAX_IN_FLIGHT = (args && args.maxInFlight) || 5
+const SMALL_DIFF_LINES = 20
+const ALWAYS_APPLICABLE_SKILLS = ['typescript', 'concise', 'paths']
+const SKILLS_DIR = '.claude/skills'
+// Skills not relevant to code review of a diff — operational workflows or environmental setup.
+const REVIEW_SKILL_DENYLIST = [
+  'changelog',
+  'feature-branch',
+  'grill-me',
+  'gus-cli',
+  'merge-conflicts',
+  'pr-draft',
+  'release',
+  'shipped-issues',
+  'query-app-insights',
+  'span-file-export',
+]
+const REVIEW_CHANNEL_ID = 'C054SJJAB24'
+const PR_URL_RE = /https?:\/\/github\.com\/forcedotcom\/apex-language-support\/pull\/\d+/g
+
+// =====================================================================
+// SCHEMAS
+// =====================================================================
+
+const IDENTITY_SCHEMA = {
+  type: 'object',
+  required: ['userId', 'username', 'ownerPrefix', 'slackId', 'githubLogin', 'projectRoot'],
+  properties: {
+    userId: { type: 'string' },
+    username: { type: 'string' },
+    ownerPrefix: { type: 'string' },
+    slackId: { type: 'string' },
+    githubLogin: { type: 'string' },
+    projectRoot: { type: 'string' },
+    error: { type: 'string' },
+  },
+}
+
+const PR_STATE_SCHEMA = {
+  type: 'object',
+  required: ['state'],
+  properties: {
+    state: { enum: ['green', 'failed', 'running', 'no-pr', 'merged', 'closed'] },
+    prUrl: { type: ['string', 'null'] },
+    prNumber: { type: ['number', 'null'] },
+    isDraft: { type: ['boolean', 'null'] },
+    mergeable: { type: ['string', 'null'] },
+    failedJobs: { type: 'array', items: { type: 'string' } },
+    failedLogsExcerpt: { type: ['string', 'null'] },
+    maxRunAttempt: { type: ['number', 'null'] },
+  },
+}
+
+const TRIAGE_SCHEMA = {
+  type: 'object',
+  required: ['route', 'summary'],
+  properties: {
+    route: { enum: ['flake-or-infra', 'e2e-test-issue', 'code-bug', 'unknown'] },
+    summary: { type: 'string' },
+  },
+}
+
+const PLAN_SCHEMA = {
+  type: 'object',
+  required: ['verdict'],
+  properties: {
+    verdict: { enum: ['plan', 'blocked'] },
+    blocked: {
+      type: 'object',
+      properties: { questions: { type: 'array', items: { type: 'string' } } },
+    },
+    plan: {
+      type: 'object',
+      properties: {
+        phases: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['title', 'commitMessage'],
+            properties: {
+              title: { type: 'string' },
+              files: { type: 'array', items: { type: 'string' } },
+              commitMessage: { type: 'string' },
+              detail: { type: 'string' },
+            },
+          },
+        },
+        skills: { type: 'array', items: { type: 'string' } },
+        verification: { type: 'array', items: { type: 'string' } },
+      },
+    },
+  },
+}
+
+const PLAN_REVIEW_SCHEMA = {
+  type: 'object',
+  required: ['approved'],
+  properties: {
+    approved: { type: 'boolean' },
+    revisions: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const EFFECT_ADVOCATE_SCHEMA = {
+  type: 'object',
+  required: ['findings'],
+  properties: {
+    verdict: { enum: ['LGTM', 'minor', 'needs rework'] },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['severity', 'suggestion'],
+        properties: {
+          severity: { enum: ['must', 'should', 'consider'] },
+          file: { type: ['string', 'null'] },
+          line: { type: ['number', 'null'] },
+          suggestion: { type: 'string' },
+          citation: { type: ['string', 'null'] },
+        },
+      },
+    },
+  },
+}
+
+const BUILD_SCHEMA = {
+  type: 'object',
+  required: ['status'],
+  properties: {
+    status: { enum: ['done', 'stuck'] },
+    commits: { type: 'array', items: { type: 'string' } },
+    reason: { type: 'string' },
+  },
+}
+
+const SKILL_DETECT_SCHEMA = {
+  type: 'object',
+  required: ['applies', 'findings'],
+  properties: {
+    applies: { type: 'boolean' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['severity', 'suggestion'],
+        properties: {
+          severity: { enum: ['critical', 'high', 'medium', 'low'] },
+          file: { type: ['string', 'null'] },
+          line: { type: ['number', 'null'] },
+          suggestion: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const THERMO_SCHEMA = {
+  type: 'object',
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['severity', 'claim'],
+        properties: {
+          severity: { enum: ['critical', 'high', 'medium', 'low'] },
+          file: { type: ['string', 'null'] },
+          line: { type: ['number', 'null'] },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const PLAN_ADVERSARY_SCHEMA = {
+  type: 'object',
+  required: ['findings'],
+  properties: {
+    verdict: { enum: ['LGTM', 'concerns', 'blocking'] },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['severity', 'claim'],
+        properties: {
+          severity: { enum: ['critical', 'high', 'medium', 'low'] },
+          section: { type: ['string', 'null'] },
+          claim: { type: 'string' },
+          evidence: { type: ['string', 'null'] },
+          suggestion: { type: ['string', 'null'] },
+        },
+      },
+    },
+  },
+}
+
+const FIXER_SCHEMA = {
+  type: 'object',
+  required: ['fixedCount', 'remaining'],
+  properties: {
+    fixedCount: { type: 'number' },
+    remaining: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['severity', 'note'],
+        properties: {
+          severity: { enum: ['critical', 'high', 'medium', 'low'] },
+          note: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const VERIFY_SCHEMA = {
+  type: 'object',
+  required: ['verdict', 'severity', 'rationale'],
+  properties: {
+    // confirmed: premise verified, keep as-is.
+    // downgraded: real but lower severity than claimed.
+    // dropped: premise false, or already-covered (e.g. CI runs it), or zero affected consumers.
+    verdict: { enum: ['confirmed', 'downgraded', 'dropped'] },
+    severity: { enum: ['critical', 'high', 'medium', 'low'] },
+    rationale: { type: 'string' },
+    evidence: { type: ['string', 'null'] },
+  },
+}
+
+const PR_DRAFT_SCHEMA = {
+  type: 'object',
+  required: ['prUrl', 'prNumber'],
+  properties: {
+    prUrl: { type: 'string' },
+    prNumber: { type: 'number' },
+  },
+}
+
+const PICKER_SCHEMA = {
+  type: 'object',
+  required: ['wiId', 'reason'],
+  properties: { wiId: { type: 'string' }, reason: { type: 'string' } },
+}
+
+const OK_SCHEMA = {
+  type: 'object',
+  required: ['ok'],
+  properties: { ok: { type: 'boolean' }, detail: { type: ['string', 'null'] } },
+}
+
+const WI_RECORDS_SCHEMA = {
+  type: 'object',
+  required: ['records'],
+  properties: {
+    records: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['Id', 'Name'],
+        properties: {
+          Id: { type: 'string' },
+          Name: { type: 'string' },
+          Subject__c: { type: ['string', 'null'] },
+          Details__c: { type: ['string', 'null'] },
+          Status__c: { type: ['string', 'null'] },
+          Story_Points__c: { type: ['number', 'null'] },
+          CreatedDate: { type: ['string', 'null'] },
+          Assignee__c: { type: ['string', 'null'] },
+        },
+      },
+    },
+  },
+}
+
+const WI_STATUS_RECORDS_SCHEMA = {
+  type: 'object',
+  required: ['records'],
+  properties: {
+    records: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['Name'],
+        properties: {
+          Name: { type: 'string' },
+          Status__c: { type: ['string', 'null'] },
+        },
+      },
+    },
+  },
+}
+
+const SKILL_LIST_SCHEMA = {
+  type: 'object',
+  required: ['skills'],
+  properties: { skills: { type: 'array', items: { type: 'string' } } },
+}
+
+const DIFF_RAW_SCHEMA = {
+  type: 'object',
+  required: ['shortstat', 'files'],
+  properties: {
+    shortstat: { type: 'string' },
+    files: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const FILES_SCHEMA = {
+  type: 'object',
+  required: ['files'],
+  properties: { files: { type: 'array', items: { type: 'string' } } },
+}
+
+// =====================================================================
+// HELPERS
+// =====================================================================
+
+const slugify = s =>
+  String(s)
+    .toLowerCase()
+    .replace(/\[ai-auto\]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40)
+    .replace(/-+$/g, '')
+
+const projectBasename = projectRoot => projectRoot.replace(/\/+$/, '').split('/').pop()
+
+const worktreePath = (identity, wiName, subject) =>
+  `${identity.projectRoot}/../${projectBasename(identity.projectRoot)}-wt/${identity.ownerPrefix}-${wiName}-${slugify(subject)}`
+
+const branchName = (ownerPrefix, wiName, subject) =>
+  `${ownerPrefix}/${wiName}-${slugify(subject)}`
+
+const pathsFor = (identity, wi) => ({
+  wt: worktreePath(identity, wi.name, wi.subject),
+  branch: branchName(identity.ownerPrefix, wi.name, wi.subject),
+})
+
+const extractPrUrl = details => {
+  // Only extract PR URLs appended by the workflow (<strong>PR:</strong> <a href="...">).
+  // Avoids treating "Prior art" / reference links as the WI's own PR.
+  const s = String(details || '')
+  const prSection = s.match(/<strong>PR:<\/strong>[\s\S]*?(https?:\/\/github\.com\/forcedotcom\/apex-language-support\/pull\/\d+)/)
+  if (prSection) return prSection[1]
+  return null
+}
+
+// Only match PRs appended by the workflow — formatted as <strong>PR:</strong> <a href="...">
+// This avoids false positives from "Prior art" / reference links in the WI body.
+const hasPrUrl = details =>
+  /<strong>PR:<\/strong>[\s\S]*?github\.com\/forcedotcom\/apex-language-support\/pull\/\d+/.test(
+    String(details || '')
+  )
+
+// A blocker is "satisfied" only once its work has actually merged — i.e. the WI
+// reached a terminal closed/completed status. 'Ready for Review' / 'Fixed' mean
+// the PR exists but hasn't merged, so a dependency in those states is NOT met.
+const isBlockerSatisfied = status =>
+  status === 'Completed' || status.startsWith('Closed')
+
+const stripHtml = s => String(s || '').replace(/<[^>]+>/g, ' ')
+
+// Extract WI names this WI declares a hard dependency on. A blocking keyword
+// ("blocked by", "depends on", "after", "requires", "prerequisite") opens a
+// short window; every W-number inside that window is a blocker — captures
+// chained refs ("blocked by W-1 and W-2"). HTML is stripped first; sentence
+// boundaries close the window so unrelated later refs aren't swept in.
+const BLOCKER_RE =
+  /(?:blocked by|depends on|dependent on|prerequisite|requires?|\bafter\b|\bonce\b)([^.\n]{0,80})/gi
+const extractBlockers = (subject, details) => {
+  const text = `${subject || ''} ${stripHtml(details)}`
+  const names = [...text.matchAll(BLOCKER_RE)].flatMap(m =>
+    [...m[1].matchAll(/W-\d+/g)].map(w => w[0])
+  )
+  return [...new Set(names)]
+}
+
+const mapWiRecord = r => ({
+  wiId: r.Id,
+  name: r.Name,
+  subject: r.Subject__c || '',
+  details: r.Details__c || '',
+  status: r.Status__c || '',
+  storyPoints: typeof r.Story_Points__c === 'number' ? r.Story_Points__c : null,
+  createdDate: r.CreatedDate || '',
+  prUrl: extractPrUrl(r.Details__c),
+})
+
+const parseShortstatLines = shortstat => {
+  // e.g. " 3 files changed, 12 insertions(+), 4 deletions(-)"
+  const ins = (shortstat.match(/(\d+)\s+insertion/) || [0, 0])[1]
+  const del = (shortstat.match(/(\d+)\s+deletion/) || [0, 0])[1]
+  return Number(ins) + Number(del)
+}
+
+// Severity rank for sorting/threshold logic. effect 'must'/'should'/'consider'
+// map to critical/high/medium upstream before reaching here.
+const SEVERITY_RANK = { critical: 0, high: 1, medium: 2, low: 3 }
+
+// Flatten every review source (per-skill, thermo, effect-advocate) into one
+// uniform {source, severity, file, line, claim} list the verifier can chew on.
+const normalizeFindings = (skillFindings, skillsToCheck, thermo, effectDiffReview) => {
+  const effectSeverity = s => (s === 'must' ? 'critical' : s === 'should' ? 'high' : 'medium')
+  const skill = skillFindings
+    .map((r, i) => ({ r, name: skillsToCheck[i] }))
+    .filter(({ r }) => r && r.applies)
+    .flatMap(({ r, name }) =>
+      (r.findings || []).map(f => ({
+        source: `skill:${name}`,
+        severity: f.severity,
+        file: f.file ?? null,
+        line: f.line ?? null,
+        claim: f.suggestion,
+      }))
+    )
+  const thermoF = ((thermo && thermo.findings) || []).map(f => ({
+    source: 'thermo',
+    severity: f.severity,
+    file: f.file ?? null,
+    line: f.line ?? null,
+    claim: `${f.claim}${f.evidence ? ` [${f.evidence}]` : ''}`,
+  }))
+  const effectF = ((effectDiffReview && effectDiffReview.findings) || []).map(f => ({
+    source: 'effect',
+    severity: effectSeverity(f.severity),
+    file: f.file ?? null,
+    line: f.line ?? null,
+    claim: `${f.suggestion}${f.citation ? ` [${f.citation}]` : ''}`,
+  }))
+  return [...skill, ...thermoF, ...effectF]
+}
+
+const classifyMonitor = monitorOutcomes => ({
+  toFinalize: monitorOutcomes.filter(r => r && r.decision === 'finalize'),
+  toTriage: monitorOutcomes.filter(r => r && r.decision === 'triage'),
+  toRestart: monitorOutcomes.filter(
+    r => r && (r.decision === 'no-pr-restart' || r.action === 'no-pr-restart')
+  ),
+  toCloseWi: monitorOutcomes.filter(r => r && r.decision === 'close-wi'),
+  toRefresh: monitorOutcomes.filter(
+    r =>
+      r &&
+      r.wi.prUrl &&
+      r.prState &&
+      r.prState.mergeable === 'CONFLICTING' &&
+      r.decision !== 'close-wi'
+  ),
+})
+
+// =====================================================================
+// PROMPTS
+// =====================================================================
+
+const identityPrompt = `Resolve runner identity per .claude/skills/gus-cli/SKILL.md → ## Runner identity.
+
+Schema: {userId, username, ownerPrefix, slackId, githubLogin, projectRoot}.
+
+1. Capture currentProjectRoot = 'pwd' (the workflow runs from the project root). Strip trailing slashes.
+2. 'sf alias list --json' → /^gus$/i. Missing → {error: "no gus alias — run 'sf org login web -a gus'"}. Value = currentUsername.
+3. Read $HOME/.claude/runner-identity.json. Cache hit requires: all 6 fields present, cached username == currentUsername, AND cached projectRoot exists as a directory ('test -d "<cached.projectRoot>"'). On hit, return cached. Stop.
+4. Miss → resolve per skill: query userId, match team table for githubLogin/slackId/ownerPrefix. Sanity-check team row Id == userId; mismatch → {error: "team table Id != User query Id"}. Not in table → {error: "runner '<currentUsername>' not in gus-cli Team members"}. Set projectRoot = currentProjectRoot.
+5. mkdir -p $HOME/.claude; write JSON (all 6 fields). Write failure non-fatal — still return object.
+
+Structured result only.`
+
+const ensureGhaRerunPrompt = `Ensure the gha-rerun daemon is running.
+
+Read .claude/skills/gha-rerun/SKILL.md (and .claude/commands/gha-rerun.md if present) to learn the launcher and how to detect a running daemon (process name, lock file, or state file). Check current state:
+- If running: return {ok: true, detail: "already-running"}.
+- If not: invoke the launcher per the skill, verify it's running, and return {ok: true, detail: "started"}.
+- If launch fails: return {ok: false, detail: "<reason>"}.
+
+Do not configure or rerun anything else. The daemon owns rerun budget; this step just keeps it alive.`
+
+const reapWorktreesPrompt = identity =>
+  `Reap worktrees + branches for WIs whose PRs are already merged/closed (e.g. user merged manually and the WI dropped out of the in-flight query).
+
+Run from ${identity.projectRoot}:
+
+1. List worktrees: 'git worktree list --porcelain'. Parse into entries.
+2. For each entry, find its branch (porcelain 'branch refs/heads/<name>' line). Skip:
+   - The main worktree (path == ${identity.projectRoot})
+   - Any worktree under '${identity.projectRoot}/.claude/worktrees/' (workflow-isolation worktrees, not WI worktrees)
+   - Any worktree whose branch does NOT start with '${identity.ownerPrefix}/W-'
+3. For each remaining (path, branch), find a PR: 'gh pr list --head <branch> --state all --json number,state,url --limit 1'.
+   - No PR found → leave it alone (still being built).
+   - PR state == 'MERGED' or 'CLOSED' → reap:
+     a. 'git worktree remove <path> --force'  (ignore failure)
+     b. 'git branch -D <branch>'              (ignore failure)
+   - PR state == 'OPEN' → leave it alone.
+
+Return {ok: true, detail: '<n reaped>: <comma-separated branch names>'} or {ok: true, detail: 'none'} when nothing to reap. Never error out — partial progress is fine.`
+
+const inFlightQueryPrompt = identity =>
+  `Run this SOQL and return the raw records array.
+
+sf data query --query "SELECT Id, Name, Subject__c, Details__c, Status__c, Story_Points__c, CreatedDate FROM ADM_Work__c WHERE Assignee__c = '${identity.userId}' AND Status__c IN ('In Progress', 'Ready for Review', 'Fixed') AND Subject__c LIKE '%[ai-auto]%'" -o gus --result-format json
+
+Return {records: <result.records as-is>}. No filtering, no transformation.`
+
+const checkPrStatePrompt = wi =>
+  `Check PR state for ${wi.prUrl}.
+
+Run:
+- gh pr view ${wi.prUrl} --json state,isDraft,number,mergeable,statusCheckRollup
+- FIRST check the top-level .state field (PR lifecycle state, NOT to be confused with row .state):
+  - "MERGED" → return state='merged' (no need to inspect statusCheckRollup)
+  - "CLOSED" → return state='closed'
+  - "OPEN" → continue to check evaluation below
+- Capture .mergeable verbatim into the result's mergeable field (string: "MERGEABLE" / "CONFLICTING" / "UNKNOWN").
+- Parse statusCheckRollup. Two row shapes exist:
+  - CheckRun rows expose .conclusion (SUCCESS/FAILURE/NEUTRAL/SKIPPED/CANCELLED/TIMED_OUT) and .status (COMPLETED/IN_PROGRESS/QUEUED/PENDING)
+  - StatusContext rows expose .state (SUCCESS/FAILURE/PENDING/EXPECTED/ERROR) only — no .conclusion
+  Treat each row's effective outcome as: row.conclusion ?? row.state. A null on both = treat as PENDING.
+- Determine overall state:
+  - 'no-pr' if gh fails to find the PR
+  - 'running' if ANY row is IN_PROGRESS / QUEUED / PENDING / EXPECTED (or has no resolved outcome)
+  - 'green' if every row resolves to SUCCESS / NEUTRAL / SKIPPED
+  - 'failed' otherwise (any FAILURE / CANCELLED / TIMED_OUT / ERROR, with NO running rows remaining)
+- If state is 'failed', collect failed job names. Run 'gh run view --log-failed <runId>' for the most recent failed/cancelled run linked to the PR head SHA, capture last ~100 lines as failedLogsExcerpt. Also gather the maximum 'run_attempt' across the workflow runs for the PR head SHA (gh api repos/forcedotcom/apex-language-support/actions/runs?head_sha=<sha> → max .run_attempt). Return that as maxRunAttempt.
+
+Return ONLY the structured result.`
+
+const closeMergedPrompt = (r, identity) => {
+  const { wt, branch } = pathsFor(identity, r.wi)
+  return `WI ${r.wi.name} has its PR (${r.wi.prUrl}) ${r.prState.state} on GitHub. Close out.
+
+Steps (idempotent):
+1. If WI Status__c is not already a closed terminal value, update:
+   sf data update record -s ADM_Work__c -i ${r.wi.wiId} -o gus -v "Status__c='Closed'"
+2. Remove worktree if present: 'git worktree remove ${wt} --force'.
+3. Delete local branch if present: from ${identity.projectRoot}, 'git branch -D ${branch}' (ignore failure if branch doesn't exist).
+
+Return {ok: true, detail} summarizing changes.`
+}
+
+const triageCiPrompt = (r, identity) => {
+  const { wt } = pathsFor(identity, r.wi)
+  return `Triage CI failure on PR ${r.wi.prUrl} for WI ${r.wi.name}.
+
+Failed jobs: ${(r.prState.failedJobs || []).join(', ')}
+Log excerpt:
+${r.prState.failedLogsExcerpt || '(none)'}
+
+Worktree path: ${wt}
+
+Tasks:
+1. Reattach to the worktree (recreate via 'git worktree add <path> <branch>' if missing; run 'npm install' if package-lock.json differs).
+2. Inspect the failure vs. the diff ('git diff origin/main...HEAD').
+3. Classify:
+   - 'flake-or-infra' if the failure is unrelated to the diff (network, infra, transient)
+   - 'e2e-test-issue' if the failure is in e2e test code itself (selector drift, race, etc.) and the fix is contained to e2e files
+   - 'code-bug' if the failure indicates a real bug in the source under change (cross-OS path bug, runtime mismatch, logic bug, etc.)
+   - 'unknown' if you cannot decide
+
+Return ONLY the structured result.`
+}
+
+const dmCiFailurePrompt = (r, identity) =>
+  `DM the runner about a CI failure that needs human attention.
+
+Slack ID: ${identity.slackId}
+Use mcp__slack__slack_send_message to send a DM with content:
+"⚠️ ${r.wi.name} CI failed after rerun budget exhausted (route=${r.triage.route}): ${r.triage.summary}\nPR: ${r.wi.prUrl}"
+
+Return {ok: true} on success.`
+
+const e2eFixPrompt = (r, identity) => {
+  const { wt } = pathsFor(identity, r.wi)
+  return `Fix an e2e test failure in worktree ${wt} for WI ${r.wi.name}.
+
+Use the analyze-e2e command and the playwright-e2e skill. Inspect failing job logs (gh run view --log-failed) and the e2e test code in the worktree. Make the fix, commit with message "fix(e2e): <brief> - ${r.wi.name}", and push.
+
+Failed jobs: ${(r.prState.failedJobs || []).join(', ')}
+Log excerpt:
+${r.prState.failedLogsExcerpt || '(none)'}
+
+Return {status: 'done', commits: [<sha>], reason?} on success or {status: 'stuck', reason} otherwise.`
+}
+
+const codeFixPrompt = (r, identity) => {
+  const { wt } = pathsFor(identity, r.wi)
+  return `Fix a code bug exposed by CI in worktree ${wt} for WI ${r.wi.name}.
+
+Read the original plan at .claude/plans/${r.wi.name}.md. The failure indicates the code under change is wrong (cross-OS, cross-runtime, or logic bug).
+
+Failed jobs: ${(r.prState.failedJobs || []).join(', ')}
+Log excerpt:
+${r.prState.failedLogsExcerpt || '(none)'}
+
+Apply the appropriate skills (read frontmatter from .claude/skills/*/SKILL.md to pick relevant ones; always apply: typescript, paths). Repo hooks run on tool calls and will surface compile/lint/dead-code/LSP issues — use that signal to drive correctness; don't run your own retry loop. Commit each logical fix as a separate commit. Push when done.
+
+Return {status: 'done', commits} or {status: 'stuck', reason}.`
+}
+
+const refreshBranchPrompt = (r, identity) => {
+  const { wt, branch } = pathsFor(identity, r.wi)
+  return `Keep WI ${r.wi.name}'s branch current with origin/main.
+
+Worktree: ${wt}
+Branch: ${branch}
+PR: ${r.wi.prUrl}
+
+Steps (idempotent; skip work if already current):
+1. Reattach worktree if missing: 'git worktree add <path> <branch>'.
+2. cd worktree && git fetch origin main
+3. If 'git rev-list --count HEAD..origin/main' is 0, return {ok: true, detail: "already current"}.
+4. git merge origin/main --no-edit
+5. Conflicts → apply .claude/skills/merge-conflicts/SKILL.md best-effort. Unresolvable → 'git merge --abort' and DM ${identity.slackId} via mcp__slack__slack_send_message: "⚠️ ${r.wi.name} merge conflict with main — manual intervention needed\\nWorktree: <path>\\nPR: ${r.wi.prUrl}". Return {ok: false, detail: "merge-conflict-unresolved"}.
+6. If package-lock.json changed, run 'npm install'.
+7. git push
+
+Return {ok: true, detail: "<n> commits merged"} or {ok: false, detail}.`
+}
+
+const openReviewPrompt = (r, identity) => {
+  const { wt } = pathsFor(identity, r.wi)
+  return `Open WI ${r.wi.name} for review (CI is green; transition In Progress → Ready for Review).
+
+PR: ${r.wi.prUrl}
+Worktree: ${wt}
+Runner userId: ${identity.userId}
+Runner GitHub login: ${identity.githubLogin}
+Runner Slack ID: ${identity.slackId}
+
+Monitor only enters this phase when WI is 'In Progress' — no need to re-check status.
+
+Steps (idempotent):
+1. If PR is still draft: 'gh pr ready ${r.wi.prUrl}'.
+2. Advance WI status:
+   sf data update record -s ADM_Work__c -i ${r.wi.wiId} -o gus -v "Status__c='Ready for Review' QA_Engineer__c='${identity.userId}'"
+3. Reviewer reassignment per pr-draft skill (read .claude/skills/pr-draft/SKILL.md):
+   - gh pr view ${r.wi.prUrl} --json reviewRequests --jq '.reviewRequests[].login'
+   - For each existing reviewer that isn't ${identity.githubLogin}: 'gh pr edit ${r.wi.prUrl} --remove-reviewer <login>'
+   - 'gh pr edit ${r.wi.prUrl} --add-reviewer ${identity.githubLogin}' (if not already)
+4. Slack post in #ide-exp-code-review (channel ${REVIEW_CHANNEL_ID}) tagging the runner:
+   "<@${identity.slackId}> PR ready for review: <${r.wi.prUrl}|PR> (${r.wi.name})"
+   Use mcp__slack__slack_send_message.
+5. Remove the worktree: 'git worktree remove ${wt} --force' (if present).
+
+Return {ok: true, detail} where detail summarizes what changed.`
+}
+
+const peerApproveQueryPrompt = identity =>
+  `Run this SOQL and return the raw records array.
+
+sf data query --query "SELECT Id, Name, Subject__c, Details__c, Assignee__c FROM ADM_Work__c WHERE Status__c = 'Ready for Review' AND Assignee__c != '${identity.userId}' AND Subject__c LIKE '%[ai-auto]%'" -o gus --result-format json
+
+Return {records: <result.records as-is>}. No filtering, no transformation.`
+
+const peerApprovePrompt = (c, identity) =>
+  `Evaluate WI ${c.name} (PR ${c.prUrl}) for peer-approve. Owner userId: ${c.ownerUserId}. Runner: ${identity.username} (userId ${identity.userId}, GitHub ${identity.githubLogin}, Slack ${identity.slackId}).
+
+Magic string: a PR comment matching line-anchored regex /^\\/ai-auto approve\\b/m authored by the PR owner, posted at-or-after the current head SHA's commit timestamp.
+
+Steps (idempotent — every step skips if already done):
+
+1. Resolve owner GitHub login from gus-cli team table (read .claude/skills/gus-cli/SKILL.md if needed):
+   sf data query --query "SELECT Github_Username__c FROM ADM_Scrum_Team_Member__c WHERE Id = '${c.ownerUserId}'" -o gus --result-format json
+   If the team row is missing or has no Github_Username__c, ABORT with {ok: false, detail: "owner not in team table"}.
+
+2. Resolve PR head SHA + commit timestamp + author:
+   gh pr view ${c.prUrl} --json headRefOid,author,isDraft,state,commits
+   - If isDraft=true, state!='OPEN', or PR is closed/merged → skip: {ok: true, detail: "pr-not-eligible"}.
+   - If author.login != owner GitHub login (mismatch between WI Assignee and PR author) → skip: {ok: true, detail: "owner/author mismatch"}.
+   - Get head SHA's authoredDate from commits[].oid==headRefOid → committedDate (or use 'gh api repos/forcedotcom/apex-language-support/commits/<sha>' → .commit.committer.date).
+
+3. Fetch issue comments:
+   gh api repos/forcedotcom/apex-language-support/issues/<prNumber>/comments --paginate
+   Filter to comments where:
+   - user.login == owner GitHub login
+   - body matches /^\\/ai-auto approve\\b/m (line-anchored, multiline)
+   - created_at >= head SHA committed date
+   If none → skip: {ok: true, detail: "no-magic-string"}.
+
+4. Idempotency: check existing reviews:
+   gh api repos/forcedotcom/apex-language-support/pulls/<prNumber>/reviews --paginate
+   If runner (${identity.githubLogin}) already has an APPROVED review with commit_id == head SHA → skip: {ok: true, detail: "already-approved"}.
+
+5. Submit approval:
+   gh pr review ${c.prUrl} --approve --body "Peer-approved on behalf of @<ownerLogin> per /ai-auto approve"
+
+6. Update WI Status__c to 'Fixed' — only if current is 'Ready for Review' (forward-only):
+   sf data query --query "SELECT Status__c FROM ADM_Work__c WHERE Id = '${c.wiId}'" -o gus --result-format json
+   If Status__c == 'Ready for Review':
+     sf data update record -s ADM_Work__c -i ${c.wiId} -o gus -v "Status__c='Fixed'"
+
+The owner gets GitHub's native approval notification — no Slack DM (it would look like a DM from the runner machine).
+
+Return {ok: true, detail: "<approved | skip reason>"} or {ok: false, detail}.`
+
+const candidatesQueryPrompt = identity =>
+  `Run EXACTLY ONE SOQL query — the one below — and return its records.
+
+sf data query --query "SELECT Id, Name, Subject__c, Details__c, Status__c, Assignee__c, Story_Points__c, CreatedDate FROM ADM_Work__c WHERE Assignee__c = '${identity.userId}' AND Status__c IN ('New','Ready','Triaged') AND Subject__c LIKE '%[ai-auto]%' ORDER BY CreatedDate ASC LIMIT 50" -o gus --result-format json
+
+Return {records: <result.records, verbatim>}.
+
+HARD RULES:
+- Do NOT run any other queries. If this query returns zero records, return {records: []}. An empty result is a valid, expected outcome — not a problem to investigate.
+- Do NOT modify the WHERE clause, drop filters, or broaden the search.
+- Do NOT add, remove, or transform fields in the records.`
+
+const blockerStatusQueryPrompt = wiNames =>
+  `Run EXACTLY ONE SOQL query — the one below — and return its records.
+
+sf data query --query "SELECT Name, Status__c FROM ADM_Work__c WHERE Name IN (${wiNames
+    .map(n => `'${n}'`)
+    .join(',')})" -o gus --result-format json
+
+Return {records: <result.records, verbatim>}.
+
+HARD RULES:
+- Do NOT run any other queries. Zero records is valid — return {records: []}.
+- Do NOT modify the WHERE clause or transform fields.`
+
+const prFilesPrompt = url =>
+  `Run 'gh pr diff ${url} --name-only' and return {files: [<one path per line>]}.`
+
+const pickWiPrompt = (candidateList, inFlightFileList) =>
+  `Pick the next WI to work on from these candidates.
+
+Candidates (JSON):
+${JSON.stringify(candidateList, null, 2)}
+
+Files already touched by in-flight PRs (avoid overlap when possible):
+${inFlightFileList.join(', ') || 'none'}
+
+Candidates with unmet hard dependencies were already filtered out upstream — every WI here is unblocked.
+
+Selection rules (in order):
+1. If a candidate's likely files (inferred from Subject/Details) overlap heavily with in-flight files, defer it.
+2. Prefer smaller Story_Points (null treated as 5).
+3. Tie-break by oldest CreatedDate.
+
+Return ONLY {wiId, reason}.`
+
+const claimOrRestartPrompt = (chosen, identity, isRestart) => {
+  const { wt, branch } = pathsFor(identity, chosen)
+  if (isRestart) {
+    return `Reattach the worktree for in-flight WI ${chosen.name} that has no PR yet (build crashed in a prior tick). WI is already 'In Progress' — do not change its Status.
+
+Worktree: ${wt}
+Branch: ${branch}
+
+Steps (idempotent):
+1. From ${identity.projectRoot}: 'git fetch origin main'.
+2. Ensure a worktree is checked out at ${wt} for ${branch}:
+   - If ${wt} already exists, leave it alone (skip to step 3).
+   - Else if branch exists locally ('git rev-parse --verify ${branch}'): 'git worktree add ${wt} ${branch}'.
+   - Else if branch exists on origin ('git ls-remote --exit-code --heads origin ${branch}'): 'git worktree add ${wt} -b ${branch} origin/${branch}'.
+   - Else (no branch anywhere): 'git worktree add -b ${branch} ${wt} origin/main --no-track'.
+3. cd ${wt} && npm install.
+
+Return {ok: false, detail} on failure, else {ok: true, detail: "reattached"}.`
+  }
+  return `Claim WI ${chosen.name} (${chosen.wiId}) and set up the worktree.
+
+Step 0 — concurrent-claim guard (run FIRST, before any writes):
+  git ls-remote --exit-code --heads origin ${branch}
+  If the branch EXISTS on origin:
+    gh pr list --head ${branch} --state open --json number,url --limit 1 --repo forcedotcom/apex-language-support
+    If an open PR is found → return {ok: false, detail: "concurrent-claim-detected: branch ${branch} already has open PR <url>"}.
+    If no open PR → the branch exists but has no open PR (prior build crashed); continue with steps below treating it as a fresh start (do NOT create the branch again in step 2 — use 'git worktree add ${wt} -b ${branch} origin/${branch}' instead).
+
+Steps:
+1. Update WI:
+   sf data update record -s ADM_Work__c -i ${chosen.wiId} -o gus -v "Status__c='In Progress'"
+2. From ${identity.projectRoot}, run:
+   git fetch origin main
+   If branch does NOT exist on origin: git worktree add -b ${branch} ${wt} origin/main --no-track
+   Else (branch exists on origin, no open PR): git worktree add ${wt} -b ${branch} origin/${branch}
+3. cd ${wt} && npm install (deps may differ from origin/main's lockfile and hooks need them).
+
+If any step fails, return {ok: false, detail: "<reason>"}. On success {ok: true, detail: "claimed"}.`
+}
+
+const listSkillsPrompt = identity =>
+  `Run 'ls -1 ${SKILLS_DIR}' from ${identity.projectRoot} and return {skills: [<one entry per line, no blanks>]}.`
+
+const planPrompt = (chosen, identity, skillList) => {
+  const { wt } = pathsFor(identity, chosen)
+  return `Plan implementation for WI ${chosen.name} in worktree ${wt}.
+
+WI Subject: ${chosen.subject}
+WI Details:
+${chosen.details || '(empty)'}
+
+Available skills (read each .claude/skills/<name>/SKILL.md frontmatter as needed to choose relevant ones):
+${skillList.join(', ')}
+
+BEFORE doing anything else, Read ${wt}/.claude/skills/concise/SKILL.md and apply that style to every word you write in the plan file: fragments/bullets, not full sentences; remove words without altering meaning; cut repetition; shorter synonyms.
+
+Restart-aware: this may be a re-run after a prior crash. First check whether ${wt}/.claude/plans/${chosen.name}.md already exists AND is tracked in git ('git ls-files --error-unmatch .claude/plans/${chosen.name}.md' from ${wt}). If it exists and is tracked, treat the plan as already authored — read it, return {verdict: 'plan', plan: {phases, skills, verification}} reflecting its contents, do NOT rewrite the file.
+
+Otherwise:
+1. Decide if the WI is implementable: can you name (a) what files/area to touch and (b) a definition of done? If either is genuinely unknowable, return {verdict: 'blocked', blocked: {questions: [...]}} with concrete questions.
+2. Otherwise, write the plan to ${wt}/.claude/plans/${chosen.name}.md in the concise style you just read. Sections: Context, Phases (each phase = one commit; include commit message), Skills to apply, Verification (excluding things covered by e2e tests on the branch — note which are e2e-covered).
+3. Return {verdict: 'plan', plan: {phases, skills, verification}}.
+
+Do not commit yet.`
+}
+
+const bouncePlanPrompt = (chosen, planResult, identity) => {
+  const { wt } = pathsFor(identity, chosen)
+  return `Bounce WI ${chosen.name} to Waiting and DM the runner.
+
+Steps:
+1. Update WI:
+   sf data update record -s ADM_Work__c -i ${chosen.wiId} -o gus -v "Status__c='Waiting'"
+2. DM ${identity.slackId} via mcp__slack__slack_send_message:
+   "🚧 ${chosen.name} bounced to Waiting (plan blocked): ${chosen.subject}\\nQuestions:\\n${(planResult.blocked && planResult.blocked.questions || []).map(q => `• ${q}`).join('\\n')}\\nRun /grill-me to refine."
+3. Remove worktree: 'git worktree remove ${wt} --force'.
+Return {ok: true}.`
+}
+
+const planReviewPrompt = (chosen, identity) => {
+  const { wt } = pathsFor(identity, chosen)
+  return `Review the plan at ${wt}/.claude/plans/${chosen.name}.md.
+
+BEFORE judging, Read ${wt}/.claude/skills/concise/SKILL.md so 'concise style' is concrete to you.
+
+Enforce:
+- concise skill style (the rules you just read)
+- Each phase has a clear commit message
+- Verification section exists and notes which items are e2e-covered
+- Skills list is non-empty and includes typescript
+
+Return {approved: true} or {approved: false, revisions: [...]}.`
+}
+
+const planRevisePrompt = (chosen, identity, revisions) => {
+  const { wt } = pathsFor(identity, chosen)
+  return `Revise the plan at ${wt}/.claude/plans/${chosen.name}.md addressing:
+${(revisions || []).map(r => `- ${r}`).join('\n')}
+
+Return {verdict: 'plan'} when done.`
+}
+
+const effectPlanReviewPrompt = (chosen, identity) => {
+  const { wt } = pathsFor(identity, chosen)
+  return `Review the plan at ${wt}/.claude/plans/${chosen.name}.md (mode: plan review). Identify Effect-TS smells the plan would introduce — hand-rolled retry/timeout/cache, untyped errors, ad-hoc PubSub, services that already exist in packages/custom-services or packages/lsp-compliant-services, etc.
+
+Return ONLY the structured result.`
+}
+
+const e2ePlanReviewPrompt = (chosen, identity) => {
+  const { wt } = pathsFor(identity, chosen)
+  return `Review the plan at ${wt}/.claude/plans/${chosen.name}.md for e2e test coverage adequacy.
+
+WI Subject: ${chosen.subject}
+WI Details:
+${chosen.details || '(empty)'}
+
+Return ONLY the structured result.`
+}
+
+const adversaryPlanReviewPrompt = (chosen, identity) => {
+  const { wt } = pathsFor(identity, chosen)
+  return `Adversarially review the plan at ${wt}/.claude/plans/${chosen.name}.md.
+
+WI Subject: ${chosen.subject}
+WI Details:
+${chosen.details || '(empty)'}
+
+Return ONLY the structured result.`
+}
+
+const planAdvocateRevisePrompt = (chosen, identity, advocateRevisions) => {
+  const { wt } = pathsFor(identity, chosen)
+  return `Revise the plan at ${wt}/.claude/plans/${chosen.name}.md to address these advocate findings before implementation. The plan must reflect the right approach (Effect idioms, e2e coverage, adversarial concerns), not work around them.
+
+Findings:
+${advocateRevisions.map(r => `- ${r}`).join('\n')}
+
+Return {verdict: 'plan'} when done.`
+}
+
+const commitPlanPrompt = (chosen, identity) => {
+  const { wt } = pathsFor(identity, chosen)
+  return `Commit the plan file in ${wt} — only if there is something to commit.
+
+Steps:
+1. cd ${wt}
+2. git add .claude/plans/${chosen.name}.md
+3. If 'git diff --cached --quiet' returns 0 (nothing staged), skip the commit and return {ok: true, detail: "no-op (plan unchanged)"}.
+4. Else commit with subject "chore: plan for ${chosen.name}". Use a HEREDOC so the Co-Authored-By trailer with YOUR actual model name is preserved (the same trailer you append on any normal commit). Return {ok: true, detail: "committed"}.`
+}
+
+const buildPrompt = (chosen, identity) => {
+  const { wt } = pathsFor(identity, chosen)
+  return `Build WI ${chosen.name} per the plan at ${wt}/.claude/plans/${chosen.name}.md.
+
+Operate inside ${wt}. Execute each plan phase end-to-end and commit per the plan's commit-message boundaries (one commit per phase). Apply the skills listed in the plan.
+
+Repo hooks run on tool calls and will surface compile / lint / dead-code / LSP / effect issues — use that feedback to drive correctness. Do NOT run your own retry counter. If you genuinely cannot make progress, return {status: 'stuck', reason}.
+
+If 'package-lock.json' changes during build, re-run 'npm install'.
+
+Return {status: 'done', commits: [<shas>]} on success.`
+}
+
+const bounceBuildPrompt = (chosen, buildResult, identity) => {
+  const { wt, branch } = pathsFor(identity, chosen)
+  return `Bounce WI ${chosen.name} to Waiting (build stuck) and DM the runner. Worktree stays for human takeover.
+
+Steps:
+1. Update WI: sf data update record -s ADM_Work__c -i ${chosen.wiId} -o gus -v "Status__c='Waiting'"
+2. DM ${identity.slackId} via mcp__slack__slack_send_message:
+   "⚠️ ${chosen.name} build stuck: ${(buildResult.reason || '').replace(/"/g, "'")}\\nWorktree: ${wt}\\nBranch: ${branch}"
+Return {ok: true}.`
+}
+
+const diffPrompt = wt =>
+  `From ${wt}, run both:
+- git diff --shortstat origin/main...HEAD
+- git diff --name-only origin/main...HEAD
+
+Return {shortstat: "<raw stdout of --shortstat, may be empty>", files: [<one path per line of --name-only>]}.`
+
+const skillDetectPrompt = (skill, wt) =>
+  `Decide if skill '${skill}' applies to the current branch's diff in ${wt}.
+
+Read .claude/skills/${skill}/SKILL.md.
+Examine: git diff origin/main...HEAD (run from ${wt}).
+
+Answer:
+- applies: true if the diff intersects this skill's domain
+- findings: concrete code-level changes that would improve the code per this skill, severity-graded. If applies but no actionable findings, return findings: [].
+
+Return ONLY the structured result.`
+
+const thermoPrompt = wt =>
+  `Run a rigorous, severity-graded code-quality review on the diff in ${wt}.
+
+Examine 'git diff origin/main...HEAD' and review it adversarially for correctness bugs, regressions, resource/lifecycle issues, error-handling gaps, concurrency hazards, security problems, and reuse/simplification opportunities. Be thorough and skeptical — do not rubber-stamp. Return severity-graded findings only — file:line evidence required.`
+
+const effectDiffReviewPrompt = wt =>
+  `Review the diff in ${wt} (mode: diff review). Examine 'git diff origin/main...HEAD'.`
+
+const verifyFindingPrompt = (wt, finding) =>
+  `Adversarially verify ONE code-review finding against the diff in ${wt}. Default to skepticism: a finding survives only if its premise is demonstrably true AND acting on it adds value beyond what CI/automation already provides.
+
+Finding (source: ${finding.source}):
+${JSON.stringify({ severity: finding.severity, file: finding.file, line: finding.line, claim: finding.claim }, null, 2)}
+
+Establish the premise with EVIDENCE, not assumption. Read the cited file:line and 'git diff origin/main...HEAD' in ${wt}.
+
+Verdict rules:
+- **dropped** if ANY of:
+  - The premise is false (cited code doesn't do what the finding claims).
+  - It only asks to RUN tests/checks that CI already runs on the PR. CI runs Playwright e2e (with retries) and the stop-hook chain (compile/lint/knip/effect-LS/unit) as gating checks — re-running them by hand before merge is redundant. Inspect '.github/workflows/' in ${wt} to confirm what CI covers; a "run X before merge" finding where X is a gating CI job → dropped.
+  - It claims a BREAKING API change / removed export / dead code. PROVE affected consumers exist before keeping it. Read .claude/skills/external-consumers/SKILL.md and run its gh searches across org:forcedotcom and org:salesforcecli for the exact removed symbol AND its public-export form (e.g. workspaceContextUtils.<name>). Discount false positives (unrelated same-named symbols, the ci-testing mirror repo, the export site itself, plan/doc files). Zero real consumers → dropped (note "removed unused export, no consumers" for the PR body instead).
+- **downgraded** if the premise holds but the real severity is lower than claimed (e.g. theoretical edge, no user-facing impact). Downgrade to 'low' — do NOT drop. A correct fix with no user-facing impact (misleading comment, dead/no-op config line, stale rationale) is still worth applying for free; keep it as a low-severity 'confirmed' or 'downgraded', never 'dropped'.
+- **confirmed** if premise verified and the fix is correct. "Adds genuine value" includes trivially-correct cleanups (delete a no-op line, fix a misleading comment) — these are cheap and unambiguous, so confirm them at low severity rather than discarding.
+
+'dropped' is ONLY for findings that are FALSE, ALREADY-COVERED (CI re-run), or ZERO-CONSUMER. A true-but-minor finding is low severity, not dropped.
+
+Return ONLY the structured result. 'severity' = the corrected severity (== claimed if confirmed). 'evidence' = file:line or gh-search summary that grounds the verdict.`
+
+const fixerPrompt = (wt, verifiedFindings) =>
+  `Apply review findings to the code in ${wt}.
+
+Each finding was already adversarially verified — premise confirmed, severity corrected, false/redundant/no-consumer findings already removed. 'verifiedSeverity' is authoritative; 'rationale'/'evidence' explain why it survived.
+
+Verified findings (JSON):
+${JSON.stringify(verifiedFindings, null, 2)}
+
+Rules:
+- Auto-apply ALL critical and high severity findings.
+- Auto-apply ALL medium / low findings too — these survived adversarial verification, so the premise is already confirmed. Default to APPLYING, not surfacing. This explicitly includes trivial mechanical edits: deleting a no-op/dead config line, fixing or removing a misleading/stale comment, renaming for clarity. "Low value" is NOT a reason to skip — if the edit is unambiguous and self-contained, just make it.
+- Surface to 'remaining' ONLY when applying would be genuinely risky or ambiguous: the fix requires a design decision, spans many files, changes public behavior, or you cannot determine the correct change with confidence. State which of these applies in the note.
+- A finding may carry a 'prBodyNote' (e.g. "removed unused export, no consumers") instead of a code change — pass those straight into 'remaining' so they land in the PR body, no edit needed.
+
+Group commits logically: e.g. one commit "fix: critical/high review findings", one "refactor: medium/low review findings". If nothing to fix, return {fixedCount: 0, remaining: [...]}.
+
+Return ONLY the structured result.`
+
+const mergeDevelopPrompt = wt =>
+  `Merge origin/main into the branch in ${wt}.
+
+Steps:
+1. cd ${wt}
+2. git fetch origin main
+3. git merge origin/main --no-edit
+4. If conflicts, apply .claude/skills/merge-conflicts/SKILL.md best-effort. If unresolvable: 'git merge --abort' and return {ok: false, detail: "merge-conflict-unresolved"}.
+5. If package-lock.json changed in the merge, run 'npm install'.
+6. If the merge ran cleanly with no conflicts, no commit needed beyond the merge commit git already made.
+Return {ok: true} on success.`
+
+const draftPrPrompt = (chosen, identity, fixerResult) => {
+  const { wt, branch } = pathsFor(identity, chosen)
+  return `Push the branch and open a draft PR for WI ${chosen.name}.
+
+Worktree: ${wt}
+Branch: ${branch}
+WI Subject: ${chosen.subject}
+Plan path (in repo): .claude/plans/${chosen.name}.md
+Remaining review notes (medium/low not auto-fixed):
+${JSON.stringify(fixerResult.remaining || [], null, 2)}
+
+Steps:
+1. cd ${wt}
+2. git push -u origin ${branch}
+3. Read .claude/skills/pr-draft/SKILL.md for title/body conventions. Title format: 'type(scope): description - ${chosen.name}'.
+4. Compose body. Sections (markdown):
+   - ## Summary — 1–3 bullets distilled from the plan
+   - ## Plan — link to .claude/plans/${chosen.name}.md
+   - ## Reviewer notes — list the remaining findings (skip if empty)
+   - ## Test plan — items from the plan's verification section, EXCLUDING items covered by new/modified e2e tests on the branch (inspect 'git diff --name-only origin/main...HEAD' for files matching '**/e2e/**' or '*.e2e.*' or 'packages/*-e2e/**' to determine coverage)
+   - GUS reference per pr-draft skill
+   - Footer: '🤖 Generated by auto-build pipeline. Original WI: <gus link>'
+5. Before creating the PR, check for an existing open PR on this branch:
+   gh pr list --head ${branch} --state open --json number,url --limit 1 --repo forcedotcom/apex-language-support
+   If one exists → skip gh pr create. Use that existing PR's url/number as the result. Skip to step 7.
+6. Create draft PR: gh pr create --draft --title "<title>" --body "<body>" --base main
+   Take the PR URL from gh's output.
+7. Append a PR link to the WI Details__c. CRITICAL: do NOT replace Details__c — read it first, then APPEND.
+   a. Fetch existing: \`sf data query --query "SELECT Details__c FROM ADM_Work__c WHERE Id = '${chosen.wiId}'" -o gus --result-format json\`. Parse \`result.records[0].Details__c\` (may be null/empty).
+   b. If existing already contains this exact PR URL, skip the update (idempotent — return success).
+   c. Compose new value: take the existing Details__c (or empty string if null), then concatenate this exact HTML snippet, with PR_URL replaced by the actual URL string from gh (e.g. https://github.com/forcedotcom/apex-language-support/pull/7382) and PR_NUMBER replaced by the integer:
+        <p><strong>PR:</strong> <a href="PR_URL">#PR_NUMBER</a></p>
+      VERIFY before writing: the substring 'href="https://github.com/forcedotcom/apex-language-support/pull/' must appear in your new value. If 'href=""' appears anywhere in the appended snippet, you have failed substitution — abort and return {prUrl, prNumber} only after fixing it. Do NOT preserve angle-bracket placeholders like <prUrl> or <prNumber> in the output.
+   d. Write via --flags-dir to handle quotes safely:
+      - mkdir -p /tmp/gus-flags-${chosen.name}
+      - Write a SINGLE-LINE file at /tmp/gus-flags-${chosen.name}/values. Format: Details__c="<NEW_VALUE>" using double-quotes around the value. Inside the value, all HTML attribute quotes must remain as plain double-quotes (the file uses single-quote-shell-escaping at the sf CLI layer; per gus-cli skill, single-line values with double-quote outer + literal double-quote inner work). If the existing Details__c contains a literal " character that would break the value file, fall back to appending using the plain-text form: Details__c='<existing-stripped>\\nPR: <prUrl>' but log a warning that the original HTML was lossy.
+      - sf data update record -s ADM_Work__c -i ${chosen.wiId} -o gus --flags-dir /tmp/gus-flags-${chosen.name}
+   e. Verify: re-query Details__c and confirm BOTH (i) the new PR URL is present AND (ii) at least one original Goal/Done-when/Why marker from the prior content is still present. If either check fails, do NOT claim success — log the failure detail and return so the workflow retries next tick.
+
+Return {prUrl, prNumber}.`
+}
+
+// =====================================================================
+// PHASE FUNCTIONS
+// =====================================================================
+
+const resolveIdentity = async () => {
+  phase('Resolve identity')
+  return await agent(identityPrompt, {
+    schema: IDENTITY_SCHEMA,
+    label: 'resolve-identity',
+    model: 'haiku',
+  })
+}
+
+const ensureDaemons = async () => {
+  phase('Ensure daemons')
+  await agent(ensureGhaRerunPrompt, {
+    schema: OK_SCHEMA,
+    label: 'ensure-gha-rerun-daemon',
+    phase: 'Ensure daemons',
+    model: 'haiku',
+  })
+}
+
+const reapStrandedWorktrees = async identity => {
+  phase('Reap stranded worktrees')
+  await agent(reapWorktreesPrompt(identity), {
+    schema: OK_SCHEMA,
+    label: 'reap-stranded-worktrees',
+    phase: 'Reap stranded worktrees',
+    model: 'haiku',
+  })
+}
+
+const monitorInFlight = async identity => {
+  phase('Monitor in-flight')
+
+  const inFlightRaw = await agent(inFlightQueryPrompt(identity), {
+    schema: WI_RECORDS_SCHEMA,
+    label: 'query-in-flight',
+    phase: 'Monitor in-flight',
+    model: 'haiku',
+  })
+
+  // Include all in-flight WIs — with and without a PR URL. No-PR 'In Progress' WIs are active
+  // builds that crashed before opening a PR; they need to count toward the cap and be restarted.
+  const inFlightWis = (inFlightRaw.records || []).map(mapWiRecord)
+  log(`in-flight: ${inFlightWis.length} WI(s) — ${inFlightWis.map(w => `${w.name}(${w.status})`).join(', ')}`)
+
+  const monitorOutcomes = await pipeline(
+    inFlightWis,
+    async wi => {
+      if (!wi.prUrl) {
+        // WI is 'In Progress' but no PR opened yet — build crashed in a prior tick. Restart.
+        return { wi, action: 'no-pr-restart' }
+      }
+      const prState = await agent(checkPrStatePrompt(wi), {
+        schema: PR_STATE_SCHEMA,
+        label: `check-pr-${wi.name}`,
+        phase: 'Monitor in-flight',
+        model: 'sonnet',
+      })
+      return { wi, prState, action: 'evaluate' }
+    },
+    async result => {
+      if (!result || result.action === 'no-pr-restart') return result
+      const { prState } = result
+      if (prState.state === 'merged' || prState.state === 'closed') {
+        return { ...result, decision: 'close-wi' }
+      }
+      // Only finalize a green PR whose WI is still 'In Progress'. WIs already advanced to
+      // 'Ready for Review'/'Fixed' in a prior tick are done — re-finalizing them re-posts the
+      // Slack "PR ready for review" message every tick (openReviewPrompt step 4 is not idempotent).
+      if (prState.state === 'green') {
+        return { ...result, decision: result.wi.status === 'In Progress' ? 'finalize' : 'wait' }
+      }
+      if (prState.state === 'running') return { ...result, decision: 'wait' }
+      if (prState.state === 'no-pr') return { ...result, decision: 'no-pr-restart' }
+      // state === 'failed': all checks settled, at least one not green.
+      // The gha-rerun daemon owns the rerun budget (max 3 attempts per its skill).
+      // If maxRunAttempt < 3, the daemon will rerun soon → wait.
+      // If maxRunAttempt >= 3, reruns are exhausted → triage and iterate on the diff.
+      const attempt = typeof prState.maxRunAttempt === 'number' ? prState.maxRunAttempt : 0
+      return { ...result, decision: attempt >= 3 ? 'triage' : 'wait' }
+    }
+  )
+
+  return { inFlightWis, monitorOutcomes }
+}
+
+const closeMergedWis = async (toCloseWi, identity) => {
+  phase('Close merged WIs')
+  await parallel(
+    toCloseWi.map(r => () =>
+      agent(closeMergedPrompt(r, identity), {
+        schema: OK_SCHEMA,
+        label: `close-${r.wi.name}`,
+        phase: 'Close merged WIs',
+        model: 'haiku',
+      })
+    )
+  )
+}
+
+const triageAndFixCi = async (toTriage, identity) => {
+  phase('Triage failures')
+  const triaged = await parallel(
+    toTriage.map(r => () =>
+      agent(triageCiPrompt(r, identity), {
+        schema: TRIAGE_SCHEMA,
+        label: `triage-${r.wi.name}`,
+        phase: 'Triage failures',
+        model: 'opus',
+      }).then(triage => ({ ...r, triage }))
+    )
+  )
+
+  phase('Fix CI failures')
+  await parallel(
+    triaged.filter(Boolean).map(r => async () => {
+      if (r.triage.route === 'flake-or-infra' || r.triage.route === 'unknown') {
+        await agent(dmCiFailurePrompt(r, identity), {
+          schema: OK_SCHEMA,
+          label: `dm-${r.wi.name}`,
+          phase: 'Fix CI failures',
+          model: 'haiku',
+        })
+        return
+      }
+      if (r.triage.route === 'e2e-test-issue') {
+        await agent(e2eFixPrompt(r, identity), {
+          schema: BUILD_SCHEMA,
+          label: `e2e-fix-${r.wi.name}`,
+          phase: 'Fix CI failures',
+          model: 'opus',
+        })
+        return
+      }
+      // code-bug → run builder with failure context
+      await agent(codeFixPrompt(r, identity), {
+        schema: BUILD_SCHEMA,
+        label: `code-fix-${r.wi.name}`,
+        phase: 'Fix CI failures',
+        model: 'opus',
+      })
+    })
+  )
+}
+
+const keepInFlightCurrent = async (toRefresh, identity) => {
+  phase('Keep in-flight current')
+  // Sequential, not parallel: merges may trigger compile/lint/test across many
+  // worktrees concurrently and crash the machine.
+  for (const r of toRefresh) {
+    await agent(refreshBranchPrompt(r, identity), {
+      schema: OK_SCHEMA,
+      label: `refresh-${r.wi.name}`,
+      phase: 'Keep in-flight current',
+      model: 'opus',
+    })
+  }
+}
+
+const openForReview = async (toFinalize, identity) => {
+  phase('Open for review')
+  await parallel(
+    toFinalize.map(r => () =>
+      agent(openReviewPrompt(r, identity), {
+        schema: OK_SCHEMA,
+        label: `open-review-${r.wi.name}`,
+        phase: 'Open for review',
+        model: 'haiku',
+      })
+    )
+  )
+}
+
+const peerApprove = async identity => {
+  phase('Peer approve')
+
+  const peerApproveRaw = await agent(peerApproveQueryPrompt(identity), {
+    schema: WI_RECORDS_SCHEMA,
+    label: 'peer-approve-query',
+    phase: 'Peer approve',
+    model: 'haiku',
+  })
+
+  const peerCandidates = (peerApproveRaw.records || [])
+    .map(r => ({
+      wiId: r.Id,
+      name: r.Name,
+      subject: r.Subject__c || '',
+      prUrl: extractPrUrl(r.Details__c),
+      ownerUserId: r.Assignee__c || '',
+    }))
+    .filter(c => c.prUrl && c.ownerUserId)
+  log(`peer-approve candidates: ${peerCandidates.length}`)
+
+  if (!peerCandidates.length) return
+
+  await parallel(
+    peerCandidates.map(c => () =>
+      agent(peerApprovePrompt(c, identity), {
+        schema: OK_SCHEMA,
+        label: `peer-approve-${c.name}`,
+        phase: 'Peer approve',
+        model: 'sonnet',
+      })
+    )
+  )
+}
+
+const pickCandidate = async (identity, inFlightWis) => {
+  phase('Pick candidate')
+
+  const candidatesRaw = await agent(candidatesQueryPrompt(identity), {
+    schema: WI_RECORDS_SCHEMA,
+    label: 'query-candidates',
+    phase: 'Pick candidate',
+    model: 'haiku',
+  })
+
+  const inFlightWiIds = new Set(inFlightWis.map(w => w.wiId))
+  const validStatuses = new Set(['New', 'Ready', 'Triaged'])
+  const rawRecords = candidatesRaw.records || []
+  const offSpec = rawRecords.filter(
+    r => r.Assignee__c !== identity.userId || !validStatuses.has(r.Status__c)
+  )
+  if (offSpec.length) {
+    log(
+      `query-candidates returned ${offSpec.length}/${rawRecords.length} record(s) outside the WHERE clause — agent went off-script. Dropping all results.`
+    )
+  }
+  const filteredRecords = offSpec.length ? [] : rawRecords
+  const preCandidates = filteredRecords.map(mapWiRecord).filter(c => {
+    if (inFlightWiIds.has(c.wiId)) return false
+    return true
+  })
+  // For WIs with a workflow-appended PR URL, verify the PR is still open (not closed
+  // without merging). A closed PR means the WI needs a new attempt.
+  const candidateList = (
+    await Promise.all(
+      preCandidates.map(async c => {
+        const prUrl = extractPrUrl(c.details)
+        if (!prUrl) return c
+        const prNum = prUrl.split('/').pop()
+        const stateRaw = await agent(
+          `Run: gh pr view ${prNum} --json state,mergedAt --jq '{state: .state, mergedAt: .mergedAt}'\nReturn only the JSON object from stdout, nothing else.`,
+          { schema: { type: 'object', properties: { state: { type: 'string' }, mergedAt: {} }, required: ['state'] }, label: `pr-state-${prNum}`, phase: 'Pick candidate', model: 'haiku' }
+        )
+        const prState = (stateRaw && stateRaw.state) || 'UNKNOWN'
+        if (prState === 'OPEN') {
+          log(`excluding ${c.name}: PR #${prNum} is open — already in progress`)
+          return null
+        }
+        if (prState === 'MERGED' || stateRaw.mergedAt) {
+          log(`excluding ${c.name}: PR #${prNum} already merged`)
+          return null
+        }
+        // CLOSED without merge — PR was abandoned; re-queue the WI
+        log(`re-queuing ${c.name}: PR #${prNum} was closed without merging`)
+        return c
+      })
+    )
+  ).filter(Boolean)
+
+  if (!candidateList.length) return null
+
+  // Deterministic blocked-WI gate: drop any candidate that declares a hard
+  // dependency ("blocked by W-XXX", "depends on W-XXX", "after W-XXX merges")
+  // on a WI that hasn't merged yet. Done in code, not left to the picker LLM,
+  // and applied even when there's a single candidate (the picker is skipped
+  // in that path). One batched status query covers every referenced blocker.
+  const blockerMap = new Map(
+    candidateList.map(c => [c.wiId, extractBlockers(c.subject, c.details)])
+  )
+  const allBlockerNames = [...new Set([...blockerMap.values()].flat())]
+  if (allBlockerNames.length) {
+    const blockerRaw = await agent(blockerStatusQueryPrompt(allBlockerNames), {
+      schema: WI_STATUS_RECORDS_SCHEMA,
+      label: 'query-blocker-status',
+      phase: 'Pick candidate',
+      model: 'haiku',
+    })
+    const statusByName = new Map(
+      (blockerRaw.records || []).map(r => [r.Name, r.Status__c || ''])
+    )
+    const unblocked = candidateList.filter(c => {
+      const blockers = blockerMap.get(c.wiId) || []
+      // A blocker not present in query results doesn't exist (or is mistyped) —
+      // treat an unresolvable reference as unsatisfied to stay safe.
+      const unmet = blockers.filter(b => !isBlockerSatisfied(statusByName.get(b) || ''))
+      if (unmet.length) {
+        log(
+          `excluding ${c.name}: blocked by unmerged ${unmet
+            .map(b => `${b} (${statusByName.get(b) || 'not found'})`)
+            .join(', ')}`
+        )
+        return false
+      }
+      return true
+    })
+    if (!unblocked.length) {
+      log('all candidates blocked by unmerged dependencies — nothing to claim')
+      return null
+    }
+    candidateList.length = 0
+    candidateList.push(...unblocked)
+  }
+
+  if (candidateList.length === 1) {
+    log(`single candidate: ${candidateList[0].name}`)
+    return candidateList[0]
+  }
+
+  const inFlightUrls = inFlightWis.filter(w => w.prUrl).map(w => w.prUrl)
+  const inFlightFiles = inFlightUrls.length
+    ? await parallel(
+        inFlightUrls.map(url => () =>
+          agent(prFilesPrompt(url), {
+            schema: FILES_SCHEMA,
+            label: `pr-files-${url.split('/').pop()}`,
+            phase: 'Pick candidate',
+            model: 'haiku',
+          })
+        )
+      )
+    : []
+  const inFlightFileList = [
+    ...new Set((inFlightFiles || []).filter(Boolean).flatMap(d => d.files || [])),
+  ]
+
+  const pick = await agent(pickWiPrompt(candidateList, inFlightFileList), {
+    schema: PICKER_SCHEMA,
+    label: 'pick-wi',
+    phase: 'Pick candidate',
+    model: 'sonnet',
+  })
+  const chosen = candidateList.find(c => c.wiId === pick.wiId) || candidateList[0]
+  log(`picked ${chosen.name}: ${pick.reason}`)
+  return chosen
+}
+
+const claimOrRestart = async (chosen, identity, isRestart) => {
+  phase('Claim + worktree')
+  return await agent(claimOrRestartPrompt(chosen, identity, isRestart), {
+    schema: OK_SCHEMA,
+    label: `${isRestart ? 'restart' : 'claim'}-${chosen.name}`,
+    phase: 'Claim + worktree',
+    model: 'haiku',
+  })
+}
+
+const runPlan = async (chosen, identity) => {
+  phase('Plan')
+
+  const skillNames = await agent(listSkillsPrompt(identity), {
+    schema: SKILL_LIST_SCHEMA,
+    label: 'list-skills',
+    phase: 'Plan',
+    model: 'haiku',
+  })
+  const skillList = (skillNames.skills || []).map(s => s.trim()).filter(Boolean)
+
+  const planResult = await agent(planPrompt(chosen, identity, skillList), {
+    schema: PLAN_SCHEMA,
+    label: `plan-${chosen.name}`,
+    phase: 'Plan',
+    model: 'opus',
+  })
+
+  return { planResult, skillList }
+}
+
+const bounceBlockedPlan = async (chosen, planResult, identity) => {
+  await agent(bouncePlanPrompt(chosen, planResult, identity), {
+    schema: OK_SCHEMA,
+    label: `bounce-${chosen.name}`,
+    phase: 'Plan',
+    model: 'haiku',
+  })
+}
+
+const reviewAndCommitPlan = async (chosen, identity) => {
+  const planReview = await agent(planReviewPrompt(chosen, identity), {
+    schema: PLAN_REVIEW_SCHEMA,
+    label: `plan-review-${chosen.name}`,
+    phase: 'Plan',
+    model: 'sonnet',
+  })
+
+  if (!planReview.approved) {
+    await agent(planRevisePrompt(chosen, identity, planReview.revisions), {
+      schema: PLAN_SCHEMA,
+      label: `plan-revise-${chosen.name}`,
+      phase: 'Plan',
+      model: 'sonnet',
+    })
+  }
+
+  const [effectPlanReview, e2ePlanReview, adversaryPlanReview] = await parallel([
+    () =>
+      agent(effectPlanReviewPrompt(chosen, identity), {
+        schema: EFFECT_ADVOCATE_SCHEMA,
+        label: `effect-plan-${chosen.name}`,
+        phase: 'Plan',
+        agentType: 'effect-advocate',
+      }),
+    () =>
+      agent(e2ePlanReviewPrompt(chosen, identity), {
+        schema: EFFECT_ADVOCATE_SCHEMA,
+        label: `e2e-plan-${chosen.name}`,
+        phase: 'Plan',
+        agentType: 'e2e-advocate',
+      }),
+    () =>
+      agent(adversaryPlanReviewPrompt(chosen, identity), {
+        schema: PLAN_ADVERSARY_SCHEMA,
+        label: `adversary-plan-${chosen.name}`,
+        phase: 'Plan',
+        agentType: 'plan-adversary',
+      }),
+  ])
+
+  const effectMust = ((effectPlanReview && effectPlanReview.findings) || []).filter(
+    f => f.severity === 'must'
+  )
+  const e2eMust = ((e2ePlanReview && e2ePlanReview.findings) || []).filter(
+    f => f.severity === 'must'
+  )
+  const adversaryBlocking = ((adversaryPlanReview && adversaryPlanReview.findings) || []).filter(
+    f => f.severity === 'critical' || f.severity === 'high'
+  )
+
+  const advocateRevisions = [
+    ...effectMust.map(f => `[effect] ${f.suggestion}${f.citation ? ' [' + f.citation + ']' : ''}`),
+    ...e2eMust.map(f => `[e2e] ${f.suggestion}${f.citation ? ' [' + f.citation + ']' : ''}`),
+    ...adversaryBlocking.map(
+      f =>
+        `[adversary:${f.severity}] ${f.claim}${f.suggestion ? ' — ' + f.suggestion : ''}${f.evidence ? ' [' + f.evidence + ']' : ''}`
+    ),
+  ]
+
+  if (advocateRevisions.length) {
+    await agent(planAdvocateRevisePrompt(chosen, identity, advocateRevisions), {
+      schema: PLAN_SCHEMA,
+      label: `plan-advocate-revise-${chosen.name}`,
+      phase: 'Plan',
+      model: 'opus',
+    })
+  }
+
+  await agent(commitPlanPrompt(chosen, identity), {
+    schema: OK_SCHEMA,
+    label: `commit-plan-${chosen.name}`,
+    phase: 'Plan',
+    model: 'haiku',
+  })
+}
+
+const runBuild = async (chosen, identity) => {
+  phase('Build')
+  return await agent(buildPrompt(chosen, identity), {
+    schema: BUILD_SCHEMA,
+    label: `build-${chosen.name}`,
+    phase: 'Build',
+    model: 'opus',
+  })
+}
+
+const bounceStuckBuild = async (chosen, buildResult, identity) => {
+  await agent(bounceBuildPrompt(chosen, buildResult, identity), {
+    schema: OK_SCHEMA,
+    label: `bounce-build-${chosen.name}`,
+    phase: 'Build',
+    model: 'haiku',
+  })
+}
+
+const runReview = async (chosen, identity, skillList) => {
+  phase('Review')
+  const { wt } = pathsFor(identity, chosen)
+
+  const diffInfo = await agent(diffPrompt(wt), {
+    schema: DIFF_RAW_SCHEMA,
+    label: `diff-${chosen.name}`,
+    phase: 'Review',
+    model: 'haiku',
+  })
+
+  const lineCount = parseShortstatLines(diffInfo.shortstat || '')
+  const skillsToCheck =
+    lineCount < SMALL_DIFF_LINES
+      ? skillList.filter(s => ALWAYS_APPLICABLE_SKILLS.includes(s))
+      : skillList.filter(s => !REVIEW_SKILL_DENYLIST.includes(s))
+
+  log(`diff: ${lineCount} lines; checking ${skillsToCheck.length} skills`)
+
+  const skillFindings = await parallel(
+    skillsToCheck.map(skill => () =>
+      agent(skillDetectPrompt(skill, wt), {
+        schema: SKILL_DETECT_SCHEMA,
+        label: `skill-${skill}`,
+        phase: 'Review',
+        model: 'sonnet',
+      })
+    )
+  )
+
+  const thermo = await agent(thermoPrompt(wt), {
+    schema: THERMO_SCHEMA,
+    label: `thermo-${chosen.name}`,
+    phase: 'Review',
+    model: 'opus',
+  })
+
+  const effectDiffReview = await agent(effectDiffReviewPrompt(wt), {
+    schema: EFFECT_ADVOCATE_SCHEMA,
+    label: `effect-diff-${chosen.name}`,
+    phase: 'Review',
+    agentType: 'effect-advocate',
+  })
+
+  // Verify every finding before fixing: each gets an adversarial verifier that
+  // proves the premise (reads cited code; gh-searches consumers for breaking/
+  // dead-code claims; checks CI coverage for "run X before merge" claims) and
+  // returns confirmed / downgraded / dropped. Kills false positives, redundant
+  // CI re-runs, and zero-consumer "breaking changes" before they reach the fixer.
+  phase('Verify findings')
+
+  const rawFindings = normalizeFindings(skillFindings, skillsToCheck, thermo, effectDiffReview)
+  log(`verifying ${rawFindings.length} raw finding(s)`)
+
+  const verdicts = await parallel(
+    rawFindings.map((finding, i) => () =>
+      agent(verifyFindingPrompt(wt, finding), {
+        schema: VERIFY_SCHEMA,
+        label: `verify-${finding.source}-${i}`,
+        phase: 'Verify findings',
+        model: 'sonnet',
+      }).then(v => (v ? { finding, ...v } : null))
+    )
+  )
+
+  const verifiedFindings = verdicts
+    .filter(Boolean)
+    .filter(v => v.verdict !== 'dropped')
+    .map(v => ({
+      source: v.finding.source,
+      file: v.finding.file,
+      line: v.finding.line,
+      claim: v.finding.claim,
+      verifiedSeverity: v.severity,
+      rationale: v.rationale,
+      evidence: v.evidence ?? null,
+    }))
+    .sort((a, b) => SEVERITY_RANK[a.verifiedSeverity] - SEVERITY_RANK[b.verifiedSeverity])
+
+  const droppedCount = verdicts.filter(Boolean).filter(v => v.verdict === 'dropped').length
+  log(
+    `verified: ${verifiedFindings.length} kept, ${droppedCount} dropped (${verdicts.filter(Boolean).filter(v => v.verdict === 'downgraded').length} downgraded)`
+  )
+
+  phase('Fix review findings')
+
+  const fixerResult = await agent(fixerPrompt(wt, verifiedFindings), {
+    schema: FIXER_SCHEMA,
+    label: `fix-${chosen.name}`,
+    phase: 'Fix review findings',
+    model: 'opus',
+  })
+
+  await agent(mergeDevelopPrompt(wt), {
+    schema: OK_SCHEMA,
+    label: `merge-${chosen.name}`,
+    phase: 'Fix review findings',
+    model: 'opus',
+  })
+
+  return fixerResult
+}
+
+const draftPr = async (chosen, identity, fixerResult) => {
+  phase('Draft PR')
+  return await agent(draftPrPrompt(chosen, identity, fixerResult), {
+    schema: PR_DRAFT_SCHEMA,
+    label: `pr-${chosen.name}`,
+    phase: 'Draft PR',
+    model: 'sonnet',
+  })
+}
+
+// =====================================================================
+// ORCHESTRATION
+// =====================================================================
+
+const identity = await resolveIdentity()
+if (identity.error || !identity.userId) {
+  log(`identity resolution failed: ${identity.error || 'unknown'} — exiting`)
+  return { exited: 'identity-failed', error: identity.error }
+}
+log(`runner: ${identity.username} (${identity.ownerPrefix}, ${identity.githubLogin})`)
+
+await ensureDaemons()
+await reapStrandedWorktrees(identity)
+
+const { inFlightWis, monitorOutcomes } = await monitorInFlight(identity)
+const { toFinalize, toTriage, toRestart, toCloseWi, toRefresh } = classifyMonitor(monitorOutcomes)
+
+if (toCloseWi.length) await closeMergedWis(toCloseWi, identity)
+if (toTriage.length) await triageAndFixCi(toTriage, identity)
+if (toRefresh.length) await keepInFlightCurrent(toRefresh, identity)
+if (toFinalize.length) await openForReview(toFinalize, identity)
+await peerApprove(identity)
+
+// Cap = number of WIs currently 'In Progress' in GUS. GUS status is authoritative.
+// 'Ready for Review'/'Fixed' WIs are waiting on human review — not consuming builder slots.
+// No subtraction needed: GUS already reflects transitions from prior ticks.
+const stillInFlight = inFlightWis.filter(w => w.status === 'In Progress').length
+log(`cap: stillInFlight=${stillInFlight} (In Progress WIs) toFinalize=${toFinalize.length} toCloseWi=${toCloseWi.length} toRestart=${toRestart.length}`)
+
+let chosen
+let isRestart = false
+
+if (toRestart.length) {
+  chosen = toRestart[0].wi
+  isRestart = true
+  log(`restarting stuck in-flight WI ${chosen.name} (no PR)`)
+} else {
+  if (stillInFlight >= MAX_IN_FLIGHT) {
+    log(`at cap (${stillInFlight}/${MAX_IN_FLIGHT}); not claiming new WI`)
+    return { exited: 'at-cap', inFlight: stillInFlight, finalized: toFinalize.length }
+  }
+  chosen = await pickCandidate(identity, inFlightWis)
+  if (!chosen) {
+    log('no candidates — nothing to do')
+    return { exited: 'idle', inFlight: stillInFlight }
+  }
+}
+
+const claimed = await claimOrRestart(chosen, identity, isRestart)
+if (!claimed.ok) {
+  log(`${isRestart ? 'restart' : 'claim'} failed: ${claimed.detail}`)
+  return {
+    exited: isRestart ? 'restart-failed' : 'claim-failed',
+    error: claimed.detail,
+  }
+}
+
+const { planResult, skillList } = await runPlan(chosen, identity)
+if (planResult.verdict === 'blocked') {
+  await bounceBlockedPlan(chosen, planResult, identity)
+  return { exited: 'plan-blocked', wi: chosen.name }
+}
+await reviewAndCommitPlan(chosen, identity)
+
+const buildResult = await runBuild(chosen, identity)
+if (buildResult.status === 'stuck') {
+  await bounceStuckBuild(chosen, buildResult, identity)
+  return { exited: 'build-stuck', wi: chosen.name, reason: buildResult.reason }
+}
+
+const fixerResult = await runReview(chosen, identity, skillList)
+
+const prResult = await draftPr(chosen, identity, fixerResult)
+
+log(`opened draft PR ${prResult.prUrl} for ${chosen.name}`)
+return {
+  exited: 'claimed-and-pr-opened',
+  wi: chosen.name,
+  prUrl: prResult.prUrl,
+  finalized: toFinalize.length,
+}

--- a/.github/workflows/claude-skills-sync.yml
+++ b/.github/workflows/claude-skills-sync.yml
@@ -1,0 +1,78 @@
+name: Sync Claude skills from monorepo
+
+# Keeps ALS's allowlisted Claude skills/agents/commands in sync with the
+# salesforcedx-vscode monorepo. Driven by .claude/skills-sync.json and
+# scripts/sync-claude-skills.mjs. When an allowlisted item drifts upstream,
+# this opens (or updates) a single PR with the synced changes for human review.
+# ALS-owned/adapted items (see "ownedByAls" in the config) are never touched.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC — weekly drift check.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Upstream ref to sync from (overrides skills-sync.json)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Sync allowlisted skills
+        run: node scripts/sync-claude-skills.mjs
+        env:
+          # Allow workflow_dispatch to override the upstream ref via the script's
+          # config at runtime is not supported; the script reads skills-sync.json.
+          # The optional input is surfaced for visibility only.
+          SYNC_REF_OVERRIDE: ${{ inputs.ref }}
+
+      - name: Detect changes
+        id: diff
+        run: |
+          if git diff --quiet -- .claude; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No skill drift detected."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Drift detected in:"
+            git diff --name-only -- .claude
+          fi
+
+      - name: Open / update drift PR
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/sync-claude-skills
+          base: main
+          commit-message: 'chore: sync Claude skills from salesforcedx-vscode monorepo'
+          title: 'chore: sync Claude skills from monorepo'
+          body: |
+            Automated drift sync of allowlisted Claude skills/agents/commands from
+            `forcedotcom/salesforcedx-vscode` (see `.claude/skills-sync.json`).
+
+            The files below drifted upstream and were pulled in. **Review carefully** —
+            confirm no ALS-specific facts were clobbered before merging. Items adapted
+            for ALS live under `ownedByAls` in the config and are intentionally excluded.
+
+            To stop tracking an item, remove it from the `allowlist` in
+            `.claude/skills-sync.json`.
+          labels: |
+            dependencies
+          delete-branch: true
+          add-paths: |
+            .claude/**

--- a/scripts/sync-claude-skills.mjs
+++ b/scripts/sync-claude-skills.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * sync-claude-skills.mjs
+ *
+ * Keeps ALS's allowlisted Claude skills/agents/commands in sync with the
+ * salesforcedx-vscode monorepo. Driven by .claude/skills-sync.json.
+ *
+ * What it does:
+ *   1. Reads the allowlist + upstream repo/ref from .claude/skills-sync.json.
+ *   2. Shallow sparse-checkouts only the allowlisted paths from upstream into a temp dir.
+ *   3. Copies each upstream path over the local copy (skills are whole dirs; agents/commands are files).
+ *   4. Prints a summary of which paths changed.
+ *
+ * It does NOT commit or push — the GitHub Action (.github/workflows/claude-skills-sync.yml)
+ * wraps this and opens a drift PR via the working-tree changes. Run locally any time with:
+ *   node scripts/sync-claude-skills.mjs            # apply changes to working tree
+ *   node scripts/sync-claude-skills.mjs --check    # exit 1 if drift exists, change nothing
+ *
+ * Items NOT in the allowlist (see "ownedByAls" in the config) are ALS-owned and never touched.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, cpSync, existsSync, readFileSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const CONFIG_PATH = join(REPO_ROOT, '.claude', 'skills-sync.json');
+const CHECK_ONLY = process.argv.includes('--check');
+
+function run(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], ...opts });
+}
+
+function log(msg) {
+  process.stdout.write(`${msg}\n`);
+}
+
+if (!existsSync(CONFIG_PATH)) {
+  console.error(`Config not found: ${CONFIG_PATH}`);
+  process.exit(2);
+}
+
+const config = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+const { repo, ref, claudeDir } = config.upstream;
+const localClaude = join(REPO_ROOT, claudeDir);
+
+// Build the list of upstream paths (relative to repo root) we care about.
+const targets = [];
+for (const skill of config.allowlist.skills ?? []) {
+  targets.push({ kind: 'dir', rel: `${claudeDir}/skills/${skill}` });
+}
+for (const agent of config.allowlist.agents ?? []) {
+  targets.push({ kind: 'file', rel: `${claudeDir}/agents/${agent}` });
+}
+for (const cmd of config.allowlist.commands ?? []) {
+  targets.push({ kind: 'file', rel: `${claudeDir}/commands/${cmd}` });
+}
+
+if (targets.length === 0) {
+  log('Allowlist is empty — nothing to sync.');
+  process.exit(0);
+}
+
+log(`Syncing ${targets.length} allowlisted path(s) from ${repo}@${ref}`);
+
+// Shallow sparse checkout of upstream into a temp dir.
+const work = mkdtempSync(join(tmpdir(), 'als-skills-sync-'));
+const cloneUrl = `https://github.com/${repo}.git`;
+let changed = [];
+try {
+  run('git', ['clone', '--depth', '1', '--filter=blob:none', '--sparse', '--branch', ref, cloneUrl, work]);
+  // --no-cone lets us list individual files (agents/commands) as well as dirs (skills);
+  // cone mode treats every pattern as a directory and rejects file paths.
+  run('git', ['-C', work, 'sparse-checkout', 'set', '--no-cone', ...targets.map((t) => t.rel)]);
+
+  for (const t of targets) {
+    const upstreamPath = join(work, t.rel);
+    const localPath = join(REPO_ROOT, t.rel);
+    if (!existsSync(upstreamPath)) {
+      log(`  ⚠ upstream missing: ${t.rel} (skipped — removed upstream or renamed?)`);
+      continue;
+    }
+    // Detect drift with git diff --no-index (works for files and dirs).
+    let differs = false;
+    try {
+      run('git', ['diff', '--no-index', '--quiet', localPath, upstreamPath]);
+    } catch (e) {
+      // git diff exits 1 when files differ, >1 on error. Treat 1 as "differs".
+      differs = (e.status === 1) || !existsSync(localPath);
+    }
+    if (!differs) continue;
+
+    changed.push(t.rel);
+    if (CHECK_ONLY) {
+      log(`  ✗ drift: ${t.rel}`);
+      continue;
+    }
+    if (t.kind === 'dir') {
+      // Replace the whole skill dir to pick up added/removed reference files.
+      if (existsSync(localPath)) rmSync(localPath, { recursive: true, force: true });
+      cpSync(upstreamPath, localPath, { recursive: true });
+    } else {
+      cpSync(upstreamPath, localPath);
+    }
+    log(`  ↻ synced: ${t.rel}`);
+  }
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}
+
+if (changed.length === 0) {
+  log('✓ All allowlisted skills are current with upstream.');
+  process.exit(0);
+}
+
+if (CHECK_ONLY) {
+  log(`\n${changed.length} path(s) drifted from upstream. Run without --check to sync.`);
+  process.exit(1);
+}
+
+log(`\n✓ Synced ${changed.length} path(s) from upstream. Review the diff before committing.`);
+process.exit(0);


### PR DESCRIPTION
### What does this PR do?

Ports relevant Claude tooling from `forcedotcom/salesforcedx-vscode` into ALS and adds a pipeline to keep shared skills from drifting.

**Ported (adapted to ALS):**
- **Skills:** `lsp-custom-requests`, `grill-me`, `merge-conflicts`, `shipped-issues`
- **Agents:** `effect-advocate`, `trace-debugger`, `e2e-advocate`, `plan-adversary`, `playwright-e2e-monitor`, `gha-rerun` (+ daemon)
- **Commands:** `debug-traces`, `analyze-e2e`, `shipped-issues`, `mergeConflicts`, `adopt-pr`, `gha-rerun`
- **Workflow:** `auto-build-wi.js` (+ README)

Every ported item was adapted to ALS facts: repo `forcedotcom/apex-language-support`, base branch `main`, Effect services in `custom-services`/`lsp-compliant-services`, Playwright-only e2e under `e2e-tests/`, and the CI babysitter retargeted to `kylewalke` + ALS workflow names. The `thermonuclear-code-quality-review` dependency (which doesn't exist in ALS) was replaced with an inline severity-graded review.

**Reconciled drift:** 14 already-shared skills pulled in monorepo improvements (notably `effect-best-practices`, `services-extension-consumption`, `span-file-export`, `gus-cli`) while preserving ALS-specific customizations.

**Sync pipeline:**
- `.claude/skills-sync.json` — allowlist of skills to track + `ownedByAls` exclusions
- `scripts/sync-claude-skills.mjs` — sparse-clones upstream, diffs allowlisted paths (`--check` for CI-style detection)
- `.github/workflows/claude-skills-sync.yml` — weekly + manual; opens a `chore/sync-claude-skills` drift PR for human review

### What issues does this PR fix or reference?

@W-23078393@