### PR TITLE
fix(apex-lsp-extension): compile didChange/didSave into the data-owner + action-tailored load status - W-23006798

### DIFF
--- a/packages/apex-ls/src/server/LCSAdapter.ts
+++ b/packages/apex-ls/src/server/LCSAdapter.ts
@@ -58,9 +58,9 @@ import {
   LSP_SPAN_NAMES,
   CommandPerformanceAggregator,
   collectStartupSnapshot,
+  type WorkspaceLoadReason,
+  type LspSpanAttributes,
 } from '@salesforce/apex-lsp-shared';
-
-import type { LspSpanAttributes } from '@salesforce/apex-lsp-shared';
 
 import {
   dispatchProcessOnOpenDocument,
@@ -550,13 +550,15 @@ export class LCSAdapter {
    * request may return partial/empty results; once the load completes a repeat
    * request resolves against the full graph.
    */
-  private async triggerWorkspaceLoadIfNeeded(): Promise<void> {
+  private async triggerWorkspaceLoadIfNeeded(
+    reason?: WorkspaceLoadReason,
+  ): Promise<void> {
     if (isWorkspaceLoaded() || isWorkspaceLoading()) {
       return;
     }
     try {
       await Effect.runPromise(
-        ensureWorkspaceLoaded(this.connection, this.logger),
+        ensureWorkspaceLoaded(this.connection, this.logger, undefined, reason),
       );
     } catch (error) {
       this.logger.debug(
@@ -650,7 +652,14 @@ export class LCSAdapter {
           // runs on the request pool with no LSP connection. This guarantees
           // the dataOwner graph is (being) populated with all workspace classes
           // before the search asks the dataOwner for inbound implementor tables.
-          await this.triggerWorkspaceLoadIfNeeded();
+          // The load is fire-and-forget (the workspace can be large; we must not
+          // block the IDE), so the FIRST cold invocation returns before the
+          // graph is populated and the client renders "No implementations
+          // found". Passing the 'implementation' reason makes the client show an
+          // action-tailored busy status ("Searching workspace for
+          // implementations…") so the user understands work is in progress; a
+          // repeat invocation after the load completes returns the implementors.
+          await this.triggerWorkspaceLoadIfNeeded('implementation');
           return this.handleLspRequest(
             LSP_SPAN_NAMES.IMPLEMENTATION,
             'textDocument/implementation',

--- a/packages/apex-ls/src/server/WorkerCoordinator.ts
+++ b/packages/apex-ls/src/server/WorkerCoordinator.ts
@@ -713,7 +713,11 @@ function createDispatcher(
     async dispatch(type: LSPRequestType, params: unknown): Promise<unknown> {
       dispatchedCount++;
 
-      if (type === 'documentOpen' || type === 'documentChange') {
+      if (
+        type === 'documentOpen' ||
+        type === 'documentChange' ||
+        type === 'documentSave'
+      ) {
         const dataOwnerMsg = buildDataOwnerMessage(type, params);
         const compileMsg = buildCompileMessage(type, params);
         logger.debug(() => `[WorkerDispatch] → dataOwner→compilation: ${type}`);

--- a/packages/apex-ls/src/worker.platform.ts
+++ b/packages/apex-ls/src/worker.platform.ts
@@ -1860,11 +1860,24 @@ const handlers: WorkerRunner.SerializedRunner.Handlers<
 
   DispatchDocumentSave: dataOwnerDocHandler(
     'DispatchDocumentSave',
-    (_svc, req) =>
+    (svc, req) =>
       Effect.gen(function* () {
-        yield* Effect.logDebug(
-          `[DATA-OWNER] DispatchDocumentSave: uri=${req.uri}`,
+        // Mirror DispatchDocumentChange: store a version placeholder and arm the
+        // readiness latch so the CompileDocument this save triggers can write
+        // its symbols back (UpdateSymbolSubset requires the document present at
+        // this version) and a request racing the save re-evaluates against the
+        // saved version. The compile message carries the real saved content; the
+        // placeholder text is replaced when the write-back merges.
+        const doc: WorkerDocument = {
+          uri: req.uri,
+          getText: () => '',
+          languageId: 'apex',
+          version: req.version,
+        };
+        yield* Effect.promise(() =>
+          svc.storageManager.getStorage().setDocument(req.uri, doc as never),
         );
+        armReadiness(req.uri, req.version);
         return { accepted: true };
       }),
   ),

--- a/packages/apex-ls/src/worker.platform.web.ts
+++ b/packages/apex-ls/src/worker.platform.web.ts
@@ -1613,11 +1613,22 @@ const handlers: WorkerRunner.SerializedRunner.Handlers<
 
   DispatchDocumentSave: dataOwnerDocHandler(
     'DispatchDocumentSave',
-    (_svc, req) =>
+    (svc, req) =>
       Effect.gen(function* () {
-        yield* Effect.logDebug(
-          `[DATA-OWNER] DispatchDocumentSave: uri=${req.uri}`,
+        // Mirror DispatchDocumentChange: store a version placeholder and arm the
+        // readiness latch so the CompileDocument this save triggers can write
+        // its symbols back and a racing request re-evaluates against the saved
+        // version. The compile message carries the real saved content.
+        const doc: WorkerDocument = {
+          uri: req.uri,
+          getText: () => '',
+          languageId: 'apex',
+          version: req.version,
+        };
+        yield* Effect.promise(() =>
+          svc.storageManager.getStorage().setDocument(req.uri, doc as never),
         );
+        armReadiness(req.uri, req.version);
         return { accepted: true };
       }),
   ),

--- a/packages/apex-ls/test/integration/EnrichmentRoundTrip.node.test.ts
+++ b/packages/apex-ls/test/integration/EnrichmentRoundTrip.node.test.ts
@@ -188,12 +188,12 @@ describe('Enrichment round-trip through the worker topology (live assistance bus
       // tests hung here because the bus was unwired).
       const response = (yield* topology.requestPool.executeEffect(
         makeRequest() as never,
-      )) as { result: unknown };
+      ) as Effect.Effect<unknown, never, never>) as { result: unknown };
       return response;
     }).pipe(
       Effect.scoped,
       Effect.provide(makeNodeWorkerLayer(WORKER_TS_ENTRY, TSX_OPTIONS)),
-    );
+    ) as Effect.Effect<{ result: unknown }, never, never>;
 
   it('completes a hover round-trip end-to-end', async () => {
     const response = await Effect.runPromise(
@@ -565,5 +565,169 @@ describe('Enrichment round-trip through the worker topology (live assistance bus
     // Before the fix the stale cache returned only FaceImpl (the first).
     expect(secondUris.some((u) => u.includes('FaceImpl.cls'))).toBe(true);
     expect(secondUris.some((u) => u.includes('FaceImpl2'))).toBe(true);
+  }, 120_000);
+
+  /**
+   * NEW IMPLEMENTOR CREATED + EDITED VIA THE LIVE NOTIFICATION PATH (regression
+   * for the live "second implementor never resolves" bug).
+   *
+   * The multi-implementor test above adds implementor #2 via batch
+   * ingest+compile, which writes straight to the data-owner — so it never
+   * exercised the live editor flow and passed even while the live bug persisted.
+   * Live, a newly-created class arrives as documentOpen (often an empty/partial
+   * class) followed by documentChange/documentSave as the user types
+   * `implements IFace` and the method body. Those change/save notifications must
+   * recompile the file into the DATA-OWNER graph — not just the coordinator's
+   * local symbol manager — or the request-pool go-to-implementation never sees
+   * the new implements edge.
+   *
+   * This test drives implementor #2 through documentOpen (no `implements`),
+   * then documentChange (full-text sync: the whole updated document), then
+   * documentSave, then runs go-to-implementation. It must return BOTH
+   * implementors. Before the fix, change/save ran only coordinator-local and the
+   * data-owner kept the edge-less open version, so only FaceImpl resolved.
+   */
+  it('go-to-implementation sees a new implementor added via documentOpen→change→save', async () => {
+    // Implementor #2 starts WITHOUT the implements clause (as a new empty class
+    // would), then gains it via a change + save.
+    const IMPL3_URI = 'file:///test/FaceImpl3.cls';
+    const IMPL3_OPEN_SRC = `public with sharing class FaceImpl3 {
+}`;
+    const IMPL3_FINAL_SRC = `public with sharing class FaceImpl3 implements IFace {
+    public String run() {
+        return 'r3';
+    }
+}`;
+
+    const program = Effect.gen(function* () {
+      const topology = yield* initializeTopology({
+        poolSize: 1,
+        enableResourceLoader: true,
+        logger,
+        logLevel: 'error',
+      });
+      // Serve whichever content each URI currently holds; updated as the
+      // implementor is edited so getDocumentContent (used by request-pool
+      // dispatches) returns the live text.
+      const sources: Record<string, string> = {
+        [IFACE_URI]: IFACE_SRC,
+        [IMPL3_URI]: IMPL3_OPEN_SRC,
+      };
+      const dispatcher = makeWorkerDispatcher(
+        topology,
+        logger,
+        (uri) => sources[uri],
+      );
+      wireProductionMediator(topology, dispatcher, logger);
+      yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+      // 1. Cold-open the interface + load the workspace with implementor #1.
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentOpen', {
+          document: {
+            uri: IFACE_URI,
+            languageId: 'apex',
+            version: 1,
+            getText: () => IFACE_SRC,
+          },
+          textDocument: { uri: IFACE_URI },
+          text: IFACE_SRC,
+        }),
+      );
+      const ingest = dispatcher.createBatchIngestionDispatcher();
+      const compile = dispatcher.createBatchCompileDispatcher();
+      const firstWave = [
+        { uri: IFACE_URI, content: IFACE_SRC, languageId: 'apex', version: 1 },
+        { uri: IMPL_URI, content: IMPL_SRC, languageId: 'apex', version: 1 },
+      ];
+      yield* Effect.promise(() => ingest('wf-live-test', firstWave));
+      yield* Effect.promise(() => compile('wf-live-test', firstWave));
+
+      // 2. First go-to-implementation — caches the current set ([FaceImpl]).
+      const firstResult = yield* Effect.promise(() =>
+        dispatcher.dispatch('implementation', {
+          textDocument: { uri: IFACE_URI },
+          position: { line: 1, character: 11 },
+        }),
+      );
+
+      // 3. Create FaceImpl3 as a new file via documentOpen — NO implements yet.
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentOpen', {
+          document: {
+            uri: IMPL3_URI,
+            languageId: 'apex',
+            version: 1,
+            getText: () => IMPL3_OPEN_SRC,
+          },
+          textDocument: { uri: IMPL3_URI },
+          text: IMPL3_OPEN_SRC,
+        }),
+      );
+
+      // 4. Type the implements clause + method (full-text sync: the change event
+      //    carries the entire updated document), then save.
+      sources[IMPL3_URI] = IMPL3_FINAL_SRC;
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentChange', {
+          document: {
+            uri: IMPL3_URI,
+            languageId: 'apex',
+            version: 2,
+            getText: () => IMPL3_FINAL_SRC,
+          },
+          textDocument: { uri: IMPL3_URI },
+          contentChanges: [{ text: IMPL3_FINAL_SRC }],
+        }),
+      );
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentSave', {
+          document: {
+            uri: IMPL3_URI,
+            languageId: 'apex',
+            version: 2,
+            getText: () => IMPL3_FINAL_SRC,
+          },
+          textDocument: { uri: IMPL3_URI },
+        }),
+      );
+
+      // 5. Second go-to-implementation — must now include FaceImpl3.
+      const secondResult = yield* Effect.promise(() =>
+        dispatcher.dispatch('implementation', {
+          textDocument: { uri: IFACE_URI },
+          position: { line: 1, character: 11 },
+        }),
+      );
+
+      return { firstResult, secondResult };
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(makeNodeWorkerLayer(WORKER_TS_ENTRY, TSX_OPTIONS)),
+    );
+
+    const { firstResult, secondResult } = await Effect.runPromise(program);
+
+    const toUris = (result: unknown): string[] => {
+      const locations = (
+        Array.isArray(result) ? result : result ? [result] : []
+      ) as Array<{ uri?: string; targetUri?: string }>;
+      return locations.map((l) => l.uri ?? l.targetUri ?? '');
+    };
+
+    const firstUris = toUris(firstResult);
+    const secondUris = toUris(secondResult);
+    console.log(
+      `[round-trip:goto-impl-live-edit] first=${JSON.stringify(firstUris)} ` +
+        `second=${JSON.stringify(secondUris)}`,
+    );
+
+    expect(firstUris.some((u) => u.includes('FaceImpl.cls'))).toBe(true);
+
+    // The crux: the edit+save of the new implementor reached the data-owner, so
+    // go-to-implementation discovers it. Before the fix change/save ran only on
+    // the coordinator and FaceImpl3 never appeared.
+    expect(secondUris.some((u) => u.includes('FaceImpl.cls'))).toBe(true);
+    expect(secondUris.some((u) => u.includes('FaceImpl3'))).toBe(true);
   }, 120_000);
 });

--- a/packages/apex-lsp-shared/src/index.ts
+++ b/packages/apex-lsp-shared/src/index.ts
@@ -274,10 +274,43 @@ export type LoadWorkspaceResult =
   | { error: string };
 
 /**
+ * Why a workspace load was triggered. Lets the client show an action-tailored
+ * status message (e.g. "Searching workspace for implementations…") instead of
+ * the generic load text, so a feature that triggers a cold workspace load can
+ * tell the user what it is doing right now.
+ *
+ * 'startup' is the default (explicit workspace load / no specific feature).
+ * Feature reasons are added as features adopt the pattern (implementation is
+ * first; references will follow).
+ */
+export type WorkspaceLoadReason = 'startup' | 'implementation' | 'references';
+
+/**
+ * User-facing status-bar message for each workspace-load reason. The client
+ * shows this (with a busy spinner) at load start and reverts on
+ * apex/workspaceIngestionComplete. Centralized here so server (which sends the
+ * reason) and client (which renders it) stay in agreement, and so new features
+ * adopt the pattern by adding one entry.
+ */
+export const WORKSPACE_LOAD_REASON_MESSAGE: Record<
+  WorkspaceLoadReason,
+  string
+> = {
+  startup: 'Loading Apex workspace…',
+  implementation: 'Searching workspace for implementations…',
+  references: 'Searching workspace for references…',
+};
+
+/**
  * Parameters for server-to-client workspace load request notification
  */
 export interface RequestWorkspaceLoadParams {
   readonly workDoneToken?: ProgressToken;
+  /**
+   * Why the load was requested. The client maps this to an action-tailored
+   * busy status message. Omitted/unknown → treated as 'startup'.
+   */
+  readonly reason?: WorkspaceLoadReason;
 }
 
 /**

--- a/packages/apex-lsp-vscode-extension/src/language-server.ts
+++ b/packages/apex-lsp-vscode-extension/src/language-server.ts
@@ -16,6 +16,7 @@ import type {
 import {
   getClientCapabilitiesForMode,
   getDocumentSelectorsFromSettings,
+  WORKSPACE_LOAD_REASON_MESSAGE,
 } from '@salesforce/apex-lsp-shared';
 import type {
   InitializeParams,
@@ -41,6 +42,7 @@ import {
   updateApexServerStatusReady,
   updateApexServerStatusError,
   updateApexServerStatusStopped,
+  updateApexServerStatusLoading,
   clearIngestionTimeout,
 } from './status-bar';
 import {
@@ -856,6 +858,17 @@ async function createWebLanguageClient(
         'debug',
       );
 
+      // Show an action-tailored busy status the moment the load is requested,
+      // so a feature that triggered a cold load (e.g. go-to-implementation)
+      // tells the user what is happening right now. The generic per-phase load
+      // messages (Scanning…/Sending batches…) follow; this just sets the
+      // initial context. Reverts to ready on apex/workspaceIngestionComplete.
+      if (params.reason && WORKSPACE_LOAD_REASON_MESSAGE[params.reason]) {
+        updateApexServerStatusLoading(
+          WORKSPACE_LOAD_REASON_MESSAGE[params.reason],
+        );
+      }
+
       try {
         await Effect.runPromise(
           Effect.provide(
@@ -1292,6 +1305,17 @@ async function createDesktopLanguageClient(
         '📨 Received apex/requestWorkspaceLoad notification from server',
         'debug',
       );
+
+      // Show an action-tailored busy status the moment the load is requested,
+      // so a feature that triggered a cold load (e.g. go-to-implementation)
+      // tells the user what is happening right now. The generic per-phase load
+      // messages (Scanning…/Sending batches…) follow; this just sets the
+      // initial context. Reverts to ready on apex/workspaceIngestionComplete.
+      if (params.reason && WORKSPACE_LOAD_REASON_MESSAGE[params.reason]) {
+        updateApexServerStatusLoading(
+          WORKSPACE_LOAD_REASON_MESSAGE[params.reason],
+        );
+      }
 
       try {
         await Effect.runPromise(

--- a/packages/apex-lsp-vscode-extension/src/workspace-load-handler.ts
+++ b/packages/apex-lsp-vscode-extension/src/workspace-load-handler.ts
@@ -12,6 +12,7 @@ import type {
   LoadWorkspaceResult,
   ProgressToken,
   WorkspaceLoadCompleteParams,
+  WorkspaceLoadReason,
 } from '@salesforce/apex-lsp-shared';
 import { getDefaultDocumentSelectors } from '@salesforce/apex-lsp-shared';
 import { loadWorkspaceForServer } from './workspace-loader';
@@ -87,6 +88,7 @@ const launchWorkspaceLoaderEffect = (
   languageClient: ClientInterface,
   workDoneToken: ProgressToken | undefined,
   documentSelector: any[],
+  reason?: WorkspaceLoadReason,
 ) =>
   Effect.gen(function* (_) {
     yield* _(setWorkspaceLoading(true));
@@ -99,6 +101,7 @@ const launchWorkspaceLoaderEffect = (
             languageClient,
             workDoneToken,
             documentSelector,
+            reason,
           ),
         ),
         Effect.tapError((e) =>
@@ -140,6 +143,7 @@ export class WorkspaceLoaderService extends Effect.Service<WorkspaceLoaderServic
           languageClient: ClientInterface,
           workDoneToken?: ProgressToken,
           documentSelector?: any[],
+          reason?: WorkspaceLoadReason,
         ) =>
           Effect.gen(function* (_) {
             const {
@@ -168,6 +172,7 @@ export class WorkspaceLoaderService extends Effect.Service<WorkspaceLoaderServic
                   languageClient,
                   workDoneToken,
                   selector,
+                  reason,
                 ),
               ),
             );
@@ -247,6 +252,7 @@ export const startWorkspaceLoad = (
   languageClient: ClientInterface,
   workDoneToken?: ProgressToken,
   documentSelector?: any[],
+  reason?: WorkspaceLoadReason,
 ) =>
   pipe(
     WorkspaceLoaderService,
@@ -255,6 +261,7 @@ export const startWorkspaceLoad = (
         languageClient,
         workDoneToken,
         documentSelector,
+        reason,
       ),
     ),
   );

--- a/packages/apex-lsp-vscode-extension/src/workspace-loader.ts
+++ b/packages/apex-lsp-vscode-extension/src/workspace-loader.ts
@@ -11,10 +11,12 @@ import { findFilesAcrossWorkspaceFolders } from './workspace-find-files';
 import { logToOutputChannel } from './logging';
 import {
   formattedError,
+  WORKSPACE_LOAD_REASON_MESSAGE,
   type ProgressToken,
   type WorkDoneProgress,
   type SendWorkspaceBatchParams,
   type WorkspaceFileBatch,
+  type WorkspaceLoadReason,
 } from '@salesforce/apex-lsp-shared';
 import { getWorkspaceSettings } from './configuration';
 import {
@@ -92,6 +94,7 @@ export async function loadWorkspaceForServer(
   languageClient: any,
   workDoneToken: ProgressToken | undefined,
   documentSelector: any[],
+  reason?: WorkspaceLoadReason,
 ): Promise<void> {
   // Note: State management is now handled by WorkspaceState service
   // This function is kept for internal use by the service only
@@ -126,7 +129,14 @@ export async function loadWorkspaceForServer(
     });
   }
 
-  updateApexServerStatusLoading('Scanning for Apex files...');
+  // When a feature triggered this load (e.g. go-to-implementation), lead with
+  // its action-tailored message so the user sees what is happening right now;
+  // the later phase messages (Found N files / Sending batches…) follow.
+  updateApexServerStatusLoading(
+    reason && WORKSPACE_LOAD_REASON_MESSAGE[reason]
+      ? WORKSPACE_LOAD_REASON_MESSAGE[reason]
+      : 'Scanning for Apex files...',
+  );
 
   // Create the Effect fiber
   const loadEffect = Effect.gen(function* (_: any) {

--- a/packages/apex-lsp-vscode-extension/test/workspace-load-handler.test.ts
+++ b/packages/apex-lsp-vscode-extension/test/workspace-load-handler.test.ts
@@ -269,6 +269,7 @@ describe('Workspace Load Handler', () => {
         mockLanguageClient,
         undefined,
         customSelector,
+        undefined,
       );
     });
 
@@ -286,6 +287,32 @@ describe('Workspace Load Handler', () => {
         mockLanguageClient,
         token,
         expect.any(Array),
+        undefined,
+      );
+    });
+
+    it('should forward the workspace-load reason to the loader', async () => {
+      // The reason drives the client's action-tailored busy status message
+      // (e.g. "Searching workspace for implementations…"). It must reach
+      // loadWorkspaceForServer as the 4th arg.
+      await Effect.runPromise(
+        Effect.provide(
+          startWorkspaceLoad(
+            mockLanguageClient,
+            undefined,
+            undefined,
+            'implementation',
+          ),
+          Layer.mergeAll(WorkspaceStateLive, WorkspaceLoaderServiceLive),
+        ),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(mockLoadWorkspaceForServer).toHaveBeenCalledWith(
+        mockLanguageClient,
+        undefined,
+        expect.any(Array),
+        'implementation',
       );
     });
   });
@@ -306,6 +333,7 @@ describe('Workspace Load Handler', () => {
         mockLanguageClient,
         'test-token',
         expect.any(Array),
+        undefined,
       );
     });
 
@@ -324,6 +352,7 @@ describe('Workspace Load Handler', () => {
         mockLanguageClient,
         undefined,
         expect.any(Array),
+        undefined,
       );
     });
 

--- a/packages/lsp-compliant-services/src/config/ServiceConfiguration.ts
+++ b/packages/lsp-compliant-services/src/config/ServiceConfiguration.ts
@@ -109,14 +109,16 @@ export const DEFAULT_SERVICE_CONFIG: ServiceConfig[] = [
     priority: Priority.Normal,
     timeout: 5000,
     maxRetries: 2,
-    serviceFactory: (deps) => deps.serviceFactory.createDocumentSymbolService(),
+    serviceFactory: (deps) =>
+      deps.serviceFactory.createDocumentSaveProcessingService(),
   },
   {
     requestType: 'documentChange',
     priority: Priority.Normal,
     timeout: 5000,
     maxRetries: 2,
-    serviceFactory: (deps) => deps.serviceFactory.createDocumentSymbolService(),
+    serviceFactory: (deps) =>
+      deps.serviceFactory.createDocumentChangeProcessingService(),
   },
   {
     requestType: 'implementation',

--- a/packages/lsp-compliant-services/src/factories/ServiceFactory.ts
+++ b/packages/lsp-compliant-services/src/factories/ServiceFactory.ts
@@ -22,6 +22,8 @@ import { RenameProcessingService } from '../services/RenameProcessingService';
 import { DiagnosticProcessingService } from '../services/DiagnosticProcessingService';
 import { DocumentSymbolProcessingService } from '../services/DocumentSymbolProcessingService';
 import { DocumentProcessingService } from '../services/DocumentProcessingService';
+import { DocumentChangeProcessingService } from '../services/DocumentChangeProcessingService';
+import { DocumentSaveProcessingService } from '../services/DocumentSaveProcessingService';
 import { DocumentLoadProcessingService } from '../services/DocumentLoadProcessingService';
 import { WorkspaceSymbolProcessingService } from '../services/WorkspaceSymbolProcessingService';
 import { ImplementationProcessingService } from '../services/ImplementationProcessingService';
@@ -261,6 +263,32 @@ export class ServiceFactory {
     const service = new DocumentProcessingService(this.dependencies.logger);
     service.setLayerEnrichmentService(this.getLayerEnrichmentService());
     return service;
+  }
+
+  /**
+   * Create document change processing service.
+   * Used as the coordinator-local fallback for documentChange when the worker
+   * topology is unavailable; shares the same layer-enrichment-configured
+   * DocumentProcessingService pipeline as documentOpen so an edited file is
+   * recompiled into the symbol manager.
+   */
+  createDocumentChangeProcessingService(): DocumentChangeProcessingService {
+    return new DocumentChangeProcessingService(
+      this.dependencies.logger,
+      this.createDocumentProcessingService(),
+    );
+  }
+
+  /**
+   * Create document save processing service.
+   * Coordinator-local fallback for documentSave (workers disabled); recompiles
+   * the saved content into the symbol manager via the shared pipeline.
+   */
+  createDocumentSaveProcessingService(): DocumentSaveProcessingService {
+    return new DocumentSaveProcessingService(
+      this.dependencies.logger,
+      this.createDocumentProcessingService(),
+    );
   }
 
   /**

--- a/packages/lsp-compliant-services/src/index.ts
+++ b/packages/lsp-compliant-services/src/index.ts
@@ -41,7 +41,6 @@ import { ServiceFactory } from './factories/ServiceFactory';
 import { DEFAULT_SERVICE_CONFIG } from './config/ServiceConfiguration';
 import { ApexStorageManager } from './storage/ApexStorageManager';
 import { DocumentChangeBatcher } from './services/DocumentChangeBatcher';
-import { DocumentChangeProcessingService } from './services/DocumentChangeProcessingService';
 
 // Export storage interfaces and classes
 export * from './storage/ApexStorageBase';
@@ -203,12 +202,24 @@ let changeBatcher: DocumentChangeBatcher | null = null;
 
 /**
  * Dispatch function for document change events (LSP notification - fire-and-forget)
- * Routes through DocumentChangeBatcher for per-URI debounce, then delegates
- * to the shared tier-1 pipeline (same as didOpen).
+ * Routes through DocumentChangeBatcher for per-URI debounce, then submits a
+ * documentChange notification to the queue manager. When the worker topology is
+ * active the queue dispatches the change to the data-owner -> compilation worker
+ * (recompiling the file's current content and writing its symbols back to the
+ * single-writer graph); when workers are disabled it falls back to the local
+ * document-processing handler. This keeps the data-owner graph current as a file
+ * is edited — without it, edits to an already-open file (e.g. adding
+ * `implements MyInterface` to a freshly-created class) only updated the
+ * coordinator's local symbol manager, so request-pool features that read the
+ * data-owner graph (go-to-implementation, references) never saw the new edges.
  *
  * The document is stored in ApexStorage immediately so that LSP requests
  * (documentSymbol, hover, etc.) that arrive before the debounce timer fires
  * can still find the latest document content.
+ *
+ * The LS negotiates full-text sync (TextDocumentSyncKind.Full), so each change
+ * event carries the entire updated document; event.document.getText() is the
+ * authoritative current content used to build the compile message.
  * @param event The document change event
  */
 export const dispatchProcessOnChangeDocument = (
@@ -227,12 +238,14 @@ export const dispatchProcessOnChangeDocument = (
 
   if (!changeBatcher) {
     const logger = getLogger();
-    const processor = new DocumentChangeProcessingService(logger);
     changeBatcher = new DocumentChangeBatcher(
       logger,
       (ev) =>
         new Promise<void>((resolve) => {
-          processor.processDocumentChange(ev);
+          // Per-URI debounce has collapsed rapid typing to the latest version;
+          // submit that version to the queue so the data-owner recompiles it
+          // (or the local handler does, when workers are disabled).
+          LSPQueueManager.getInstance().submitDocumentChangeNotification(ev);
           resolve();
         }),
     );
@@ -254,14 +267,26 @@ export const dispatchProcessOnCloseDocument = (
 
 /**
  * Dispatch function for document save events (LSP notification - fire-and-forget)
+ *
+ * Submits a documentSave notification to the queue manager. When the worker
+ * topology is active the queue dispatches the save to the data-owner ->
+ * compilation worker so the file's saved content is recompiled into the
+ * single-writer graph; when workers are disabled it falls back to the local
+ * save handler. A save is the authoritative final content, so (unlike change)
+ * it is submitted without debounce. The document is stored immediately so any
+ * read racing the dispatch sees the saved content.
  * @param event The document save event
  */
 export const dispatchProcessOnSaveDocument = (
   event: TextDocumentChangeEvent<TextDocument>,
 ): void => {
-  const handler = HandlerFactory.createDidSaveDocumentHandler();
-  // Error handling is done internally in handleDocumentSave
-  handler.handleDocumentSave(event);
+  try {
+    const storage = ApexStorageManager.getInstance().getStorage();
+    void storage.setDocument(event.document.uri, event.document);
+  } catch {
+    // Storage may not be initialised yet during early startup.
+  }
+  LSPQueueManager.getInstance().submitDocumentSaveNotification(event);
 };
 
 /**

--- a/packages/lsp-compliant-services/src/services/WorkspaceLoadCoordinator.ts
+++ b/packages/lsp-compliant-services/src/services/WorkspaceLoadCoordinator.ts
@@ -11,6 +11,7 @@ import {
   LoggerInterface,
   RequestWorkspaceLoadParams,
   WorkspaceLoadCompleteParams,
+  WorkspaceLoadReason,
 } from '@salesforce/apex-lsp-shared';
 import { Effect, Ref } from 'effect';
 
@@ -80,19 +81,22 @@ function sendRequestWorkspaceLoadNotification(
   connection: WorkspaceLoadConnection,
   logger: LoggerInterface,
   workDoneToken?: ProgressToken,
+  reason?: WorkspaceLoadReason,
 ): Effect.Effect<void, never, never> {
   return Effect.gen(function* () {
     const notificationStartTime = Date.now();
     const tokenStatus = workDoneToken ? 'present' : 'none';
     logger.debug(
       () =>
-        `[WORKSPACE-LOAD] Sending request notification (workDoneToken: ${tokenStatus}) at ${notificationStartTime}`,
+        `[WORKSPACE-LOAD] Sending request notification (workDoneToken: ${tokenStatus}, ` +
+        `reason: ${reason ?? 'startup'}) at ${notificationStartTime}`,
     );
 
     // sendNotification is synchronous and returns void
     try {
       connection.sendNotification('apex/requestWorkspaceLoad', {
         workDoneToken,
+        ...(reason ? { reason } : {}),
       } as RequestWorkspaceLoadParams);
     } catch (error) {
       logger.error(
@@ -183,12 +187,15 @@ export function onWorkspaceLoadFailed(
  * @param connection Connection for server-client communication
  * @param logger Logger for debug/error messages
  * @param workDoneToken Optional progress token from client
+ * @param reason Why the load was triggered; the client maps it to an
+ *   action-tailored busy status message (defaults to 'startup' when omitted)
  * @returns Effect that resolves immediately (fire-and-forget notification)
  */
 export function ensureWorkspaceLoaded(
   connection: WorkspaceLoadConnection,
   logger: LoggerInterface,
   workDoneToken?: ProgressToken,
+  reason?: WorkspaceLoadReason,
 ): Effect.Effect<void, never, never> {
   return Effect.gen(function* () {
     // Check local state first
@@ -215,6 +222,7 @@ export function ensureWorkspaceLoaded(
       connection,
       logger,
       workDoneToken,
+      reason,
     );
   });
 }


### PR DESCRIPTION
### What does this PR do?

Follow-up to the worker-topology go-to-implementation work: fixes the last live cold-start gap where a newly-created implementor wasn't discovered, and gives the user an action-tailored status while a cold request loads the workspace.

**Compile didChange/didSave into the data-owner graph**
- Only `didOpen` was routed through the queue/dispatcher to the data-owner; `didChange` and `didSave` ran coordinator-local compiles. So editing an already-open file (or creating a new one and typing `implements MyInterface`) built the supertype edge only in the coordinator's local symbol manager — never the data-owner graph that go-to-implementation reads on the request pool. The new implementor stayed invisible until a later full reload.
- Route `didChange` (debounced) and `didSave` through `submitDocumentChange/SaveNotification` so the dispatcher compiles them into the data-owner like `didOpen`. Full-text sync means each event carries the whole document.
- Add `documentSave` to the dispatcher's compile+write-back branch and give the data-owner `DispatchDocumentSave` a real handler (store version placeholder + arm readiness) in both worker platforms, so the save's write-back is accepted.
- Fix the `workers.enabled=false` local fallback: `documentChange`/`documentSave` were wired to a service lacking `processDocumentChange/Save`; added factory methods that compile via the shared pipeline and repointed the service config.

**Action-tailored status while a request loads the workspace**
- A cold go-to-implementation triggers a fire-and-forget workspace load and returns before the graph is populated, so the client renders "No implementations found" and the user retries. Blocking the IDE on a (possibly huge) load isn't acceptable, and `textDocument/implementation` can't use LSP progress/partial results with this client (no token advertised) — so surface activity through the existing status-bar busy indicator.
- Reusable pattern: a shared `WorkspaceLoadReason` type + message map; an optional `reason` threaded through `apex/requestWorkspaceLoad` and the client loader. `onImplementation` passes `'implementation'`, so the status bar shows a busy "Searching workspace for implementations…" at load start, reverting to ready on `apex/workspaceIngestionComplete`. (References will adopt the same pattern.)

Regression coverage: `EnrichmentRoundTrip` drives a new implementor through documentOpen → documentChange → documentSave and asserts go-to-implementation then returns both implementors; `workspace-load-handler` asserts the reason is forwarded to the loader. Full workspace suite green (4488 passed, 0 failed).

### What issues does this PR fix or reference?

@W-23006798@, @W-22629627@
