### PR TITLE
fix(apex-ls): repair test typecheck drift + surface missing exports - W-23133822

### DIFF
--- a/packages/apex-ls/src/server/CoordinatorAssistanceMediator.ts
+++ b/packages/apex-ls/src/server/CoordinatorAssistanceMediator.ts
@@ -28,6 +28,11 @@ import {
   type WorkerLogMessage,
 } from '@salesforce/apex-lsp-shared';
 
+export type {
+  AssistanceRequestPayload,
+  AssistanceResponsePayload,
+} from '@salesforce/apex-lsp-shared';
+
 export type AssistanceHandler = (
   method: string,
   params: unknown,

--- a/packages/apex-ls/test/index.test.ts
+++ b/packages/apex-ls/test/index.test.ts
@@ -116,6 +116,9 @@ const mockConnection: MockConnection & {
   sendRequest?: jest.Mock;
   onNotification?: jest.Mock;
   onDidChangeConfiguration?: jest.Mock;
+  telemetry?: {
+    logEvent?: jest.Mock;
+  };
 } = {
   onInitialize: jest.fn(),
   onInitialized: jest.fn(),
@@ -209,7 +212,7 @@ mockConnection.onRequest.mockImplementation(
     if (method === 'textDocument/diagnostic') {
       mockHandlers.onRequest = handler;
     } else if (method === '$/ping') {
-      mockHandlers.ping = handler;
+      mockHandlers.ping = handler as unknown as PingHandler;
     }
     return mockConnection;
   },

--- a/packages/apex-ls/test/integration/ColdStartWriteBackGate.node.test.ts
+++ b/packages/apex-ls/test/integration/ColdStartWriteBackGate.node.test.ts
@@ -173,7 +173,7 @@ describe('Cold-start write-back + readiness gate (live assistance bus)', () => {
 
       const startedAt = yield* Effect.sync(() => Date.now());
       const readiness = yield* Effect.promise(() =>
-        dispatcher.awaitSymbolDataReady(
+        dispatcher.awaitSymbolDataReady!(
           TEST_URI,
           MATCH_LATEST_VERSION,
           GATE_BUDGET_MS,
@@ -261,7 +261,7 @@ describe('Cold-start write-back + readiness gate (live assistance bus)', () => {
 
       const startedAt = yield* Effect.sync(() => Date.now());
       const readiness = yield* Effect.promise(() =>
-        dispatcher.awaitSymbolDataReady(
+        dispatcher.awaitSymbolDataReady!(
           TEST_URI,
           MATCH_LATEST_VERSION,
           GATE_BUDGET_MS,
@@ -356,7 +356,7 @@ describe('Cold-start write-back + readiness gate (live assistance bus)', () => {
 
       const startedAt = yield* Effect.sync(() => Date.now());
       const readiness = yield* Effect.promise(() =>
-        dispatcher.awaitSymbolDataReady(
+        dispatcher.awaitSymbolDataReady!(
           STDLIB_URI,
           MATCH_LATEST_VERSION,
           GATE_BUDGET_MS,
@@ -440,7 +440,7 @@ describe('Cold-start write-back + readiness gate (live assistance bus)', () => {
 
       const startedAt = yield* Effect.sync(() => Date.now());
       const readiness = yield* Effect.promise(() =>
-        dispatcher.awaitSymbolDataReady(
+        dispatcher.awaitSymbolDataReady!(
           TEST_URI,
           MATCH_LATEST_VERSION,
           GATE_BUDGET_MS,

--- a/packages/apex-ls/test/integration/WorkerConcurrencyInterop.node.test.ts
+++ b/packages/apex-ls/test/integration/WorkerConcurrencyInterop.node.test.ts
@@ -160,7 +160,7 @@ describe('Worker concurrency + interop (live assistance bus)', () => {
         dispatcher.dispatch('documentOpen', openParams(URI, classV1, 1)),
       );
       const readyV1 = yield* Effect.promise(() =>
-        dispatcher.awaitSymbolDataReady(URI, 1, SMALL_BUDGET_MS),
+        dispatcher.awaitSymbolDataReady!(URI, 1, SMALL_BUDGET_MS),
       );
 
       // 2. Change to v2 (beta) DETACHED: dispatch() awaits the store leg (arming
@@ -177,7 +177,7 @@ describe('Worker concurrency + interop (live assistance bus)', () => {
       // 3. Reader gates for the latest armed version (v2).
       const startedAt = yield* Effect.sync(() => Date.now());
       const readiness = yield* Effect.promise(() =>
-        dispatcher.awaitSymbolDataReady(
+        dispatcher.awaitSymbolDataReady!(
           URI,
           MATCH_LATEST_VERSION,
           SMALL_BUDGET_MS,
@@ -433,7 +433,7 @@ describe('Worker concurrency + interop (live assistance bus)', () => {
       //    the single v2 Deferred; the v2 write-back must wake them ALL.
       const awaiters = Array.from({ length: AWAITERS }, () =>
         Effect.promise(() =>
-          dispatcher.awaitSymbolDataReady(uri, MATCH_LATEST_VERSION, 5000),
+          dispatcher.awaitSymbolDataReady!(uri, MATCH_LATEST_VERSION, 5000),
         ),
       );
       const results = (yield* Effect.all(awaiters, {

--- a/packages/apex-ls/test/queue-integration.test.ts
+++ b/packages/apex-ls/test/queue-integration.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { LSPQueueManager } from '@salesforce/apex-lsp-compliant-services';
-import { TextDocumentChangeEvent } from 'vscode-languageserver';
+import { Diagnostic, TextDocumentChangeEvent } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
 // Mock the LSPQueueManager
@@ -56,10 +56,9 @@ describe('Queue Integration in apex-ls', () => {
           offsetAt: jest.fn(),
           lineCount: 1001,
         },
-        contentChanges: [],
       };
 
-      const expectedDiagnostics = [];
+      const expectedDiagnostics: Diagnostic[] = [];
       mockQueueManager.submitDocumentOpenRequest.mockResolvedValue(
         expectedDiagnostics,
       );
@@ -89,7 +88,6 @@ describe('Queue Integration in apex-ls', () => {
           offsetAt: jest.fn(),
           lineCount: 1,
         },
-        contentChanges: [],
       };
 
       // Simulate the logic from apex-ls
@@ -113,7 +111,6 @@ describe('Queue Integration in apex-ls', () => {
           offsetAt: jest.fn(),
           lineCount: 1001,
         },
-        contentChanges: [],
       };
 
       const error = new Error('Queue processing failed');
@@ -141,7 +138,6 @@ describe('Queue Integration in apex-ls', () => {
           offsetAt: jest.fn(),
           lineCount: 1,
         },
-        contentChanges: [],
       };
 
       mockQueueManager.submitDocumentSaveRequest.mockResolvedValue(undefined);
@@ -164,7 +160,6 @@ describe('Queue Integration in apex-ls', () => {
           offsetAt: jest.fn(),
           lineCount: 1,
         },
-        contentChanges: [],
       };
 
       const error = new Error('Save processing failed');
@@ -191,7 +186,6 @@ describe('Queue Integration in apex-ls', () => {
           offsetAt: jest.fn(),
           lineCount: 1,
         },
-        contentChanges: [],
       };
 
       mockQueueManager.submitDocumentCloseRequest.mockResolvedValue(undefined);
@@ -214,7 +208,6 @@ describe('Queue Integration in apex-ls', () => {
           offsetAt: jest.fn(),
           lineCount: 1,
         },
-        contentChanges: [],
       };
 
       const error = new Error('Close processing failed');
@@ -334,7 +327,6 @@ describe('Queue Integration in apex-ls', () => {
           offsetAt: jest.fn(),
           lineCount: 1,
         },
-        contentChanges: [],
       };
 
       const error = new Error('Queue operation failed');
@@ -362,7 +354,6 @@ describe('Queue Integration in apex-ls', () => {
           offsetAt: jest.fn(),
           lineCount: 1,
         },
-        contentChanges: [],
       }));
 
       mockQueueManager.submitDocumentOpenRequest.mockResolvedValue([]);

--- a/packages/apex-ls/test/server/LCSAdapter-apexlib.test.ts
+++ b/packages/apex-ls/test/server/LCSAdapter-apexlib.test.ts
@@ -103,6 +103,11 @@ describe('LCSAdapter - ApexLib Support', () => {
       listen: jest.fn(),
     } as any;
 
+    // The constructor is private (public creation is via LCSAdapter.create,
+    // which also runs initialize()); this test only needs a constructed
+    // instance, so bypass the privacy check the same way the other LCSAdapter
+    // unit tests do.
+    // @ts-expect-error - private constructor, intentional direct construction
     adapter = new LCSAdapter({
       connection: mockConnection,
       logger: {
@@ -110,6 +115,8 @@ describe('LCSAdapter - ApexLib Support', () => {
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        log: jest.fn(),
+        alwaysLog: jest.fn(),
       },
     });
   });
@@ -120,12 +127,19 @@ describe('LCSAdapter - ApexLib Support', () => {
     });
 
     it('should have connection methods available', () => {
+      // hover/completion/documentSymbol/definition are not part of the current
+      // connection.languages feature type, but the mock fabricates them; read
+      // through an untyped view to assert on the mock's own structure.
+      const languages = mockConnection.languages as unknown as Record<
+        string,
+        { on: jest.Mock }
+      >;
       expect(mockConnection.languages.diagnostics.on).toBeDefined();
-      expect(mockConnection.languages.hover.on).toBeDefined();
-      expect(mockConnection.languages.completion.on).toBeDefined();
-      expect(mockConnection.languages.documentSymbol.on).toBeDefined();
+      expect(languages.hover.on).toBeDefined();
+      expect(languages.completion.on).toBeDefined();
+      expect(languages.documentSymbol.on).toBeDefined();
       expect(mockConnection.languages.foldingRange.on).toBeDefined();
-      expect(mockConnection.languages.definition.on).toBeDefined();
+      expect(languages.definition.on).toBeDefined();
       expect(mockConnection.onRequest).toBeDefined();
     });
   });

--- a/packages/apex-ls/test/server/LCSAdapter-capabilities.test.ts
+++ b/packages/apex-ls/test/server/LCSAdapter-capabilities.test.ts
@@ -8,7 +8,10 @@
 
 import { LCSAdapter } from '../../src/server/LCSAdapter';
 import { LSPConfigurationManager } from '@salesforce/apex-lsp-shared';
-import { ClientCapabilities } from 'vscode-languageserver-protocol';
+import {
+  ClientCapabilities,
+  ServerCapabilities,
+} from 'vscode-languageserver-protocol';
 
 // Mock the dependencies
 jest.mock('@salesforce/apex-lsp-shared', () => ({
@@ -110,7 +113,12 @@ describe('LCSAdapter Capabilities Alignment', () => {
       mockConfigManager,
     );
 
-    // Create adapter instance with proper config
+    // Create adapter instance with proper config.
+    // The constructor is private (public creation is via LCSAdapter.create,
+    // which also runs initialize()); these tests only need a constructed
+    // instance, so bypass the privacy check the same way the other LCSAdapter
+    // unit tests do.
+    // @ts-expect-error - private constructor, intentional direct construction
     adapter = new LCSAdapter({
       connection: mockConnection,
       logger: {
@@ -118,6 +126,8 @@ describe('LCSAdapter Capabilities Alignment', () => {
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        log: jest.fn(),
+        alwaysLog: jest.fn(),
       },
     });
   });
@@ -138,7 +148,7 @@ describe('LCSAdapter Capabilities Alignment', () => {
           triggerCharacters: ['.'],
           resolveProvider: false,
         },
-      });
+      } as ServerCapabilities);
 
       // Mock client capabilities that support dynamic registration
       const clientCapabilities: ClientCapabilities = {
@@ -194,7 +204,7 @@ describe('LCSAdapter Capabilities Alignment', () => {
           triggerCharacters: ['.'],
           resolveProvider: false,
         },
-      });
+      } as ServerCapabilities);
 
       // Mock production client capabilities (minimal dynamic registration)
       const productionClientCapabilities: ClientCapabilities = {
@@ -243,7 +253,7 @@ describe('LCSAdapter Capabilities Alignment', () => {
           triggerCharacters: ['.'],
           resolveProvider: false,
         },
-      });
+      } as ServerCapabilities);
 
       // Mock development client capabilities (full dynamic registration)
       const developmentClientCapabilities: ClientCapabilities = {
@@ -310,7 +320,7 @@ describe('LCSAdapter Capabilities Alignment', () => {
               triggerCharacters: ['.'],
               resolveProvider: false,
             },
-          },
+          } as ServerCapabilities,
           expectedDynamicRegistrations: 0, // All should be static in production
         },
         {
@@ -343,7 +353,7 @@ describe('LCSAdapter Capabilities Alignment', () => {
               triggerCharacters: ['.'],
               resolveProvider: false,
             },
-          },
+          } as ServerCapabilities,
           expectedDynamicRegistrations: 5, // All should be dynamic in development
         },
       ];

--- a/packages/apex-ls/test/server/ResourceLoaderProxy.node.test.ts
+++ b/packages/apex-ls/test/server/ResourceLoaderProxy.node.test.ts
@@ -12,7 +12,7 @@ import {
   makeNodeWorkerLayer,
 } from '../../src/server/WorkerCoordinator';
 import { ResourceLoaderProxy } from '../../src/server/ResourceLoaderProxy';
-import { Effect, Scope } from 'effect';
+import { Effect, Exit, Scope } from 'effect';
 import type { LoggerInterface } from '@salesforce/apex-lsp-shared';
 import type { WorkerTopology } from '../../src/server/WorkerCoordinator';
 
@@ -53,7 +53,7 @@ describe('ResourceLoaderProxy (Step 9)', () => {
   }, 120_000);
 
   afterAll(async () => {
-    await Effect.runPromise(Scope.close(scope, Effect.void));
+    await Effect.runPromise(Scope.close(scope, Exit.void));
   }, 30_000);
 
   it('getSymbolTable returns data for known stdlib class', async () => {

--- a/packages/apex-ls/test/server/WorkerCoordinator.node.test.ts
+++ b/packages/apex-ls/test/server/WorkerCoordinator.node.test.ts
@@ -24,7 +24,7 @@ import {
   QuerySymbolSubset,
   UpdateSymbolSubset,
 } from '@salesforce/apex-lsp-shared';
-import { Effect, Scope } from 'effect';
+import { Effect, Exit, Scope } from 'effect';
 import type { LoggerInterface } from '@salesforce/apex-lsp-shared';
 import type { WorkerTopology } from '../../src/server/WorkerCoordinator';
 type DispatcherResult = ReturnType<typeof makeWorkerDispatcher>;
@@ -95,7 +95,7 @@ describe('WorkerCoordinator', () => {
       }, 120_000);
 
       afterAll(async () => {
-        await Effect.runPromise(Scope.close(scope, Effect.void));
+        await Effect.runPromise(Scope.close(scope, Exit.void));
       }, 30_000);
 
       it('spawns data-owner + enrichment pool, ping round-trips on both', async () => {
@@ -223,7 +223,7 @@ describe('WorkerCoordinator', () => {
       }, 120_000);
 
       afterAll(async () => {
-        await Effect.runPromise(Scope.close(scope, Effect.void));
+        await Effect.runPromise(Scope.close(scope, Exit.void));
       }, 30_000);
 
       it('spawns optional resource-loader when enabled', async () => {
@@ -276,7 +276,7 @@ describe('WorkerCoordinator', () => {
     }, 120_000);
 
     afterAll(async () => {
-      await Effect.runPromise(Scope.close(scope, Effect.void));
+      await Effect.runPromise(Scope.close(scope, Exit.void));
     }, 30_000);
 
     it('isAvailable returns true by default', () => {

--- a/packages/lsp-compliant-services/src/index.ts
+++ b/packages/lsp-compliant-services/src/index.ts
@@ -151,6 +151,10 @@ export type {
   WorkerHandle,
   PoolHandle,
 } from './workers/WorkerTransport';
+export {
+  TransportSpawnError,
+  TransportSendError,
+} from './workers/WorkerTransport';
 export type {
   WorkerDispatchStrategy,
   WorkerTopologyStatus,


### PR DESCRIPTION
`npm run typecheck -w @salesforce/apex-ls` failed with **42 errors across 10 test files** on a clean `main` — all test-only type drift originating ~#462 (LCSAdapter/connection refactor). Source files compiled clean, but the failures redden CI on every branch cut from `main`. This restores a green typecheck.

### What changed
**Production source (export-only, no logic change):**
- `CoordinatorAssistanceMediator.ts` — re-export `AssistanceRequestPayload` / `AssistanceResponsePayload` from `@salesforce/apex-lsp-shared` (their canonical source) so tests can import them.
- `lsp-compliant-services/src/index.ts` — surface the existing `TransportSpawnError` / `TransportSendError` classes through the package index.

**Test files (mock/type drift):**
- `queue-integration.test.ts` — drop stale `contentChanges` from `TextDocumentChangeEvent` literals; type `expectedDiagnostics` as `Diagnostic[]`.
- `index.test.ts` — add `telemetry` to the inline MockConnection type; cast the captured `$/ping` handler to `PingHandler`.
- `ColdStartWriteBackGate.node.test.ts` / `WorkerConcurrencyInterop.node.test.ts` — non-null-assert the optional `awaitSymbolDataReady` (always provided by `makeWorkerDispatcher`).
- `LCSAdapter-capabilities.test.ts` / `LCSAdapter-apexlib.test.ts` — align capability mocks with the current shape; keep the established direct-construction test pattern.
- `ResourceLoaderProxy.node.test.ts` / `WorkerCoordinator.node.test.ts` — `Scope.close` now requires an `Exit` (`Effect.void` → `Exit.void`).

### Verification
- `npm run typecheck -w @salesforce/apex-ls` → **0 errors** (was 42).
- `npm test -w @salesforce/apex-ls` → **174/174 pass**, snapshots unchanged. Full monorepo pre-commit suite: 4511 passed, 0 failed.
- No production logic changed — only the two re-exports above.

### What issues does this PR fix or reference?
@W-23133822@
