### PR TITLE
fix(apex-lsp-extension): route code-server to desktop client; commit stable version to main - W-23140779

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -692,3 +692,81 @@ jobs:
               echo "Tracking tag pushed: $TRACKING_TAG"
             fi
           fi
+
+  # ── commit-stable-version ────────────────────────────────────────────────
+  # Stable slot only: advance main's package.json to the published stable
+  # version so the next nightly derives its version from the stable line. With
+  # the odd/even minor scheme, an even-minor stable (e.g. 0.6.1) makes the next
+  # nightly bump to the next odd minor (0.7.0). Pre-release publishes must NOT
+  # touch main's version. Idempotent and monotonic: only bumps when
+  # stable-version is strictly greater than main's current version.
+  commit-stable-version:
+    needs: [prepare, publish, create-github-release, tag-published]
+    if: needs.publish.result == 'success' && inputs.slot == 'stable'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.IDEE_GH_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+
+      - name: Commit stable version bump to main
+        env:
+          STABLE_VERSION: ${{ needs.prepare.outputs.stable-version }}
+          DRY_RUN: ${{ inputs.dry-run || 'false' }}
+          GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+        run: |
+          set -euo pipefail
+          PKG_DIR="packages/apex-lsp-vscode-extension"
+          CURRENT_VERSION=$(node -p "require('./$PKG_DIR/package.json').version")
+          echo "main version: $CURRENT_VERSION -> stable version: $STABLE_VERSION"
+
+          if [ -z "$STABLE_VERSION" ]; then
+            echo "Error: stable-version is empty but slot is stable"
+            exit 1
+          fi
+
+          # Monotonic guard: never move main backwards or sideways.
+          IS_GT=$(node -e "const s=require('semver'); console.log(s.gt('$STABLE_VERSION', '$CURRENT_VERSION') ? 'yes' : 'no');")
+          if [ "$IS_GT" != "yes" ]; then
+            echo "Skipping commit-back: main ($CURRENT_VERSION) is already >= stable ($STABLE_VERSION)"
+            exit 0
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY RUN: Would set $PKG_DIR to $STABLE_VERSION and commit to main"
+            exit 0
+          fi
+
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+
+          ( cd "$PKG_DIR" && npm version "$STABLE_VERSION" --no-git-tag-version )
+
+          git add "$PKG_DIR/package.json"
+          if git diff --staged --quiet; then
+            echo "No version change to commit - skipping (idempotent rerun)"
+            exit 0
+          fi
+
+          git commit -m "chore: set stable version $STABLE_VERSION [skip ci]"
+
+          echo "Pushing stable version bump to main..."
+          if ! git push origin HEAD:main; then
+            echo "Push failed, attempting fetch+rebase and retry..."
+            git fetch origin main
+            git rebase origin/main
+            if ! git push origin HEAD:main; then
+              echo "Error: Push failed after rebase. Check branch protection rules."
+              exit 1
+            fi
+          fi
+          echo "main package.json set to $STABLE_VERSION"

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -320,3 +320,76 @@ jobs:
               echo "Tracking tag pushed: $TRACKING_TAG"
             fi
           fi
+
+  # ── commit-stable-version ────────────────────────────────────────────────
+  # Advance main's package.json to the published stable version so the next
+  # nightly derives its version from the stable line. With the odd/even minor
+  # scheme, an even-minor stable (e.g. 0.6.0) makes the next nightly bump to the
+  # next odd minor (0.7.0). Without this, main stays on the old nightly line and
+  # the marketplace version diverges from the repo. Idempotent and monotonic:
+  # only bumps when stable-version is strictly greater than main's current
+  # version, so reruns and out-of-order promotions never move main backwards.
+  commit-stable-version:
+    needs: [find-prerelease-candidate, create-github-release, tag-stable]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.IDEE_GH_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+
+      - name: Commit stable version bump to main
+        env:
+          STABLE_VERSION: ${{ needs.find-prerelease-candidate.outputs.stable-version }}
+          DRY_RUN: ${{ inputs.dry-run || 'false' }}
+          GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+        run: |
+          set -euo pipefail
+          PKG_DIR="packages/apex-lsp-vscode-extension"
+          CURRENT_VERSION=$(node -p "require('./$PKG_DIR/package.json').version")
+          echo "main version: $CURRENT_VERSION -> stable version: $STABLE_VERSION"
+
+          # Monotonic guard: never move main backwards or sideways.
+          IS_GT=$(node -e "const s=require('semver'); console.log(s.gt('$STABLE_VERSION', '$CURRENT_VERSION') ? 'yes' : 'no');")
+          if [ "$IS_GT" != "yes" ]; then
+            echo "Skipping commit-back: main ($CURRENT_VERSION) is already >= stable ($STABLE_VERSION)"
+            exit 0
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY RUN: Would set $PKG_DIR to $STABLE_VERSION and commit to main"
+            exit 0
+          fi
+
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+
+          ( cd "$PKG_DIR" && npm version "$STABLE_VERSION" --no-git-tag-version )
+
+          git add "$PKG_DIR/package.json"
+          if git diff --staged --quiet; then
+            echo "No version change to commit - skipping (idempotent rerun)"
+            exit 0
+          fi
+
+          git commit -m "chore: set stable version $STABLE_VERSION [skip ci]"
+
+          echo "Pushing stable version bump to main..."
+          if ! git push origin HEAD:main; then
+            echo "Push failed, attempting fetch+rebase and retry..."
+            git fetch origin main
+            git rebase origin/main
+            if ! git push origin HEAD:main; then
+              echo "Error: Push failed after rebase. Check branch protection rules."
+              exit 1
+            fi
+          fi
+          echo "main package.json set to $STABLE_VERSION"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27548,7 +27548,7 @@
     },
     "packages/apex-lsp-vscode-extension": {
       "name": "apex-language-server-extension",
-      "version": "0.5.113",
+      "version": "0.6.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/apex-lsp-compliant-services": "1.0.0",

--- a/packages/apex-lsp-vscode-extension/esbuild.config.ts
+++ b/packages/apex-lsp-vscode-extension/esbuild.config.ts
@@ -28,7 +28,9 @@ const builds: BuildOptions[] = [
     format: 'cjs',
     outExtension: { '.js': '.js' },
     sourcemap: true,
-    external: ['vscode', 'vm', 'net', 'worker_threads', 'web-worker'],
+    external: ['vscode', 'vm', 'net', 'worker_threads'],
+    // Node bundle runs in a Node extension host (desktop VS Code + code-server).
+    define: { __APEX_LS_TARGET__: '"desktop"' },
     footer: undefined,
     keepNames: true,
     loader: {
@@ -102,7 +104,8 @@ const builds: BuildOptions[] = [
       NodeGlobalsPolyfillPlugin({ process: true, buffer: true }),
       NodeModulesPolyfillPlugin(),
     ],
-    define: { global: 'globalThis' },
+    // Browser bundle runs in a web-worker extension host (vscode.dev).
+    define: { global: 'globalThis', __APEX_LS_TARGET__: '"web"' },
     alias: NODE_POLYFILLS,
     keepNames: true,
     loader: {

--- a/packages/apex-lsp-vscode-extension/package.json
+++ b/packages/apex-lsp-vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Salesforce Apex Language Server (Typescript)",
   "description": "VSCode extension for Apex Language Server",
   "icon": "resources/ApexTsIcon.png",
-  "version": "0.5.113",
+  "version": "0.6.1",
   "publisher": "salesforce",
   "sideEffects": false,
   "license": "BSD-3-Clause",

--- a/packages/apex-lsp-vscode-extension/src/language-server.ts
+++ b/packages/apex-lsp-vscode-extension/src/language-server.ts
@@ -95,14 +95,31 @@ function registerIngestionCompleteHandler(client: ClientInterface) {
 }
 
 /**
+ * Compile-time bundle target, injected by esbuild `define`:
+ *   - the Node bundle (dist/extension.js)  -> 'desktop'
+ *   - the browser bundle (dist/extension.web.js) -> 'web'
+ *
+ * The bundle target IS the extension-host type, which is the correct
+ * desktop-vs-web discriminator. `vscode.env.uiKind` only reports where the UI
+ * renders, so it misclassifies a Node extension host with a browser-rendered
+ * UI (e.g. code-server) as 'web' — sending it down the web-worker client path,
+ * which a Node host cannot run. Declared loosely so unbundled runs (tests,
+ * tsc-only) fall back to the uiKind heuristic below.
+ */
+declare const __APEX_LS_TARGET__: 'desktop' | 'web' | undefined;
+
+/**
  * Environment detection
  */
-function detectEnvironment(): 'desktop' | 'web' {
-  // Check if we're in a web environment (VSCode for web)
-  if (vscode.env.uiKind === vscode.UIKind.Web) {
-    return 'web';
+export function detectEnvironment(): 'desktop' | 'web' {
+  // Bundle target is authoritative: the Node entry point only loads in a Node
+  // extension host (desktop VS Code AND code-server), the browser entry point
+  // only loads in a web-worker host (vscode.dev).
+  if (typeof __APEX_LS_TARGET__ !== 'undefined') {
+    return __APEX_LS_TARGET__;
   }
-  return 'desktop';
+  // Fallback for unbundled execution (no define injected): approximate via UI kind.
+  return vscode.env.uiKind === vscode.UIKind.Web ? 'web' : 'desktop';
 }
 
 /**

--- a/packages/apex-lsp-vscode-extension/test/language-server.test.ts
+++ b/packages/apex-lsp-vscode-extension/test/language-server.test.ts
@@ -8,16 +8,64 @@
 
 /**
  * Language Server Module Tests
- *
- * Note: The language server implementation has been significantly refactored.
- * The previous tests were testing against an outdated API that no longer exists.
- * These tests have been removed as they were testing non-existent functionality.
- *
- * TODO: Add new tests that match the current language server implementation.
  */
 
-describe('Language Server Module', () => {
-  it('should pass basic test', () => {
-    expect(true).toBe(true);
+// The shared vscode mock omits env/UIKind; provide them for environment detection.
+jest.mock('vscode', () => ({
+  ...jest.requireActual('vscode'),
+  env: { uiKind: 1, language: 'en' },
+  UIKind: { Desktop: 1, Web: 2 },
+}));
+
+// vscode-languageclient pulls in browser/node globals that are absent under Jest;
+// stub the surface language-server.ts touches at import time.
+jest.mock('vscode-languageclient', () => ({
+  Trace: { Off: 0, Messages: 1, Verbose: 2 },
+  State: { Stopped: 1, Starting: 2, Running: 3 },
+}));
+jest.mock('vscode-languageclient/node', () => ({
+  Trace: { Off: 0, Messages: 1, Verbose: 2 },
+  State: { Stopped: 1, Starting: 2, Running: 3 },
+  LanguageClient: class {},
+}));
+
+import * as vscode from 'vscode';
+import { detectEnvironment } from '../src/language-server';
+
+describe('detectEnvironment', () => {
+  const originalUiKind = vscode.env.uiKind;
+
+  afterEach(() => {
+    (vscode.env as { uiKind: number }).uiKind = originalUiKind;
+    delete (globalThis as Record<string, unknown>).__APEX_LS_TARGET__;
+  });
+
+  describe('when a bundle target is injected (esbuild define)', () => {
+    it("returns 'desktop' for the Node bundle even when the UI is a browser (code-server)", () => {
+      // code-server: Node extension host (Node bundle) but browser-rendered UI.
+      (globalThis as Record<string, unknown>).__APEX_LS_TARGET__ = 'desktop';
+      (vscode.env as { uiKind: number }).uiKind = vscode.UIKind.Web;
+
+      expect(detectEnvironment()).toBe('desktop');
+    });
+
+    it("returns 'web' for the browser bundle (vscode.dev web-worker host)", () => {
+      (globalThis as Record<string, unknown>).__APEX_LS_TARGET__ = 'web';
+      (vscode.env as { uiKind: number }).uiKind = vscode.UIKind.Web;
+
+      expect(detectEnvironment()).toBe('web');
+    });
+  });
+
+  describe('fallback when no bundle target is injected (unbundled/tsc)', () => {
+    it("returns 'web' when uiKind is Web", () => {
+      (vscode.env as { uiKind: number }).uiKind = vscode.UIKind.Web;
+      expect(detectEnvironment()).toBe('web');
+    });
+
+    it("returns 'desktop' when uiKind is Desktop", () => {
+      (vscode.env as { uiKind: number }).uiKind = vscode.UIKind.Desktop;
+      expect(detectEnvironment()).toBe('desktop');
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do?

Three related fixes that surfaced from the 0.6.1 stable release.

### 1. Apex LS failed to start in code-server
`detectEnvironment()` branched on `vscode.env.uiKind`, which reports where the **UI renders**, not where **code executes**. code-server runs a **Node** extension host with a browser-rendered UI, so `uiKind === Web` routed it down the web-worker client path. That path calls `new Worker()` from the `web-worker` package — whose Node shim depends on `import.meta.url`, which cannot survive CJS bundling — crashing with `fileURLToPath(undefined)` (and, before bundling, `Cannot find module 'web-worker'`).

Fix: use the **bundle target** as the discriminator (the target *is* the host type). Inject `__APEX_LS_TARGET__` via esbuild `define` — `'desktop'` for the Node bundle, `'web'` for the browser bundle. The Node bundle dead-code-eliminates `detectEnvironment()` to `return 'desktop'`, so the worker path is unreachable in code-server. It now uses the Node server (`server.node.js`) directly. Verified: LS starts and serves LSP requests in code-server.

`web-worker` is also dropped from esbuild `external` so the genuine web-worker host (vscode.dev) can resolve it.

### 2. Stable promotion never committed the version to main
Promotion stamped the version into the VSIX / release / tracking tags but never committed it to `main`, so the repo stayed on the nightly line while the marketplace shipped a stable version. Added a `commit-stable-version` job to `promote-stable.yml` and `manual-publish.yml` (stable slot only). Idempotent + monotonic: only bumps when the stable version is strictly greater than main's current version.

### 3. Set extension version to 0.6.1
Backfills `main` to the shipped stable version so the next nightly bumps `0.6.1 → 0.7.0` per the odd/even minor scheme.

## What issues does this PR fix or reference?

@W-23140779@

## Testing
- New `detectEnvironment` tests, incl. the code-server case (`uiKind=Web` + `desktop` target → `desktop`)
- Full suite: 4514 passed, 0 failed
- Verified the Node bundle bakes `return"desktop"` and the browser bundle bakes `return"web"`
- Confirmed working in code-server: language server starts and serves requests