### PR TITLE
fix(ci): drop semver require from commit-stable-version guard - W-23140779

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -734,7 +734,19 @@ jobs:
           fi
 
           # Monotonic guard: never move main backwards or sideways.
-          IS_GT=$(node -e "const s=require('semver'); console.log(s.gt('$STABLE_VERSION', '$CURRENT_VERSION') ? 'yes' : 'no');")
+          # Self-contained semver compare (this job installs no node_modules, so
+          # `require('semver')` is unavailable). Read versions from env to avoid
+          # interpolating into the script body, and compare X.Y.Z numerically.
+          IS_GT=$(STABLE_VERSION="$STABLE_VERSION" CURRENT_VERSION="$CURRENT_VERSION" node -e '
+            const parse = v => String(v).split("-")[0].split(".").map(Number);
+            const a = parse(process.env.STABLE_VERSION);
+            const b = parse(process.env.CURRENT_VERSION);
+            let gt = false;
+            for (let i = 0; i < 3; i++) {
+              if (a[i] !== b[i]) { gt = a[i] > b[i]; break; }
+            }
+            console.log(gt ? "yes" : "no");
+          ')
           if [ "$IS_GT" != "yes" ]; then
             echo "Skipping commit-back: main ($CURRENT_VERSION) is already >= stable ($STABLE_VERSION)"
             exit 0

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -357,7 +357,19 @@ jobs:
           echo "main version: $CURRENT_VERSION -> stable version: $STABLE_VERSION"
 
           # Monotonic guard: never move main backwards or sideways.
-          IS_GT=$(node -e "const s=require('semver'); console.log(s.gt('$STABLE_VERSION', '$CURRENT_VERSION') ? 'yes' : 'no');")
+          # Self-contained semver compare (this job installs no node_modules, so
+          # `require('semver')` is unavailable). Read versions from env to avoid
+          # interpolating into the script body, and compare X.Y.Z numerically.
+          IS_GT=$(STABLE_VERSION="$STABLE_VERSION" CURRENT_VERSION="$CURRENT_VERSION" node -e '
+            const parse = v => String(v).split("-")[0].split(".").map(Number);
+            const a = parse(process.env.STABLE_VERSION);
+            const b = parse(process.env.CURRENT_VERSION);
+            let gt = false;
+            for (let i = 0; i < 3; i++) {
+              if (a[i] !== b[i]) { gt = a[i] > b[i]; break; }
+            }
+            console.log(gt ? "yes" : "no");
+          ')
           if [ "$IS_GT" != "yes" ]; then
             echo "Skipping commit-back: main ($CURRENT_VERSION) is already >= stable ($STABLE_VERSION)"
             exit 0


### PR DESCRIPTION
### What does this PR do?

Fixes the `commit-stable-version` job that aborts stable promotions with `Error: Cannot find module 'semver'`.

That job sets up Node but does not run the `npm-install-with-retries` step, so its inline monotonic-version guard — `node -e "require('semver')"` — had no `node_modules` to resolve `semver` against and crashed immediately after computing the stable version (e.g. `0.7.0 → 0.8.0`).

The guard only needs a single `gt` check, so instead of installing the full dependency tree this replaces it with a dependency-free numeric `X.Y.Z` comparison that needs no `node_modules`. Versions are read from `process.env` rather than interpolated into the script body.

The same latent bug existed in `manual-publish.yml`'s own `commit-stable-version` job (Node set up, no install) and is fixed identically.

- [.github/workflows/promote-stable.yml](https://github.com/forcedotcom/apex-language-support/blob/main/.github/workflows/promote-stable.yml)
- [.github/workflows/manual-publish.yml](https://github.com/forcedotcom/apex-language-support/blob/main/.github/workflows/manual-publish.yml)

Verified: comparison logic tested against the failing values (`0.8.0 > 0.7.0`), the lexical pitfall (`0.10.0 > 0.9.0`), and prerelease stripping; both workflows re-parse as valid YAML.

### What issues does this PR fix or reference?

@W-23140779@

Failing run: https://github.com/forcedotcom/apex-language-support/actions/runs/28120081156/job/83270229295