### PR TITLE
chore: set stable version 0.8.0 - W-23140779

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27548,7 +27548,7 @@
     },
     "packages/apex-lsp-vscode-extension": {
       "name": "apex-language-server-extension",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/apex-lsp-compliant-services": "1.0.0",

--- a/packages/apex-lsp-vscode-extension/package.json
+++ b/packages/apex-lsp-vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Salesforce Apex Language Server (Typescript)",
   "description": "VSCode extension for Apex Language Server",
   "icon": "resources/ApexTsIcon.png",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "publisher": "salesforce",
   "sideEffects": false,
   "license": "BSD-3-Clause",


### PR DESCRIPTION
### What does this PR do?

Back-fills the `package.json` version bump that the failed v0.8.0 stable promotion never committed.

Promote-stable run [28120081156](https://github.com/forcedotcom/apex-language-support/actions/runs/28120081156) published v0.8.0 to both marketplaces, created the GitHub release `apex-language-server-extension-v0.8.0` (with VSIX asset), and wrote the `marketplace-stable-...-v0.8.0` tracking tag — but its final `commit-stable-version` step died on the `semver` bug (fixed in #490) before bumping main. So main still read `0.7.0` while the published stable is `0.8.0`.

This sets `packages/apex-lsp-vscode-extension` to `0.8.0` — exactly what the workflow's `commit-stable-version` step would have done — so the repo and marketplace are back in sync and the next nightly derives from the stable line. Both `package.json` and `package-lock.json` are updated to keep them consistent.

No publish, release, or tag work is needed: those all succeeded in the prior run and already exist.

### What issues does this PR fix or reference?

@W-23140779@

Context: failed run https://github.com/forcedotcom/apex-language-support/actions/runs/28120081156 ; the rerun https://github.com/forcedotcom/apex-language-support/actions/runs/28122270357 correctly no-ops because the v0.8.0 tracking tag already exists.