### PR TITLE
fix(ci): keep package-lock in sync on stable version bump - W-23140779

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -763,7 +763,14 @@ jobs:
 
           ( cd "$PKG_DIR" && npm version "$STABLE_VERSION" --no-git-tag-version )
 
-          git add "$PKG_DIR/package.json"
+          # Keep the root lockfile's workspace entry in sync with package.json.
+          # --package-lock-only rewrites package-lock.json from the manifests
+          # without installing node_modules, so the lockfile never drifts behind
+          # the committed version. This commit carries [skip ci], so nothing
+          # downstream re-derives the lockfile — it must be correct here.
+          npm install --package-lock-only --ignore-scripts
+
+          git add "$PKG_DIR/package.json" package-lock.json
           if git diff --staged --quiet; then
             echo "No version change to commit - skipping (idempotent rerun)"
             exit 0

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -386,7 +386,14 @@ jobs:
 
           ( cd "$PKG_DIR" && npm version "$STABLE_VERSION" --no-git-tag-version )
 
-          git add "$PKG_DIR/package.json"
+          # Keep the root lockfile's workspace entry in sync with package.json.
+          # --package-lock-only rewrites package-lock.json from the manifests
+          # without installing node_modules, so the lockfile never drifts behind
+          # the committed version. This commit carries [skip ci], so nothing
+          # downstream re-derives the lockfile — it must be correct here.
+          npm install --package-lock-only --ignore-scripts
+
+          git add "$PKG_DIR/package.json" package-lock.json
           if git diff --staged --quiet; then
             echo "No version change to commit - skipping (idempotent rerun)"
             exit 0


### PR DESCRIPTION
### What does this PR do?

Fixes lockfile drift in the `commit-stable-version` job of both publish workflows.

That job bumps `packages/apex-lsp-vscode-extension/package.json` with `npm version`, but staged **only** `package.json` (`git add "$PKG_DIR/package.json"`). The root `package-lock.json` workspace entry was never updated, and because the commit carries `[skip ci]`, no downstream job re-derived the lockfile — so `package-lock.json`'s recorded version silently fell behind `package.json` on every stable promotion. (We hit exactly this with the v0.8.0 promotion.)

Fix: after `npm version`, regenerate the lockfile with `npm install --package-lock-only --ignore-scripts` (rewrites `package-lock.json` from the manifests, no `node_modules` install) and stage **both** files. Verified locally that a real bump produces a clean single-line lockfile diff with no other churn.

Applied identically to:
- `.github/workflows/promote-stable.yml`
- `.github/workflows/manual-publish.yml`

The push mechanics are intentionally unchanged: the bump commit still carries `[skip ci]` and still pushes directly to `main` via the bot token (an intentional bypass for a trivial machine-generated bump).

### What issues does this PR fix or reference?

@W-23140779@