### PR TITLE
feat(infra): canonical apex/* method registry - W-23163171

### DIFF
--- a/.claude/plans/W-23163171.md
+++ b/.claude/plans/W-23163171.md
@@ -1,0 +1,80 @@
+# W-23163171 — 1.1 Canonical apex/* method registry in shared
+
+## Context
+
+- Epic: Apex LSP Client SDK (`a3QEE000002UYr72AG`). First WI, group 1.1 (no blockers).
+- Problem: 13 `apex/*` method strings scattered as literals across `apex-ls`, `lsp-compliant-services`, `apex-lsp-vscode-extension`. Drift risk; capability-name mismatch already shipped (`findMissingArtifactProvider` vs `findMissingArtifactHandler`).
+- Goal: single source of truth in `apex-lsp-shared`. Each entry: method name → experimental-capability key → direction → dev-mode flag → payload types. Downstream WIs (1.3, 2.1, 3.1) consume it.
+- Scope this WI: ADD registry + types + barrel export + tests. Do NOT refactor call sites to consume it (later WIs). Anti-drift guard test optional (see Verification).
+
+### 13 methods (verified vs code)
+
+direction = sender→receiver; dev = dev-mode-only; cap = experimental key gating method.
+
+| method | direction | dev | cap |
+|---|---|---|---|
+| `apex/findMissingArtifact` | server→client request | no | `findMissingArtifactProvider` |
+| `apex/requestWorkspaceLoad` | server→client notification | no | — |
+| `apex/sendWorkspaceBatch` | client→server request | no | — |
+| `apex/processWorkspaceBatches` | client→server request | no | — |
+| `apex/workspaceIngestionComplete` | server→client notification | no | — |
+| `apex/workspaceLoadComplete` | client→server notification | no | — |
+| `apex/workspaceLoadFailed` | client→server notification | no | — |
+| `apex/queueState` | client→server request | yes | — |
+| `apex/queueStateChanged` | server→client notification | yes | — |
+| `apex/graphData` | client→server request | yes | — |
+| `apex/profiling/start` | client→server request | yes | `profilingProvider` |
+| `apex/profiling/stop` | client→server request | yes | `profilingProvider` |
+| `apex/profiling/status` | client→server request | yes | `profilingProvider` |
+
+- Capability keys: ONLY 2 of 13 methods carry a capability key — `apex/findMissingArtifact` → `findMissingArtifactProvider`, and the three `apex/profiling/*` methods → `profilingProvider`. The other 9 methods have NO capability key (`—` in the table). These are the only two keys that exist in `ExperimentalCapabilities` (`packages/apex-lsp-shared/src/capabilities/ApexLanguageServerCapabilities.ts` lines 107, 112). Do NOT invent additional keys (e.g. `workspaceLoadProvider`, `queueStateProvider`); the registry is the anti-drift source of truth and inventing keys creates the very drift it exists to prevent.
+- `capabilityKey` field type: plain `string` (optional). Do NOT type it as `ExperimentalCapabilityKey` and do NOT export that union from the capabilities module — it is currently a local `type` and stays local. A typed cross-package union adds tight coupling for no benefit; the registry test validates at runtime that each `capabilityKey` value is a real key of `ExperimentalCapabilities` (see Phase 2), which is sufficient.
+- Payload types: existing typed payloads scattered (mostly `any` at call sites). This WI: declare placeholder/`unknown` payload type slots per entry; concrete payload types promoted in 1.2 (queueState/graphData) + 3.1 (typed surface). Keep slots generic now to avoid premature coupling.
+
+## Phases
+
+### Phase 1 — Registry module + types
+
+- New `packages/apex-lsp-shared/src/methods/ApexCustomMethods.ts`:
+  - `ApexMethodDirection` union: `'clientToServer' | 'serverToClient'`.
+  - `ApexMethodKind` union: `'request' | 'notification'`.
+  - `ApexMethodDescriptor` interface: `method`, `direction` (`ApexMethodDirection`), `kind` (`ApexMethodKind`), `devModeOnly: boolean`, `capabilityKey?: string` (plain optional string — NOT a typed cross-package union; see Context note), payload type slots (`params`/`result` as generic markers, e.g. phantom via `unknown` + doc).
+  - `APEX_METHODS` const object keyed by stable id (e.g. `findMissingArtifact`), each value a descriptor with `as const` literal method strings. Populate exactly from the WI table above — same 13 methods, same directions, same `devModeOnly`, and `capabilityKey` set ONLY on `findMissingArtifact` (`'findMissingArtifactProvider'`) and the three `profiling/*` ids (`'profilingProvider'`). Leave `capabilityKey` undefined on the other 9.
+  - Direction discipline (matches WI table): exactly 4 entries are `serverToClient` — `apex/findMissingArtifact` (request), `apex/requestWorkspaceLoad` (notification), `apex/workspaceIngestionComplete` (notification), `apex/queueStateChanged` (notification). All other 9, including `apex/workspaceLoadComplete` and `apex/workspaceLoadFailed`, are `clientToServer` (verified against `packages/apex-lsp-vscode-extension/src/workspace-load-handler.ts`, which calls `languageClient.sendNotification('apex/workspaceLoadFailed'|'apex/workspaceLoadComplete')` — client→server).
+  - Derived: `ApexMethod` string-literal union (`(typeof APEX_METHODS)[keyof ...]['method']`), `ApexMethodId` union of keys.
+  - Helpers: `isApexMethod(s): s is ApexMethod`, `getApexMethodDescriptor(method)`.
+- Do NOT touch `ApexLanguageServerCapabilities.ts`: leave `ExperimentalCapabilityKey` as the existing local (non-exported) `type`. The registry references capability keys only as runtime-validated strings, so no export is needed.
+- commit: `feat(apex-lsp-shared): canonical apex/* method registry - W-23163171`
+
+### Phase 2 — Barrel export + tests
+
+- Add `export * from './methods/ApexCustomMethods';` to `packages/apex-lsp-shared/src/index.ts`.
+- New `packages/apex-lsp-shared/test/methods/ApexCustomMethods.test.ts`:
+  - all 13 methods present; exact string values (assert the full set, no extras).
+  - per-method `direction`/`kind`/`devModeOnly`/`capabilityKey` match the WI table exactly.
+  - direction subset assertions (anchored to the table, not to the buggy prior draft):
+    - `serverToClient` set is EXACTLY `['apex/findMissingArtifact', 'apex/requestWorkspaceLoad', 'apex/workspaceIngestionComplete', 'apex/queueStateChanged']` (4 methods) — assert both membership and count so an extra/missing entry fails.
+    - `apex/workspaceLoadComplete` and `apex/workspaceLoadFailed` are `clientToServer` (regression guard for the prior mis-classification).
+  - capabilityKey assertions: ONLY `findMissingArtifact` (`'findMissingArtifactProvider'`) and the three `profiling/*` ids (`'profilingProvider'`) have a `capabilityKey`; the other 9 are `undefined`. Assert count of entries with a capabilityKey === 4.
+  - each present `capabilityKey` is a real runtime key of `ExperimentalCapabilities` — build the allowed set from a sample `ExperimentalCapabilities` value (or `Object.keys` on the experimental block of `DEVELOPMENT_CAPABILITIES`) imported from the capabilities module and assert membership. Runtime check only; no type-level `ExperimentalCapabilityKey` import.
+  - `isApexMethod` true/false cases; `getApexMethodDescriptor` round-trips.
+- commit: `test(apex-lsp-shared): cover apex/* method registry - W-23163171`
+
+## Skills
+
+- concise — plan + any docstrings
+- typescript — file naming (PascalCase module), const-assertion unions, no `any`
+- lsp-custom-requests — method/direction semantics
+- language-server-architecture — server/client worker topology context
+- writing-tests — Jest test structure in shared
+- wireit — run scoped compile/test/lint
+- verification — pre-done checklist
+
+## Verification
+
+- `npm run compile -w @salesforce/apex-lsp-shared` (or package name from package.json) — type-checks registry + derived unions.
+- `npm test -w @salesforce/apex-lsp-shared` — new test passes.
+- `npm run lint -w @salesforce/apex-lsp-shared` — no unused/`any`.
+- Anti-drift checks baked into the unit test (the appropriate coverage for a pure shared module): exact-13 method set, exact-4 `serverToClient` set, exact-4 `capabilityKey` set, and capabilityKey membership in real `ExperimentalCapabilities` keys. These fail loudly if the registry drifts from the WI table or invents a capability key.
+- Manual cross-check (PR note, not yet a guard test): grep distinct `apex/*` literals in repo == 13 method strings in `APEX_METHODS`. A repo-wide literal-vs-registry guard test is deferred to the WIs that adopt the registry at call sites (1.3, 2.1, 3.1), since this WI deliberately does not refactor call sites.
+- Not e2e-covered, and correctly so: pure shared module, no runtime wiring changed this WI. No e2e on the branch exercises `apex/*` methods until the client/server adapters consume the registry (2.3+); e2e assertions belong to those WIs. Unit tests are the right and sufficient coverage level here.

--- a/packages/apex-lsp-shared/README.md
+++ b/packages/apex-lsp-shared/README.md
@@ -341,6 +341,45 @@ console.log(summary);
 
 The package defines custom LSP protocol extensions:
 
+#### Canonical `apex/*` Method Registry
+
+`APEX_METHODS` is the single source of truth for every custom `apex/*` method
+exchanged between the Apex language server and its client. Downstream code should
+consume the registry instead of scattering method-name string literals across
+packages. This guards against drift, makes the direction (`clientToServer` vs
+`serverToClient`) and kind (`request` vs `notification`) of each method explicit,
+and records which experimental capability (if any) gates a method along with
+whether it is dev-mode-only.
+
+Each entry is an `ApexMethodDescriptor` with these fields:
+
+- `method` — the wire method string, e.g. `apex/findMissingArtifact`.
+- `direction` — `'clientToServer'` or `'serverToClient'`.
+- `kind` — `'request'` (expects a response) or `'notification'`.
+- `devModeOnly` — `true` when the method is only available in dev mode.
+- `capabilityKey` — optional experimental-capability key that gates the method.
+
+```typescript
+import {
+  APEX_METHODS,
+  getApexMethodDescriptor,
+  isApexMethod,
+  type ApexMethodDescriptor,
+} from '@salesforce/apex-lsp-shared';
+
+// Reference a method by its stable registry id (no string literals).
+const descriptor: ApexMethodDescriptor = APEX_METHODS.findMissingArtifact;
+const methodString = descriptor.method; // 'apex/findMissingArtifact'
+
+// Type guard: is an arbitrary string a canonical apex/* method?
+if (isApexMethod(incomingMethod)) {
+  // narrowed to the ApexMethod string-literal union
+}
+
+// Reverse lookup: descriptor for a wire method string (undefined if unknown).
+const found = getApexMethodDescriptor('apex/profiling/start');
+```
+
 #### Missing Artifact Resolution
 
 ```typescript

--- a/packages/apex-lsp-shared/src/index.ts
+++ b/packages/apex-lsp-shared/src/index.ts
@@ -56,6 +56,9 @@ export {
 // Export client capabilities
 export * from './client/ApexClientCapabilities';
 
+// Export canonical apex/* method registry
+export * from './methods/ApexCustomMethods';
+
 // Export priority types
 export * from './types/priority';
 

--- a/packages/apex-lsp-shared/src/methods/ApexCustomMethods.ts
+++ b/packages/apex-lsp-shared/src/methods/ApexCustomMethods.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, salesforce.com, inc.
+ * Copyright (c) 2026, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the
@@ -160,14 +160,21 @@ export type ApexMethodId = keyof typeof APEX_METHODS;
 /** String-literal union of every `apex/*` wire method string. */
 export type ApexMethod = (typeof APEX_METHODS)[ApexMethodId]['method'];
 
-/** All wire method strings, derived from the registry. */
-const APEX_METHOD_STRINGS: ReadonlySet<string> = new Set(
-  Object.values(APEX_METHODS).map((descriptor) => descriptor.method),
-);
+/**
+ * Wire method string → descriptor, derived from the registry. Backs both
+ * {@link isApexMethod} and {@link getApexMethodDescriptor} with O(1) lookups.
+ */
+const APEX_METHODS_BY_STRING: ReadonlyMap<string, ApexMethodDescriptor> =
+  new Map(
+    Object.values(APEX_METHODS).map((descriptor) => [
+      descriptor.method,
+      descriptor,
+    ]),
+  );
 
 /** Type guard: is `value` one of the canonical `apex/*` method strings? */
 export const isApexMethod = (value: string): value is ApexMethod =>
-  APEX_METHOD_STRINGS.has(value);
+  APEX_METHODS_BY_STRING.has(value);
 
 /**
  * Look up the descriptor for a wire method string. Returns `undefined` for
@@ -175,7 +182,4 @@ export const isApexMethod = (value: string): value is ApexMethod =>
  */
 export const getApexMethodDescriptor = (
   method: string,
-): ApexMethodDescriptor | undefined =>
-  Object.values(APEX_METHODS).find(
-    (descriptor) => descriptor.method === method,
-  );
+): ApexMethodDescriptor | undefined => APEX_METHODS_BY_STRING.get(method);

--- a/packages/apex-lsp-shared/src/methods/ApexCustomMethods.ts
+++ b/packages/apex-lsp-shared/src/methods/ApexCustomMethods.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Canonical registry of the custom `apex/*` LSP methods.
+ *
+ * Single source of truth for every `apex/*` method exchanged between the Apex
+ * language server and its client. Each descriptor records the wire method
+ * string, its direction, whether it is a request or notification, whether it is
+ * gated to dev mode, and which experimental capability (if any) gates it.
+ *
+ * Downstream WIs consume this registry instead of scattering method-name string
+ * literals across packages. This WI only adds the registry; it does not refactor
+ * existing call sites.
+ */
+
+/** Sender → receiver direction of an `apex/*` method. */
+export type ApexMethodDirection = 'clientToServer' | 'serverToClient';
+
+/** Whether an `apex/*` method is a request (expects a response) or a notification. */
+export type ApexMethodKind = 'request' | 'notification';
+
+/**
+ * Describes a single custom `apex/*` method.
+ *
+ * `Params`/`Result` are generic payload slots. They are left as `unknown`
+ * markers in this WI; concrete payload types are promoted by later WIs
+ * (1.2 for queueState/graphData, 3.1 for the typed surface). Keeping them
+ * generic now avoids premature cross-package coupling.
+ */
+export interface ApexMethodDescriptor<Params = unknown, Result = unknown> {
+  /** The wire method string, e.g. `apex/findMissingArtifact`. */
+  readonly method: string;
+  /** Sender → receiver direction. */
+  readonly direction: ApexMethodDirection;
+  /** Request (expects a response) or notification. */
+  readonly kind: ApexMethodKind;
+  /** True when the method is only available in dev mode. */
+  readonly devModeOnly: boolean;
+  /**
+   * Experimental-capability key that gates this method, if any.
+   *
+   * Plain optional string by design — NOT a typed cross-package union. The
+   * registry test validates at runtime that each value is a real key of
+   * `ExperimentalCapabilities`, which is sufficient and avoids tight coupling.
+   */
+  readonly capabilityKey?: string;
+  /**
+   * Phantom marker for the params payload type. Always `undefined` at runtime;
+   * exists only so the descriptor can carry a payload type slot.
+   */
+  readonly params?: Params;
+  /**
+   * Phantom marker for the result payload type. Always `undefined` at runtime;
+   * exists only so the descriptor can carry a payload type slot.
+   */
+  readonly result?: Result;
+}
+
+/**
+ * Canonical `apex/*` method registry, keyed by stable id.
+ *
+ * Populated exactly from the WI table: same 13 methods, directions,
+ * `devModeOnly` flags, and `capabilityKey` set only on `findMissingArtifact`
+ * and the three `profiling/*` ids.
+ */
+export const APEX_METHODS = {
+  findMissingArtifact: {
+    method: 'apex/findMissingArtifact',
+    direction: 'serverToClient',
+    kind: 'request',
+    devModeOnly: false,
+    capabilityKey: 'findMissingArtifactProvider',
+  },
+  requestWorkspaceLoad: {
+    method: 'apex/requestWorkspaceLoad',
+    direction: 'serverToClient',
+    kind: 'notification',
+    devModeOnly: false,
+  },
+  sendWorkspaceBatch: {
+    method: 'apex/sendWorkspaceBatch',
+    direction: 'clientToServer',
+    kind: 'request',
+    devModeOnly: false,
+  },
+  processWorkspaceBatches: {
+    method: 'apex/processWorkspaceBatches',
+    direction: 'clientToServer',
+    kind: 'request',
+    devModeOnly: false,
+  },
+  workspaceIngestionComplete: {
+    method: 'apex/workspaceIngestionComplete',
+    direction: 'serverToClient',
+    kind: 'notification',
+    devModeOnly: false,
+  },
+  workspaceLoadComplete: {
+    method: 'apex/workspaceLoadComplete',
+    direction: 'clientToServer',
+    kind: 'notification',
+    devModeOnly: false,
+  },
+  workspaceLoadFailed: {
+    method: 'apex/workspaceLoadFailed',
+    direction: 'clientToServer',
+    kind: 'notification',
+    devModeOnly: false,
+  },
+  queueState: {
+    method: 'apex/queueState',
+    direction: 'clientToServer',
+    kind: 'request',
+    devModeOnly: true,
+  },
+  queueStateChanged: {
+    method: 'apex/queueStateChanged',
+    direction: 'serverToClient',
+    kind: 'notification',
+    devModeOnly: true,
+  },
+  graphData: {
+    method: 'apex/graphData',
+    direction: 'clientToServer',
+    kind: 'request',
+    devModeOnly: true,
+  },
+  profilingStart: {
+    method: 'apex/profiling/start',
+    direction: 'clientToServer',
+    kind: 'request',
+    devModeOnly: true,
+    capabilityKey: 'profilingProvider',
+  },
+  profilingStop: {
+    method: 'apex/profiling/stop',
+    direction: 'clientToServer',
+    kind: 'request',
+    devModeOnly: true,
+    capabilityKey: 'profilingProvider',
+  },
+  profilingStatus: {
+    method: 'apex/profiling/status',
+    direction: 'clientToServer',
+    kind: 'request',
+    devModeOnly: true,
+    capabilityKey: 'profilingProvider',
+  },
+} as const satisfies Record<string, ApexMethodDescriptor>;
+
+/** Union of stable registry ids (keys of {@link APEX_METHODS}). */
+export type ApexMethodId = keyof typeof APEX_METHODS;
+
+/** String-literal union of every `apex/*` wire method string. */
+export type ApexMethod = (typeof APEX_METHODS)[ApexMethodId]['method'];
+
+/** All wire method strings, derived from the registry. */
+const APEX_METHOD_STRINGS: ReadonlySet<string> = new Set(
+  Object.values(APEX_METHODS).map((descriptor) => descriptor.method),
+);
+
+/** Type guard: is `value` one of the canonical `apex/*` method strings? */
+export const isApexMethod = (value: string): value is ApexMethod =>
+  APEX_METHOD_STRINGS.has(value);
+
+/**
+ * Look up the descriptor for a wire method string. Returns `undefined` for
+ * any string that is not a canonical `apex/*` method.
+ */
+export const getApexMethodDescriptor = (
+  method: string,
+): ApexMethodDescriptor | undefined =>
+  Object.values(APEX_METHODS).find(
+    (descriptor) => descriptor.method === method,
+  );

--- a/packages/apex-lsp-shared/test/methods/ApexCustomMethods.test.ts
+++ b/packages/apex-lsp-shared/test/methods/ApexCustomMethods.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, salesforce.com, inc.
+ * Copyright (c) 2026, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the

--- a/packages/apex-lsp-shared/test/methods/ApexCustomMethods.test.ts
+++ b/packages/apex-lsp-shared/test/methods/ApexCustomMethods.test.ts
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  APEX_METHODS,
+  getApexMethodDescriptor,
+  isApexMethod,
+  type ApexMethodDescriptor,
+  type ApexMethodDirection,
+  type ApexMethodId,
+} from '../../src/methods/ApexCustomMethods';
+import { DEVELOPMENT_CAPABILITIES } from '../../src/capabilities/ApexLanguageServerCapabilities';
+
+/** The 13 canonical method strings, exactly as specified by the WI table. */
+const EXPECTED_METHOD_STRINGS = [
+  'apex/findMissingArtifact',
+  'apex/requestWorkspaceLoad',
+  'apex/sendWorkspaceBatch',
+  'apex/processWorkspaceBatches',
+  'apex/workspaceIngestionComplete',
+  'apex/workspaceLoadComplete',
+  'apex/workspaceLoadFailed',
+  'apex/queueState',
+  'apex/queueStateChanged',
+  'apex/graphData',
+  'apex/profiling/start',
+  'apex/profiling/stop',
+  'apex/profiling/status',
+] as const;
+
+const descriptors: ApexMethodDescriptor[] = Object.values(APEX_METHODS);
+
+describe('APEX_METHODS registry', () => {
+  it('contains exactly the 13 expected method strings, no extras', () => {
+    const actual = descriptors.map((d) => d.method).sort();
+    const expected = [...EXPECTED_METHOD_STRINGS].sort();
+    expect(actual).toEqual(expected);
+    expect(descriptors).toHaveLength(13);
+  });
+
+  describe('per-method direction / kind / devModeOnly / capabilityKey', () => {
+    type Row = {
+      id: ApexMethodId;
+      method: string;
+      direction: ApexMethodDirection;
+      kind: 'request' | 'notification';
+      devModeOnly: boolean;
+      capabilityKey?: string;
+    };
+
+    const table: Row[] = [
+      {
+        id: 'findMissingArtifact',
+        method: 'apex/findMissingArtifact',
+        direction: 'serverToClient',
+        kind: 'request',
+        devModeOnly: false,
+        capabilityKey: 'findMissingArtifactProvider',
+      },
+      {
+        id: 'requestWorkspaceLoad',
+        method: 'apex/requestWorkspaceLoad',
+        direction: 'serverToClient',
+        kind: 'notification',
+        devModeOnly: false,
+      },
+      {
+        id: 'sendWorkspaceBatch',
+        method: 'apex/sendWorkspaceBatch',
+        direction: 'clientToServer',
+        kind: 'request',
+        devModeOnly: false,
+      },
+      {
+        id: 'processWorkspaceBatches',
+        method: 'apex/processWorkspaceBatches',
+        direction: 'clientToServer',
+        kind: 'request',
+        devModeOnly: false,
+      },
+      {
+        id: 'workspaceIngestionComplete',
+        method: 'apex/workspaceIngestionComplete',
+        direction: 'serverToClient',
+        kind: 'notification',
+        devModeOnly: false,
+      },
+      {
+        id: 'workspaceLoadComplete',
+        method: 'apex/workspaceLoadComplete',
+        direction: 'clientToServer',
+        kind: 'notification',
+        devModeOnly: false,
+      },
+      {
+        id: 'workspaceLoadFailed',
+        method: 'apex/workspaceLoadFailed',
+        direction: 'clientToServer',
+        kind: 'notification',
+        devModeOnly: false,
+      },
+      {
+        id: 'queueState',
+        method: 'apex/queueState',
+        direction: 'clientToServer',
+        kind: 'request',
+        devModeOnly: true,
+      },
+      {
+        id: 'queueStateChanged',
+        method: 'apex/queueStateChanged',
+        direction: 'serverToClient',
+        kind: 'notification',
+        devModeOnly: true,
+      },
+      {
+        id: 'graphData',
+        method: 'apex/graphData',
+        direction: 'clientToServer',
+        kind: 'request',
+        devModeOnly: true,
+      },
+      {
+        id: 'profilingStart',
+        method: 'apex/profiling/start',
+        direction: 'clientToServer',
+        kind: 'request',
+        devModeOnly: true,
+        capabilityKey: 'profilingProvider',
+      },
+      {
+        id: 'profilingStop',
+        method: 'apex/profiling/stop',
+        direction: 'clientToServer',
+        kind: 'request',
+        devModeOnly: true,
+        capabilityKey: 'profilingProvider',
+      },
+      {
+        id: 'profilingStatus',
+        method: 'apex/profiling/status',
+        direction: 'clientToServer',
+        kind: 'request',
+        devModeOnly: true,
+        capabilityKey: 'profilingProvider',
+      },
+    ];
+
+    it.each(table)(
+      '$id matches the WI table',
+      ({ id, method, direction, kind, devModeOnly, capabilityKey }) => {
+        const descriptor: ApexMethodDescriptor = APEX_METHODS[id];
+        expect(descriptor.method).toBe(method);
+        expect(descriptor.direction).toBe(direction);
+        expect(descriptor.kind).toBe(kind);
+        expect(descriptor.devModeOnly).toBe(devModeOnly);
+        expect(descriptor.capabilityKey).toBe(capabilityKey);
+      },
+    );
+  });
+
+  describe('direction discipline', () => {
+    it('serverToClient set is exactly the 4 expected methods', () => {
+      const serverToClient = descriptors
+        .filter((d) => d.direction === 'serverToClient')
+        .map((d) => d.method)
+        .sort();
+      expect(serverToClient).toEqual(
+        [
+          'apex/findMissingArtifact',
+          'apex/requestWorkspaceLoad',
+          'apex/workspaceIngestionComplete',
+          'apex/queueStateChanged',
+        ].sort(),
+      );
+      expect(serverToClient).toHaveLength(4);
+    });
+
+    it('workspaceLoadComplete and workspaceLoadFailed are clientToServer (regression guard)', () => {
+      expect(APEX_METHODS.workspaceLoadComplete.direction).toBe(
+        'clientToServer',
+      );
+      expect(APEX_METHODS.workspaceLoadFailed.direction).toBe('clientToServer');
+    });
+  });
+
+  describe('capabilityKey discipline', () => {
+    it('exactly 4 entries carry a capabilityKey', () => {
+      const withCapability = descriptors.filter(
+        (d) => d.capabilityKey !== undefined,
+      );
+      expect(withCapability).toHaveLength(4);
+    });
+
+    it('only findMissingArtifact and the three profiling ids have a capabilityKey', () => {
+      expect(APEX_METHODS.findMissingArtifact.capabilityKey).toBe(
+        'findMissingArtifactProvider',
+      );
+      expect(APEX_METHODS.profilingStart.capabilityKey).toBe(
+        'profilingProvider',
+      );
+      expect(APEX_METHODS.profilingStop.capabilityKey).toBe(
+        'profilingProvider',
+      );
+      expect(APEX_METHODS.profilingStatus.capabilityKey).toBe(
+        'profilingProvider',
+      );
+
+      const idsWithoutCapability: ApexMethodId[] = [
+        'requestWorkspaceLoad',
+        'sendWorkspaceBatch',
+        'processWorkspaceBatches',
+        'workspaceIngestionComplete',
+        'workspaceLoadComplete',
+        'workspaceLoadFailed',
+        'queueState',
+        'queueStateChanged',
+        'graphData',
+      ];
+      for (const id of idsWithoutCapability) {
+        const descriptor: ApexMethodDescriptor = APEX_METHODS[id];
+        expect(descriptor.capabilityKey).toBeUndefined();
+      }
+    });
+
+    it('every capabilityKey is a real key of ExperimentalCapabilities', () => {
+      // Build the allowed set at runtime from the experimental block of a real
+      // capabilities value — no type-level ExperimentalCapabilityKey import.
+      const experimentalKeys = new Set(
+        Object.keys(DEVELOPMENT_CAPABILITIES.experimental ?? {}),
+      );
+      expect(experimentalKeys.size).toBeGreaterThan(0);
+
+      for (const descriptor of descriptors) {
+        if (descriptor.capabilityKey !== undefined) {
+          expect(experimentalKeys.has(descriptor.capabilityKey)).toBe(true);
+        }
+      }
+    });
+  });
+
+  describe('devModeOnly discipline', () => {
+    it('exactly the dev-mode methods are flagged', () => {
+      const devOnly = descriptors
+        .filter((d) => d.devModeOnly)
+        .map((d) => d.method)
+        .sort();
+      expect(devOnly).toEqual(
+        [
+          'apex/queueState',
+          'apex/queueStateChanged',
+          'apex/graphData',
+          'apex/profiling/start',
+          'apex/profiling/stop',
+          'apex/profiling/status',
+        ].sort(),
+      );
+    });
+  });
+});
+
+describe('isApexMethod', () => {
+  it('returns true for every canonical method string', () => {
+    for (const method of EXPECTED_METHOD_STRINGS) {
+      expect(isApexMethod(method)).toBe(true);
+    }
+  });
+
+  it('returns false for non-apex strings', () => {
+    expect(isApexMethod('textDocument/hover')).toBe(false);
+    expect(isApexMethod('apex/notARealMethod')).toBe(false);
+    expect(isApexMethod('')).toBe(false);
+  });
+});
+
+describe('getApexMethodDescriptor', () => {
+  it('round-trips every registered method back to its descriptor', () => {
+    for (const descriptor of descriptors) {
+      expect(getApexMethodDescriptor(descriptor.method)).toBe(descriptor);
+    }
+  });
+
+  it('returns undefined for an unknown method', () => {
+    expect(getApexMethodDescriptor('apex/notARealMethod')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Add canonical `APEX_METHODS` registry in `apex-lsp-shared` for all 13 `apex/*` custom LSP methods, each with direction, kind, dev-mode flag, and capability key
- Include typed descriptors and helpers (`isApexMethod`, `getApexMethodDescriptor`) with derived string-literal unions
- Comprehensive unit tests validate exact method set, direction/kind/flag/capability correctness, and guard against drift

## Plan

See [.claude/plans/W-23163171.md](.claude/plans/W-23163171.md)

## Test plan

- `npm run compile -w @salesforce/apex-lsp-shared` — type-checks registry + derived unions
- `npm test -w @salesforce/apex-lsp-shared` — new test passes
- `npm run lint -w @salesforce/apex-lsp-shared` — no unused/`any`
- Anti-drift checks baked into the unit test: exact-13 method set, exact-4 `serverToClient` set, exact-4 `capabilityKey` set, and capabilityKey membership in real `ExperimentalCapabilities` keys

## What issues does this PR fix or reference?

@W-23163171@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002d1BbkYAE