### PR TITLE
refactor(apex-lsp-compliant-services): type location-helper symbol params - W-23031757

### DIFF
--- a/packages/lsp-compliant-services/src/services/ReferencesProcessingService.ts
+++ b/packages/lsp-compliant-services/src/services/ReferencesProcessingService.ts
@@ -442,7 +442,7 @@ export class ReferencesProcessingService implements IReferencesProcessor {
    * Get reference locations for a symbol
    */
   private async getReferenceLocations(
-    symbol: any,
+    symbol: ApexSymbol,
     includeDeclaration: boolean = false,
   ): Promise<Location[]> {
     return await Effect.runPromise(
@@ -454,7 +454,7 @@ export class ReferencesProcessingService implements IReferencesProcessor {
    * Get reference locations for a symbol (Effect-based with yielding)
    */
   private getReferenceLocationsEffect(
-    symbol: any,
+    symbol: ApexSymbol,
     includeDeclaration: boolean = false,
   ): Effect.Effect<Location[], never, never> {
     const self = this;
@@ -595,7 +595,7 @@ export class ReferencesProcessingService implements IReferencesProcessor {
    * Get references by specific relationship types
    */
   private async getRelationshipTypeReferences(
-    symbol: any,
+    symbol: ApexSymbol,
   ): Promise<Location[]> {
     return await Effect.runPromise(
       this.getRelationshipTypeReferencesEffect(symbol),
@@ -606,7 +606,7 @@ export class ReferencesProcessingService implements IReferencesProcessor {
    * Get references by specific relationship types (Effect-based with yielding)
    */
   private getRelationshipTypeReferencesEffect(
-    symbol: any,
+    symbol: ApexSymbol,
   ): Effect.Effect<Location[], never, never> {
     const self = this;
     return Effect.gen(function* () {

--- a/packages/lsp-compliant-services/src/services/WorkspaceSymbolProcessingService.ts
+++ b/packages/lsp-compliant-services/src/services/WorkspaceSymbolProcessingService.ts
@@ -246,7 +246,7 @@ export class WorkspaceSymbolProcessingService implements IWorkspaceSymbolProcess
    * Check if a symbol matches the workspace symbol context
    */
   private matchesWorkspaceSymbolContext(
-    symbol: any,
+    symbol: ApexSymbol,
     context: WorkspaceSymbolContext,
   ): boolean {
     // Check name matching
@@ -289,7 +289,7 @@ export class WorkspaceSymbolProcessingService implements IWorkspaceSymbolProcess
    * Create symbol information from Apex symbol
    */
   private async createSymbolInformation(
-    symbol: any,
+    symbol: ApexSymbol,
   ): Promise<SymbolInformation | null> {
     try {
       const location = await this.createLocation(symbol);


### PR DESCRIPTION
## What changed

Replaced the remaining `any`-typed `symbol` parameters in the reference/workspace-symbol location helper call paths with the existing `ApexSymbol` wire type from `@salesforce/apex-lsp-parser-ast`.

- `ReferencesProcessingService`: `getReferenceLocations`, `getReferenceLocationsEffect`, `getRelationshipTypeReferences`, `getRelationshipTypeReferencesEffect` now take `symbol: ApexSymbol`.
- `WorkspaceSymbolProcessingService`: `matchesWorkspaceSymbolContext` and `createSymbolInformation` now take `symbol: ApexSymbol`.

The six location/URI helpers named in the story (`createLocationFromSymbol`, `createLocationFromReference`, `getSymbolFileUri`, `getReferenceFileUri`, `createLocation`) were already typed (`ApexSymbol` / `WireReference = ReferenceResult | ApexSymbol`) by the W-22692420 follow-up commit `0d0906c24`. This change types the methods that *feed* those helpers so no `any` flows into them — making the `SymbolLocation` nested shape (`symbolRange`/`identifierRange`) compiler-enforced end-to-end. This locks in the W-22692420 fix so the flat-range `NaN -> null` bug class cannot recur silently.

Types only; no behavior change.

## Verification

- `npm run typecheck -w packages/lsp-compliant-services`: edited files are clean (zero errors). 3 pre-existing failures remain in unrelated test files (`test/queue/LSPQueueManager.test.ts`, `test/settings/ApexLanguageServerSettings.test.ts`); confirmed identical with the change stashed.
- `npx eslint` on both edited files: clean.
- `npx jest ReferencesProcessingService WorkspaceSymbolProcessingService`: 53/53 pass.

### What issues does this PR fix or reference?

@W-23031757@

Follow-up to W-22692420 (commit f7bfa875d).