### PR TITLE
fix(apex-lsp-parser-ast): evict renamed/deleted declarations on re-parse - W-23133526

### DIFF
--- a/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
@@ -2016,6 +2016,30 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
         );
       }
 
+      // N1/F10-1 (W-23133526): on an authoritative re-parse (REPLACE), evict
+      // declarations the fresh parse no longer carries. registerSymbolTable
+      // swaps the file's SymbolTable but the graph indexes are add-only, so a
+      // renamed/deleted declaration (e.g. Foo -> Baz) would otherwise linger:
+      // its stale id and any incoming reverse-index edge keyed on it stay
+      // resolvable, leaving findReferencesTo(Foo) surfacing a phantom reference
+      // until the referencing file is itself re-resolved. The MERGE path is
+      // deliberately skipped — enrichment passes (same document version, higher
+      // detail) intentionally preserve old private/protected symbols that are
+      // absent from the partial fresh table.
+      if (registration.decision === 'accepted-replace') {
+        const liveSymbolIds = new Set<string>();
+        for (const symbol of symbols) {
+          const liveId = symbol.key?.unifiedId || symbol.id;
+          if (liveId) {
+            liveSymbolIds.add(liveId);
+          }
+        }
+        self.symbolRefManager.evictStaleFileDeclarations(
+          normalizedUri,
+          liveSymbolIds,
+        );
+      }
+
       // Invalidate cache for all symbol names that were added
       // This ensures that findSymbolByName() will see the newly added symbols
       for (const symbolName of symbolNamesAdded) {

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolRefManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolRefManager.ts
@@ -3372,6 +3372,104 @@ export class ApexSymbolRefManager {
   }
 
   /**
+   * Evict declarations that no longer exist in a file after a re-parse.
+   *
+   * `removeFile` purges an entire file; this is the surgical analogue used on
+   * the re-add path: given the symbol ids that the fresh parse still declares
+   * for `fileUri`, it drops every other id that the file previously declared
+   * from the symbol indexes AND purges the INCOMING reverse-index edges that
+   * targeted those gone declarations.
+   *
+   * Why this is needed (W-23133526 / follow-up N1 + F10-1): on a content-change
+   * re-parse `registerSymbolTable` swaps the file's SymbolTable, but the graph
+   * indexes (`fileIndex`/`nameIndex`/`symbolIdIndex`/...) are only ever added
+   * to — a declaration that was renamed away (`Foo` -> `Baz`) or deleted is
+   * never removed. Its stale id lingers and any incoming reverse-index edge
+   * keyed on it (e.g. another file's edge into `Foo`) stays resolvable, so
+   * `findReferencesTo(Foo)` can still surface phantom references until the
+   * referencing file is itself re-resolved. Reclaiming those dead reverse-index
+   * entries here, at the moment the declaration disappears, also caps the
+   * unbounded accumulation called out by F10-1 (no separate compaction pass is
+   * required for the rename/delete case).
+   *
+   * Only call this from the REPLACE branch of a re-parse, where the fresh parse
+   * is authoritative. It must NOT run for enrichment/merge passes (same document
+   * version, higher detail level), because those intentionally preserve old
+   * private/protected declarations absent from the partial fresh table.
+   *
+   * @param fileUri The file being re-parsed
+   * @param liveSymbolIds Symbol ids the fresh canonical table still declares
+   */
+  evictStaleFileDeclarations(
+    fileUri: string,
+    liveSymbolIds: ReadonlySet<string>,
+  ): void {
+    const normalizedUri = extractFilePathFromUri(fileUri);
+    const previousIds = this.fileIndex.get(normalizedUri);
+    if (!previousIds || previousIds.length === 0) {
+      return;
+    }
+
+    const staleIds = previousIds.filter((id) => !liveSymbolIds.has(id));
+    if (staleIds.length === 0) {
+      return;
+    }
+
+    // Purge incoming reverse-index edges whose TARGET is a gone declaration so
+    // findReferencesTo(<old name>) no longer resolves a stale id. Outgoing edges
+    // from this file were already cleared by clearReferenceStateForFile.
+    this.removeIncomingReferencesToSymbols(new Set(staleIds), normalizedUri);
+
+    for (const symbolId of staleIds) {
+      this.symbolFileMap.delete(symbolId);
+      this.symbolIdIndex.delete(symbolId);
+      this.symbolQualifiedIndex.delete(
+        this.makeQualifiedSymbolKey(normalizedUri, symbolId),
+      );
+
+      // Remove the gone id from every FQN bucket (keyed by FQN, not id).
+      for (const [fqn, ids] of this.fqnIndex.entries()) {
+        if (!ids) continue;
+        const filteredIds = ids.filter((id) => id !== symbolId);
+        if (filteredIds.length === 0) {
+          this.fqnIndex.delete(fqn);
+        } else if (filteredIds.length !== ids.length) {
+          this.fqnIndex.set(fqn, filteredIds);
+        }
+      }
+
+      // Remove the gone id from every name bucket (keyed by name, not id).
+      for (const [name, ids] of this.nameIndex.entries()) {
+        if (!ids) continue;
+        const filteredIds = ids.filter((id) => id !== symbolId);
+        if (filteredIds.length === 0) {
+          this.nameIndex.delete(name);
+        } else if (filteredIds.length !== ids.length) {
+          this.nameIndex.set(name, filteredIds);
+        }
+      }
+    }
+
+    // Keep only the live ids in the file index.
+    const remainingIds = previousIds.filter((id) => liveSymbolIds.has(id));
+    if (remainingIds.length === 0) {
+      this.fileIndex.delete(normalizedUri);
+    } else {
+      this.fileIndex.set(normalizedUri, remainingIds);
+    }
+
+    // Re-sync from authoritative source to prevent drift.
+    this.memoryStats.totalSymbols = this.symbolIdIndex.size;
+    this.memoryStats.totalEdges = this.refStore.size;
+
+    this.logger.debug(
+      () =>
+        `[evictStaleFileDeclarations] Evicted ${staleIds.length} stale ` +
+        `declaration(s) for ${normalizedUri} after re-parse`,
+    );
+  }
+
+  /**
    * Generate a unique symbol ID using URI-based format
    */
   private getSymbolId(symbol: ApexSymbol, fileUri: string): string {

--- a/packages/apex-parser-ast/test/symbols/ClearReferenceStateForFile.test.ts
+++ b/packages/apex-parser-ast/test/symbols/ClearReferenceStateForFile.test.ts
@@ -301,3 +301,289 @@ describe('clearReferenceStateForFile preserves incoming edges (W-22692424)', () 
     expect(refsAfter.length).toBe(0);
   });
 });
+
+/**
+ * W-23133526 — re-parse evicts renamed/deleted declarations (N1 + F10-1).
+ *
+ * The companion fix to W-22692424: clearReferenceStateForFile preserves
+ * INCOMING edges across a re-add so that an enrichment write-back doesn't wipe
+ * other files' references into this file. But that preservation, combined with
+ * the add-only graph indexes, means a declaration that the re-parse RENAMED
+ * away (Foo -> Baz) or deleted otherwise lingers: its stale id stays in the
+ * graph and any incoming reverse-index edge keyed on it stays resolvable, so
+ * findReferencesTo(Foo) keeps surfacing a phantom reference until the
+ * referencing file is itself re-resolved.
+ *
+ * On an authoritative re-parse (newer documentVersion -> REPLACE), the re-add
+ * path now diffs the previous declarations against the fresh table and evicts
+ * the gone ones from the symbol indexes AND the incoming reverse-index edges
+ * that targeted them. Reclaiming those dead entries at the moment the
+ * declaration disappears also caps the unbounded reverse-index accumulation
+ * called out by F10-1 for the rename/delete case (no separate compaction pass).
+ */
+describe('re-parse evicts renamed/deleted declarations (W-23133526)', () => {
+  let symbolManager: ApexSymbolManager;
+  let compilerService: CompilerService;
+
+  beforeAll(async () => {
+    await Effect.runPromise(
+      schedulerInitialize({
+        queueCapacity: 100,
+        maxHighPriorityStreak: 50,
+        idleSleepMs: 1,
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    try {
+      await Effect.runPromise(schedulerShutdown());
+    } catch {
+      /* scheduler may already be down */
+    }
+    try {
+      await Effect.runPromise(schedulerReset());
+    } catch {
+      /* ignore */
+    }
+  });
+
+  beforeEach(() => {
+    symbolManager = new ApexSymbolManager();
+    compilerService = new CompilerService();
+  });
+
+  afterEach(async () => {
+    if (symbolManager) {
+      await symbolManager.clear();
+    }
+  });
+
+  const addFile = async (
+    source: string,
+    fileUri: string,
+    documentVersion?: number,
+  ) => {
+    const listener = new ApexSymbolCollectorListener(undefined, 'full');
+    const result = compilerService.compile(source, fileUri, listener);
+    expect(result.result).toBeDefined();
+    await Effect.runPromise(
+      symbolManager.addSymbolTable(result.result!, fileUri, documentVersion),
+    );
+    return result.result!;
+  };
+
+  const refManager = (): ApexSymbolRefManager =>
+    (symbolManager as unknown as { symbolRefManager: ApexSymbolRefManager })
+      .symbolRefManager;
+
+  it('drops findReferencesTo(Foo) after Foo is renamed away and A is re-parsed', async () => {
+    // A declares Foo (v1). B references Foo. A is re-parsed (v2) with Foo
+    // RENAMED to Baz. B is NOT re-parsed, so its B -> Foo outgoing edge and the
+    // reverse-index entry keyed on Foo's old id both persist on the re-add path.
+    const aUri = 'file:///EvictRenameA.cls';
+    const aFooSrc = `
+      public class Foo {
+        public void noop() {}
+      }
+    `;
+    const bUri = 'file:///EvictRenameB.cls';
+    const bSrc = `
+      public class EvictRenameB {
+        public void useFoo() {
+          Foo f = new Foo();
+        }
+      }
+    `;
+    const aBazSrc = `
+      public class Baz {
+        public void noop() {}
+      }
+    `;
+
+    await addFile(aFooSrc, aUri, 1);
+    await addFile(bSrc, bUri, 1);
+
+    for (const uri of [aUri, bUri]) {
+      await Effect.runPromise(
+        symbolManager.resolveCrossFileReferencesForFile(uri),
+      );
+    }
+    const graph = refManager();
+    graph.drainAllDeferredReferencesSync();
+
+    // Capture the old Foo declaration BEFORE the rename so we can query the
+    // reverse index by the exact symbol whose id the stale edge is keyed on.
+    const fooBefore = graph
+      .getSymbolsInFile(aUri)
+      .find((s: ApexSymbol) => s.name === 'Foo' && s.kind === SymbolKind.Class);
+    expect(fooBefore).toBeDefined();
+
+    // Pre-condition: B -> Foo incoming edge is live, and the reverse index holds
+    // exactly that one bucket (keyed on Foo's id).
+    const refsBefore = graph.findReferencesTo(fooBefore!);
+    expect(refsBefore.some((r) => r.fileUri === bUri)).toBe(true);
+    const reverseIndex = graph.getReverseIndex();
+    expect(reverseIndex.size).toBe(1);
+
+    // Authoritative re-parse of A (v2) with Foo renamed to Baz.
+    await addFile(aBazSrc, aUri, 2);
+
+    // The new Baz declaration exists; the old Foo is gone from A's table.
+    const symbolsAfter = graph.getSymbolsInFile(aUri);
+    expect(
+      symbolsAfter.some(
+        (s: ApexSymbol) => s.name === 'Baz' && s.kind === SymbolKind.Class,
+      ),
+    ).toBe(true);
+    expect(symbolsAfter.some((s: ApexSymbol) => s.name === 'Foo')).toBe(false);
+
+    // CORE N1 GUARANTEE: the stale Foo declaration AND its incoming reverse-index
+    // edge are evicted, so findReferencesTo(old Foo) returns nothing even though
+    // B has not been re-resolved. On the pre-fix behavior this still returned
+    // B's phantom reference.
+    const refsAfter = graph.findReferencesTo(fooBefore!);
+    expect(refsAfter.some((r) => r.fileUri === bUri)).toBe(false);
+    expect(refsAfter.length).toBe(0);
+
+    // The dead reverse-index bucket keyed on Foo's old id is reclaimed (not just
+    // unreachable by name). Without eviction this bucket lingers, which is the
+    // staleness/accumulation N1 + F10-1 call out.
+    expect(reverseIndex.size).toBe(0);
+
+    // And Baz surfaces no phantom edge either (B still points at the old id).
+    const bazAfter = symbolsAfter.find(
+      (s: ApexSymbol) => s.name === 'Baz' && s.kind === SymbolKind.Class,
+    );
+    expect(graph.findReferencesTo(bazAfter!).length).toBe(0);
+  });
+
+  it('reclaims the stale reverse-index bucket for a renamed declaration (F10-1)', async () => {
+    // Direct reverse-index assertion: the bucket keyed on the gone declaration's
+    // qualified id is removed, not merely unreachable by name. This is the
+    // F10-1 reclamation the eviction provides at rename time.
+    const aUri = 'file:///ReclaimA.cls';
+    const aFooSrc = `
+      public class ReclaimFoo {
+        public void noop() {}
+      }
+    `;
+    const bUri = 'file:///ReclaimB.cls';
+    const bSrc = `
+      public class ReclaimB {
+        public void useFoo() {
+          ReclaimFoo f = new ReclaimFoo();
+        }
+      }
+    `;
+    const aRenamedSrc = `
+      public class ReclaimBaz {
+        public void noop() {}
+      }
+    `;
+
+    await addFile(aFooSrc, aUri, 1);
+    await addFile(bSrc, bUri, 1);
+    for (const uri of [aUri, bUri]) {
+      await Effect.runPromise(
+        symbolManager.resolveCrossFileReferencesForFile(uri),
+      );
+    }
+    const graph = refManager();
+    graph.drainAllDeferredReferencesSync();
+
+    const fooBefore = graph
+      .getSymbolsInFile(aUri)
+      .find(
+        (s: ApexSymbol) =>
+          s.name === 'ReclaimFoo' && s.kind === SymbolKind.Class,
+      );
+    expect(fooBefore).toBeDefined();
+    const reverseIndex = graph.getReverseIndex();
+
+    // The reverse index has at least one bucket holding B's edge before rename.
+    const bucketsBefore = reverseIndex.size;
+    expect(bucketsBefore).toBeGreaterThan(0);
+    expect(graph.findReferencesTo(fooBefore!).length).toBeGreaterThan(0);
+
+    // Re-parse with the declaration renamed away.
+    await addFile(aRenamedSrc, aUri, 2);
+
+    // The dead bucket is reclaimed (no growth, and the old target resolves to
+    // nothing) rather than accumulating across the rename.
+    expect(graph.findReferencesTo(fooBefore!).length).toBe(0);
+    expect(reverseIndex.size).toBeLessThan(bucketsBefore);
+  });
+
+  it('preserves unrelated declarations and live incoming edges on re-parse', async () => {
+    // A declares two types, Keep and Drop. B references Keep. A is re-parsed
+    // with Drop deleted but Keep unchanged. The eviction must remove only Drop
+    // and leave B -> Keep intact.
+    const aUri = 'file:///PartialA.cls';
+    const aV1 = `
+      public class PartialKeep {
+        public void noop() {}
+      }
+      class PartialDrop {
+        public void noop() {}
+      }
+    `;
+    const bUri = 'file:///PartialB.cls';
+    const bSrc = `
+      public class PartialB {
+        public void useKeep() {
+          PartialKeep k = new PartialKeep();
+        }
+      }
+    `;
+    const aV2 = `
+      public class PartialKeep {
+        public void noop() {}
+        public void added() {}
+      }
+    `;
+
+    await addFile(aV1, aUri, 1);
+    await addFile(bSrc, bUri, 1);
+    for (const uri of [aUri, bUri]) {
+      await Effect.runPromise(
+        symbolManager.resolveCrossFileReferencesForFile(uri),
+      );
+    }
+    const graph = refManager();
+    graph.drainAllDeferredReferencesSync();
+
+    const keep = graph
+      .getSymbolsInFile(aUri)
+      .find(
+        (s: ApexSymbol) =>
+          s.name === 'PartialKeep' && s.kind === SymbolKind.Class,
+      );
+    expect(keep).toBeDefined();
+    expect(graph.findReferencesTo(keep!).some((r) => r.fileUri === bUri)).toBe(
+      true,
+    );
+
+    // Re-parse A (v2): Drop is deleted, Keep survives.
+    await addFile(aV2, aUri, 2);
+
+    const symbolsAfter = graph.getSymbolsInFile(aUri);
+    expect(symbolsAfter.some((s: ApexSymbol) => s.name === 'PartialDrop')).toBe(
+      false,
+    );
+    expect(symbolsAfter.some((s: ApexSymbol) => s.name === 'PartialKeep')).toBe(
+      true,
+    );
+
+    // The live incoming edge B -> Keep must be preserved (Keep was not renamed,
+    // so its id is unchanged and the edge is still valid). This guards against
+    // the eviction over-reaching.
+    const keepAfter = symbolsAfter.find(
+      (s: ApexSymbol) =>
+        s.name === 'PartialKeep' && s.kind === SymbolKind.Class,
+    );
+    expect(
+      graph.findReferencesTo(keepAfter!).some((r) => r.fileUri === bUri),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`findReferences` reverse-index staleness fix for the re-parse path. On an
authoritative re-parse (newer `documentVersion` → REPLACE), `ApexSymbolManager.addSymbolTable`
now diffs the file's previous declarations against the fresh symbol table and
evicts the gone ones from the symbol indexes **and** the incoming reverse-index
edges that targeted them (new `ApexSymbolRefManager.evictStaleFileDeclarations`).

### Why

`registerSymbolTable` swaps the file's `SymbolTable`, but the graph indexes
(`fileIndex`/`nameIndex`/`symbolIdIndex`/`fqnIndex`/`symbolQualifiedIndex`) and
the reverse index are add-only. A declaration renamed away (`Foo` → `Baz`) or
deleted therefore lingered: its stale id and any incoming reverse-index edge
keyed on it stayed resolvable, so `findReferencesTo(Foo)` kept surfacing a
phantom reference — and the dead reverse-index bucket kept accumulating — until
the *referencing* file was itself re-resolved.

### Scope — F10-1 vs N1 (explicit)

- **N1 (re-parse merge-not-replace eviction) — FIXED.** Eviction runs **only** on
  the `accepted-replace` registration decision. The MERGE path (enrichment passes:
  same document version, higher detail level) is **deliberately skipped** so old
  private/protected symbols that are absent from a partial fresh table are still
  preserved (the existing W-22692424 contract). After renaming `Foo`→`Baz` in
  file A and re-parsing, A's index no longer contains `Foo` and B's stale incoming
  edge into `Foo` is reclaimed, so `findReferencesTo(Foo)` returns nothing.
- **F10-1 (unbounded reverse-index accumulation / compaction) — ADDRESSED for the
  rename/delete case; no general compaction pass added.** Reclaiming the dead
  reverse-index bucket at the moment the target declaration disappears caps the
  accumulation for renames/deletes (the scenario F10-1 calls out). A separate
  periodic/full compaction pass is **not** introduced and was judged unnecessary
  given this eviction: the only known source of dead entries is renamed/deleted
  targets, which are now reclaimed at re-parse time. **Residual gap deliberately
  left:** dead entries originating from a *referencing* file that is never
  re-parsed AND whose target is never re-parsed are still only reclaimed when one
  of the two files is re-resolved; if a workload is found that accumulates these
  in practice, a follow-up compaction sweep can be added.

### Tests

Added to `ClearReferenceStateForFile.test.ts` (3 new tests; verified failing
without the fix by temporarily disabling the eviction branch):
- `findReferencesTo(Foo)` returns nothing and the reverse-index bucket for Foo's
  old id is reclaimed after Foo is renamed away and A is re-parsed (newer version).
- Direct reverse-index reclamation assertion (F10-1): the dead bucket count drops
  rather than accumulating across a rename.
- Over-reach guard: unrelated declarations and live incoming edges (a sibling type
  that was NOT renamed) are preserved on re-parse.

### Verification

- `npm run typecheck -w packages/apex-parser-ast` — clean.
- `npm run lint` (repo, via commit hook) — clean.
- Targeted: `ClearReferenceStateForFile` (6/6), `implementorReferences`,
  `ApexSymbolManager`, `ApexSymbolRefManager`, `test/references` — all pass.
- Full husky pre-commit suite: 4526 passed, 0 failed.

### What issues does this PR fix or reference?

@W-23133526@

Deferred from 6.10 (W-22692424); see `pr-reviews/FOLLOW-UPS-2026-06-19.md` for the
F10-1 / N1 framing.