### PR TITLE
feat(apex-lsp-parser-ast): findReferences signature-keyed + scope/namespace resolution follow-ups - W-23133640

### DIFF
--- a/packages/apex-ls/src/worker.platform.ts
+++ b/packages/apex-ls/src/worker.platform.ts
@@ -868,6 +868,12 @@ async function loadSymbolDataForEnrichment(
  * @param queryByName Coordinator-assistance fetcher; injectable so the
  *   ingestion contract can be unit-tested without a live assistance bus.
  *   Defaults to {@link requestCoordinatorAssistancePromise}.
+ * @param namespace Optional namespace/qualifier hint (e.g. the leading
+ *   qualifier of a qualified TypeReference such as `MyNs` in `MyNs.Foo`).
+ *   Threaded through to the {@link DataOwnerQuerySymbolByName} query so the
+ *   data-owner can disambiguate same-named matches across namespaces. Omitted
+ *   from the wire payload when absent so unqualified queries are byte-identical
+ *   to before.
  * @returns Count of owning files ingested (0 on failure or no matches).
  */
 export async function resolveMissingNamesViaDataOwner(
@@ -878,6 +884,7 @@ export async function resolveMissingNamesViaDataOwner(
     params: unknown,
     blocking: boolean,
   ) => Promise<unknown> = requestCoordinatorAssistancePromise,
+  namespace?: string,
 ): Promise<number> {
   // Drop duplicates and names the LOCAL name index already resolves before any
   // IPC. The local-skip also dedups against ResolveDepUris: any name it already
@@ -901,12 +908,18 @@ export async function resolveMissingNamesViaDataOwner(
     // per keystroke; batching makes it a single hop. The success `entries` map
     // is keyed by owning file URI, so it carries every matched name's table.
     //
-    // NOTE: the schema/coordinator also accept an optional `namespace`, but we
-    // intentionally omit it for now (forward-compat hint — qualifier
-    // disambiguation is not wired yet).
+    // Thread the optional namespace/qualifier hint through to the data-owner
+    // for same-name disambiguation. Only add the key when a namespace is
+    // supplied so unqualified queries keep the exact prior payload shape.
+    const queryParams: { names: string[]; namespace?: string } = {
+      names: residual,
+    };
+    if (namespace) {
+      queryParams.namespace = namespace;
+    }
     const response = (await queryByName(
       'dataOwner:QuerySymbolByName',
-      { names: residual },
+      queryParams,
       true,
     )) as {
       matches?: ReadonlyArray<{ name: string; fileUri: string }>;

--- a/packages/apex-ls/src/worker.platform.web.ts
+++ b/packages/apex-ls/src/worker.platform.web.ts
@@ -800,6 +800,12 @@ async function loadSymbolDataForEnrichment(
  * @param queryByName Coordinator-assistance fetcher; injectable so the
  *   ingestion contract can be unit-tested without a live assistance bus.
  *   Defaults to {@link requestCoordinatorAssistancePromise}.
+ * @param namespace Optional namespace/qualifier hint (e.g. the leading
+ *   qualifier of a qualified TypeReference such as `MyNs` in `MyNs.Foo`).
+ *   Threaded through to the {@link DataOwnerQuerySymbolByName} query so the
+ *   data-owner can disambiguate same-named matches across namespaces. Omitted
+ *   from the wire payload when absent so unqualified queries are byte-identical
+ *   to before.
  * @returns Count of owning files ingested (0 on failure or no matches).
  */
 export async function resolveMissingNamesViaDataOwner(
@@ -810,6 +816,7 @@ export async function resolveMissingNamesViaDataOwner(
     params: unknown,
     blocking: boolean,
   ) => Promise<unknown> = requestCoordinatorAssistancePromise,
+  namespace?: string,
 ): Promise<number> {
   // Drop duplicates and names the LOCAL name index already resolves before any
   // IPC. The local-skip also dedups against ResolveDepUris: any name it already
@@ -833,12 +840,18 @@ export async function resolveMissingNamesViaDataOwner(
     // per keystroke; batching makes it a single hop. The success `entries` map
     // is keyed by owning file URI, so it carries every matched name's table.
     //
-    // NOTE: the schema/coordinator also accept an optional `namespace`, but we
-    // intentionally omit it for now (forward-compat hint — qualifier
-    // disambiguation is not wired yet).
+    // Thread the optional namespace/qualifier hint through to the data-owner
+    // for same-name disambiguation. Only add the key when a namespace is
+    // supplied so unqualified queries keep the exact prior payload shape.
+    const queryParams: { names: string[]; namespace?: string } = {
+      names: residual,
+    };
+    if (namespace) {
+      queryParams.namespace = namespace;
+    }
     const response = (await queryByName(
       'dataOwner:QuerySymbolByName',
-      { names: residual },
+      queryParams,
       true,
     )) as {
       matches?: ReadonlyArray<{ name: string; fileUri: string }>;

--- a/packages/apex-ls/test/server/resolveMissingNamesViaDataOwner.test.ts
+++ b/packages/apex-ls/test/server/resolveMissingNamesViaDataOwner.test.ts
@@ -111,6 +111,44 @@ describe('resolveMissingNamesViaDataOwner — ingestion contract', () => {
     ]);
   });
 
+  it('threads an optional namespace hint into the batched query (F12-2)', async () => {
+    // A qualified TypeReference (e.g. MyNs.Foo) supplies its leading qualifier
+    // as the namespace hint so the data-owner can disambiguate same-named
+    // matches across namespaces.
+    const { svc } = makeFakeServices(new Set());
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const queryByName = (method: string, params: unknown) => {
+      calls.push({ method, params });
+      return Promise.resolve({ matches: [], entries: {} });
+    };
+
+    await resolveMissingNamesViaDataOwner(svc, ['Foo'], queryByName, 'MyNs');
+
+    expect(calls).toHaveLength(1);
+    const params = calls[0].params as { names: string[]; namespace?: string };
+    expect(params.names).toEqual(['Foo']);
+    expect(params.namespace).toBe('MyNs');
+  });
+
+  it('omits the namespace key entirely when no namespace is supplied (F12-2)', async () => {
+    // Unqualified queries must keep the exact prior payload shape — the
+    // namespace key must be absent, not present-and-undefined — so the wire
+    // payload is byte-identical to the pre-F12-2 batched query.
+    const { svc } = makeFakeServices(new Set());
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const queryByName = (method: string, params: unknown) => {
+      calls.push({ method, params });
+      return Promise.resolve({ matches: [], entries: {} });
+    };
+
+    await resolveMissingNamesViaDataOwner(svc, ['Foo'], queryByName);
+
+    expect(calls).toHaveLength(1);
+    const params = calls[0].params as Record<string, unknown>;
+    expect(params.names).toEqual(['Foo']);
+    expect('namespace' in params).toBe(false);
+  });
+
   it('issues no query when every name resolves locally', async () => {
     const { svc } = makeFakeServices(new Set(['A', 'B']));
     const calls: unknown[] = [];

--- a/packages/apex-parser-ast/src/types/symbolReference.ts
+++ b/packages/apex-parser-ast/src/types/symbolReference.ts
@@ -71,6 +71,18 @@ export interface SymbolReference {
   literalType?: 'Integer' | 'Long' | 'Decimal' | 'String' | 'Boolean' | 'Null';
   /** Optional: chain nodes for chained expressions (e.g., obj.field1.field2) */
   chainNodes?: SymbolReference[];
+  /**
+   * Optional: call-site argument type strings for METHOD_CALL / CONSTRUCTOR_CALL
+   * references, positional and in source order (e.g. `['String', 'List<Integer>']`
+   * for `f('x', myIntList)`). Holds each argument's `originalTypeString` so a
+   * generic instantiation like `List<Integer>` is NOT collapsed to `List`
+   * (F11-1). This is the call-site signature key that lets a signature-aware
+   * `findReferencesTo` separate references to one overload from its same-named
+   * siblings (F11-2); name-only keying cannot. Undefined when the parser cannot
+   * statically determine an argument's type (the reference then falls back to
+   * name-only keying, preserving today's behavior for non-overloaded methods).
+   */
+  argumentTypes?: string[];
   /** Optional: ID of the resolved type (if type is known, undefined otherwise) */
   resolvedTypeId?: string;
   /** Optional: which tier resolved this reference */
@@ -127,6 +139,7 @@ export class EnhancedSymbolReference implements SymbolReference {
       | 'syntax_only'
       | 'partially_validated'
       | 'fully_validated',
+    public argumentTypes?: string[],
   ) {}
 
   // Custom JSON serialization to avoid circular references
@@ -147,6 +160,7 @@ export class EnhancedSymbolReference implements SymbolReference {
       isFullyResolved: this.isFullyResolved,
       validatedAccess: this.validatedAccess,
       accessValidationState: this.accessValidationState,
+      argumentTypes: this.argumentTypes,
     };
 
     // Add chained expression info without circular references
@@ -209,12 +223,18 @@ export class SymbolReferenceFactory {
 
   /**
    * Create a method call reference
+   *
+   * @param argumentTypes Optional positional call-site argument type strings
+   *   (each argument's `originalTypeString`, in source order). Carried on the
+   *   reference as its signature key for overload-aware reference separation
+   *   (F11-2/F11-1). Omit when arg types are not statically known.
    */
   static createMethodCallReference(
     methodName: string,
     location: SymbolLocation,
     parentContext?: string,
     isStatic?: boolean,
+    argumentTypes?: string[],
   ): SymbolReference {
     const reference = new EnhancedSymbolReference(
       methodName,
@@ -224,6 +244,15 @@ export class SymbolReferenceFactory {
       parentContext,
       undefined,
       isStatic,
+      undefined, // literalValue
+      undefined, // literalType
+      undefined, // chainNodes
+      undefined, // resolvedTypeId
+      undefined, // resolutionTier
+      undefined, // isFullyResolved
+      undefined, // validatedAccess
+      undefined, // accessValidationState
+      argumentTypes,
     );
 
     // Note: For simple qualified references, we don't need complex chain structures

--- a/packages/apex-parser-ast/test/references/signatureKeying.test.ts
+++ b/packages/apex-parser-ast/test/references/signatureKeying.test.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Signature-key foundations for overload-aware reference separation
+ * (W-23133640 — F11-1 + F11-2 schema slice).
+ *
+ * F11-1 (generic-overload collapse): the shared signature comparison must key
+ * on each parameter's `originalTypeString`, NOT its erased `type.name`, so a
+ * generic instantiation like `List<String>` is not collapsed to `List` and
+ * confused with `List<Integer>`. These tests lock that behavior in
+ * `areMethodSignaturesIdentical` (the canonical signature comparator) so a
+ * future signature-keyed `findReferencesTo` builds on a proven base.
+ *
+ * F11-2 (per-overload reference separation, schema slice): `SymbolReference`
+ * gained an optional `argumentTypes` field — the call-site signature key a
+ * signature-aware reverse index needs. These tests verify the field flows
+ * through the method-call factory and survives JSON serialization (so it
+ * round-trips across the worker boundary like every other reference field).
+ */
+
+import {
+  ReferenceContext,
+  SymbolReferenceFactory,
+  EnhancedSymbolReference,
+} from '../../src/types/symbolReference';
+import { SymbolKind } from '../../src/types/symbol';
+import {
+  createPrimitiveType,
+  createCollectionType,
+  createArrayType,
+} from '../../src/types/typeInfo';
+import { areMethodSignaturesIdentical } from '../../src/semantics/validation/utils/methodSignatureUtils';
+import { ValidationTier } from '../../src/semantics/validation/ValidationTier';
+
+const LOCATION = {
+  symbolRange: { startLine: 1, startColumn: 0, endLine: 1, endColumn: 5 },
+  identifierRange: { startLine: 1, startColumn: 0, endLine: 1, endColumn: 5 },
+};
+
+/**
+ * Minimal MethodSymbol stand-in: `areMethodSignaturesIdentical` only reads
+ * `kind` (via isMethodSymbol), `name`, and `parameters[].type`.
+ */
+function method(
+  name: string,
+  paramTypes: ReturnType<typeof createPrimitiveType>[],
+) {
+  return {
+    kind: SymbolKind.Method,
+    name,
+    parameters: paramTypes.map((type, i) => ({ name: `p${i}`, type })),
+  } as never;
+}
+
+describe('signature keying — F11-1 generic/varargs (areMethodSignaturesIdentical)', () => {
+  it('treats List<String> and List<Integer> as DISTINCT signatures (no generic collapse)', () => {
+    const listOfString = method('f', [
+      createCollectionType('List', [createPrimitiveType('String')]),
+    ]);
+    const listOfInteger = method('f', [
+      createCollectionType('List', [createPrimitiveType('Integer')]),
+    ]);
+
+    // Erased name is `List` for both; originalTypeString is `List<String>` vs
+    // `List<Integer>`. The comparator must use originalTypeString and report
+    // them as different signatures.
+    expect(
+      areMethodSignaturesIdentical(
+        listOfString,
+        listOfInteger,
+        ValidationTier.IMMEDIATE,
+      ),
+    ).toBe(false);
+  });
+
+  it('treats two List<String> overloads as the SAME signature', () => {
+    const a = method('f', [
+      createCollectionType('List', [createPrimitiveType('String')]),
+    ]);
+    const b = method('f', [
+      createCollectionType('List', [createPrimitiveType('String')]),
+    ]);
+
+    expect(areMethodSignaturesIdentical(a, b, ValidationTier.IMMEDIATE)).toBe(
+      true,
+    );
+  });
+
+  it('distinguishes a scalar param from an array (varargs-style) param', () => {
+    const scalar = method('f', [createPrimitiveType('String')]);
+    const array = method('f', [createArrayType(createPrimitiveType('String'))]);
+
+    // originalTypeString is `String` vs `String[]`.
+    expect(
+      areMethodSignaturesIdentical(scalar, array, ValidationTier.IMMEDIATE),
+    ).toBe(false);
+  });
+
+  it('distinguishes overloads that differ only in parameter arity', () => {
+    const one = method('f', [createPrimitiveType('String')]);
+    const two = method('f', [
+      createPrimitiveType('String'),
+      createPrimitiveType('Integer'),
+    ]);
+
+    expect(
+      areMethodSignaturesIdentical(one, two, ValidationTier.IMMEDIATE),
+    ).toBe(false);
+  });
+});
+
+describe('signature keying — F11-2 SymbolReference.argumentTypes', () => {
+  it('createMethodCallReference carries positional call-site argument types', () => {
+    const ref = SymbolReferenceFactory.createMethodCallReference(
+      'f',
+      LOCATION,
+      'caller',
+      false,
+      ['String', 'List<Integer>'],
+    );
+
+    expect(ref.context).toBe(ReferenceContext.METHOD_CALL);
+    expect(ref.argumentTypes).toEqual(['String', 'List<Integer>']);
+  });
+
+  it('argumentTypes is undefined when not supplied (name-only keying fallback)', () => {
+    const ref = SymbolReferenceFactory.createMethodCallReference(
+      'f',
+      LOCATION,
+      'caller',
+    );
+
+    // Non-overloaded / statically-unknown call sites keep today's behavior:
+    // no signature key, so resolution falls back to name-only.
+    expect(ref.argumentTypes).toBeUndefined();
+  });
+
+  it('argumentTypes survives JSON serialization (round-trips across the worker boundary)', () => {
+    const ref = new EnhancedSymbolReference(
+      'f',
+      LOCATION,
+      ReferenceContext.METHOD_CALL,
+      undefined,
+      'caller',
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      ['String', 'List<Integer>'],
+    );
+
+    const wire = JSON.parse(JSON.stringify(ref));
+    expect(wire.argumentTypes).toEqual(['String', 'List<Integer>']);
+  });
+});

--- a/packages/lsp-compliant-services/src/services/ImplementationProcessingService.ts
+++ b/packages/lsp-compliant-services/src/services/ImplementationProcessingService.ts
@@ -22,6 +22,7 @@ import {
   isMethodSymbol,
   MethodSymbol,
   SymbolKind,
+  isPositionWithinLocation,
 } from '@salesforce/apex-lsp-parser-ast';
 import {
   transformLspToParserPosition,
@@ -105,6 +106,28 @@ export class ImplementationProcessingService implements IImplementationProcessor
           () =>
             `[impl] no refs — scope symbol: ${scopeSymbol ? `${scopeSymbol.name} (${scopeSymbol.kind})` : 'null'}`,
         );
+        // identifierRange guard (mirrors the 6.11 find-references guard that
+        // standardized on the 'precise' strategy). The 'scope' strategy's
+        // Step-4 fallback returns the *enclosing* method/class whenever the
+        // cursor is anywhere inside that symbol's scope body — including on
+        // whitespace, punctuation, or a keyword — because it matches on the
+        // symbol's full symbolRange, not its declaration identifier. Without
+        // this guard, go-to-implementation with the cursor on a non-identifier
+        // position inside an abstract/interface method body would return
+        // implementations for the enclosing symbol instead of nothing. Require
+        // the cursor to land on the symbol's own declaration identifier
+        // (identifierRange) before honoring the scope fallback.
+        if (
+          scopeSymbol &&
+          !this.isCursorOnDeclarationIdentifier(scopeSymbol, parserPosition)
+        ) {
+          this.logger.debug(
+            () =>
+              `[impl] scope symbol ${scopeSymbol.name} rejected — cursor not on its ` +
+              'declaration identifier (non-identifier position); returning []',
+          );
+          return [];
+        }
         if (scopeSymbol) {
           // Interface declaration — find all implementing classes
           if (scopeSymbol.kind === SymbolKind.Interface) {
@@ -222,6 +245,25 @@ export class ImplementationProcessingService implements IImplementationProcessor
       );
       return [];
     }
+  }
+
+  /**
+   * Whether the cursor lands on the symbol's own declaration identifier.
+   *
+   * The 'scope' position strategy returns the enclosing symbol for any cursor
+   * inside its scope body (matching on symbolRange), so this narrows that to
+   * the symbol's identifierRange — the precise declaration name — guarding the
+   * scope fallback against non-identifier cursors (whitespace/keyword/body).
+   * A symbol without an identifierRange is treated as not matching.
+   */
+  private isCursorOnDeclarationIdentifier(
+    symbol: ApexSymbol,
+    position: { line: number; character: number },
+  ): boolean {
+    if (!symbol.location?.identifierRange) {
+      return false;
+    }
+    return isPositionWithinLocation(symbol.location, position);
   }
 
   /**

--- a/packages/lsp-compliant-services/test/services/ImplementationProcessingService.test.ts
+++ b/packages/lsp-compliant-services/test/services/ImplementationProcessingService.test.ts
@@ -1079,6 +1079,282 @@ describe('ImplementationProcessingService', () => {
       expect(uris).toContain('file:///test/Cat.cls');
     });
 
+    it('should NOT honor the scope fallback when cursor is not on the declaration identifier (F11-4)', async () => {
+      // Cursor sits on whitespace/keyword INSIDE an abstract method body. LSP
+      // line 6 maps to parser line 7 (1-based), which is within the symbol's
+      // body symbolRange (parser lines 5-9) but NOT within its identifierRange
+      // (the method name on parser line 5). The 'scope' strategy returns the
+      // enclosing abstract MethodSymbol, so the identifierRange guard must
+      // reject it and return [] rather than surfacing implementations for the
+      // enclosing symbol.
+      const params: ImplementationParams = {
+        textDocument: { uri: 'file:///test/AbstractClass.cls' },
+        position: { line: 6, character: 4 },
+      };
+
+      // No TypeReferences at a non-identifier position — drives the scope fallback.
+      mockSymbolManager.getReferencesAtPosition.mockReturnValue([]);
+
+      const abstractMethod: MethodSymbol = {
+        id: 'method-id',
+        name: 'abstractMethod',
+        kind: SymbolKind.Method,
+        location: {
+          // symbolRange spans the whole method body (parser lines 5-9); the
+          // scope strategy matches the body cursor against this range.
+          symbolRange: {
+            startLine: 5,
+            startColumn: 10,
+            endLine: 9,
+            endColumn: 3,
+          },
+          // identifierRange is only the method name on line 5 — the cursor on
+          // line 8 is NOT within it.
+          identifierRange: {
+            startLine: 5,
+            startColumn: 10,
+            endLine: 5,
+            endColumn: 25,
+          },
+        },
+        fileUri: 'file:///test/AbstractClass.cls',
+        returnType: createPrimitiveType('void'),
+        parameters: [],
+        key: {
+          prefix: 'method',
+          name: 'abstractMethod',
+          path: ['file:///test/AbstractClass.cls', 'abstractMethod'],
+          unifiedId: 'method-id',
+          fileUri: 'file:///test/AbstractClass.cls',
+          kind: SymbolKind.Method,
+        },
+        parentId: null,
+        _isLoaded: true,
+        modifiers: {
+          visibility: SymbolVisibility.Public,
+          isStatic: false,
+          isFinal: false,
+          isAbstract: true,
+          isVirtual: false,
+          isOverride: false,
+          isTransient: false,
+          isTestMethod: false,
+          isWebService: false,
+          isBuiltIn: false,
+        },
+      };
+      // The scope strategy returns the enclosing abstract method.
+      mockSymbolManager.getSymbolAtPosition.mockResolvedValue(abstractMethod);
+
+      const result = await service.processImplementation(params);
+
+      expect(result).toEqual([]);
+      // The guard short-circuits before any implementation discovery.
+      expect(mockSymbolManager.findSubtypes).not.toHaveBeenCalled();
+    });
+
+    it('should honor the scope fallback when cursor IS on the declaration identifier (F11-4)', async () => {
+      // Cursor is on the abstract method's name. LSP line 4 maps to parser
+      // line 5 — within the method's identifierRange (parser line 5) — so the
+      // guard allows the scope fallback and implementations are returned.
+      const params: ImplementationParams = {
+        textDocument: { uri: 'file:///test/AbstractClass.cls' },
+        position: { line: 4, character: 12 },
+      };
+
+      mockSymbolManager.getReferencesAtPosition.mockReturnValue([]);
+
+      const abstractMethod: MethodSymbol = {
+        id: 'method-id',
+        name: 'abstractMethod',
+        kind: SymbolKind.Method,
+        location: {
+          symbolRange: {
+            startLine: 5,
+            startColumn: 10,
+            endLine: 9,
+            endColumn: 3,
+          },
+          identifierRange: {
+            startLine: 5,
+            startColumn: 10,
+            endLine: 5,
+            endColumn: 25,
+          },
+        },
+        fileUri: 'file:///test/AbstractClass.cls',
+        returnType: createPrimitiveType('void'),
+        parameters: [],
+        key: {
+          prefix: 'method',
+          name: 'abstractMethod',
+          path: ['file:///test/AbstractClass.cls', 'abstractMethod'],
+          unifiedId: 'method-id',
+          fileUri: 'file:///test/AbstractClass.cls',
+          kind: SymbolKind.Method,
+        },
+        parentId: null,
+        _isLoaded: true,
+        modifiers: {
+          visibility: SymbolVisibility.Public,
+          isStatic: false,
+          isFinal: false,
+          isAbstract: true,
+          isVirtual: false,
+          isOverride: false,
+          isTransient: false,
+          isTestMethod: false,
+          isWebService: false,
+          isBuiltIn: false,
+        },
+      };
+      mockSymbolManager.getSymbolAtPosition.mockResolvedValue(abstractMethod);
+
+      const concreteClass: TypeSymbol = {
+        id: 'concrete-class-id',
+        name: 'ConcreteClass',
+        kind: SymbolKind.Class,
+        location: {
+          symbolRange: {
+            startLine: 1,
+            startColumn: 0,
+            endLine: 1,
+            endColumn: 13,
+          },
+          identifierRange: {
+            startLine: 1,
+            startColumn: 0,
+            endLine: 1,
+            endColumn: 13,
+          },
+        },
+        fileUri: 'file:///test/ConcreteClass.cls',
+        superClass: 'AbstractClass',
+        interfaces: [],
+        key: {
+          prefix: 'class',
+          name: 'ConcreteClass',
+          path: ['file:///test/ConcreteClass.cls', 'ConcreteClass'],
+          unifiedId: 'concrete-class-id',
+          fileUri: 'file:///test/ConcreteClass.cls',
+          kind: SymbolKind.Class,
+        },
+        parentId: null,
+        _isLoaded: true,
+        modifiers: {
+          visibility: SymbolVisibility.Public,
+          isStatic: false,
+          isFinal: false,
+          isAbstract: false,
+          isVirtual: false,
+          isOverride: false,
+          isTransient: false,
+          isTestMethod: false,
+          isWebService: false,
+          isBuiltIn: false,
+        },
+      };
+
+      const overridingMethod: MethodSymbol = {
+        id: 'overriding-method-id',
+        name: 'abstractMethod',
+        kind: SymbolKind.Method,
+        location: {
+          symbolRange: {
+            startLine: 3,
+            startColumn: 10,
+            endLine: 3,
+            endColumn: 25,
+          },
+          identifierRange: {
+            startLine: 3,
+            startColumn: 10,
+            endLine: 3,
+            endColumn: 25,
+          },
+        },
+        fileUri: 'file:///test/ConcreteClass.cls',
+        returnType: createPrimitiveType('void'),
+        parameters: [],
+        key: {
+          prefix: 'method',
+          name: 'abstractMethod',
+          path: ['file:///test/ConcreteClass.cls', 'abstractMethod'],
+          unifiedId: 'overriding-method-id',
+          fileUri: 'file:///test/ConcreteClass.cls',
+          kind: SymbolKind.Method,
+        },
+        parentId: null,
+        _isLoaded: true,
+        modifiers: {
+          visibility: SymbolVisibility.Public,
+          isStatic: false,
+          isFinal: false,
+          isAbstract: false,
+          isVirtual: false,
+          isOverride: true,
+          isTransient: false,
+          isTestMethod: false,
+          isWebService: false,
+          isBuiltIn: false,
+        },
+      };
+
+      // Containing type is a (non-interface) abstract class — drives the
+      // abstract-class subtype path in findImplementingMethods.
+      const abstractClass: TypeSymbol = {
+        id: 'abstract-class-id',
+        name: 'AbstractClass',
+        kind: SymbolKind.Class,
+        location: {
+          symbolRange: {
+            startLine: 1,
+            startColumn: 0,
+            endLine: 1,
+            endColumn: 14,
+          },
+          identifierRange: {
+            startLine: 1,
+            startColumn: 0,
+            endLine: 1,
+            endColumn: 14,
+          },
+        },
+        fileUri: 'file:///test/AbstractClass.cls',
+        interfaces: [],
+        key: {
+          prefix: 'class',
+          name: 'AbstractClass',
+          path: ['file:///test/AbstractClass.cls', 'AbstractClass'],
+          unifiedId: 'abstract-class-id',
+          fileUri: 'file:///test/AbstractClass.cls',
+          kind: SymbolKind.Class,
+        },
+        parentId: null,
+        _isLoaded: true,
+        modifiers: {
+          visibility: SymbolVisibility.Public,
+          isStatic: false,
+          isFinal: false,
+          isAbstract: true,
+          isVirtual: false,
+          isOverride: false,
+          isTransient: false,
+          isTestMethod: false,
+          isWebService: false,
+          isBuiltIn: false,
+        },
+      };
+      mockSymbolManager.getContainingType.mockReturnValue(abstractClass);
+      mockSymbolManager.findSubtypes.mockResolvedValue([concreteClass]);
+      mockSymbolManager.findSymbolsInFile.mockReturnValue([overridingMethod]);
+
+      const result = await service.processImplementation(params);
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0].uri).toBe('file:///test/ConcreteClass.cls');
+    });
+
     it('should return empty array for non-interface, non-abstract-method symbols', async () => {
       const params: ImplementationParams = {
         textDocument: { uri: 'file:///test/TestClass.cls' },


### PR DESCRIPTION
### What does this PR do?

Follow-up work from 6.11 (PR #465) / 6.12 (PR #468) addressing the family of bugs rooted in **name-keyed** find-references/go-to-implementation resolution that is neither signature- nor scope-aware. Lands the self-contained, provably-correct items in full and the foundational schema slice of the hard signature-keying core, with the large/risky remainder clearly deferred.

> **Note on basing:** this work was originally intended to stack on `feature/W-22692427-cross-worker-query` (PR #468, story 6.12). #468 has since **squash-merged into `main`** (commit `4e8e6fbbd`) and its branch was deleted, so this PR is now based on `main` and rebased onto current `main` — it carries only its own three commits and builds on the already-merged 6.12 cross-worker batching work.

#### Sub-item status

| Item | Status | Notes |
|------|--------|-------|
| **F11-4** — go-to-implementation scope-fallback guard | **DONE** | `ImplementationProcessingService` used an unguarded `getSymbolAtPosition('scope')` result, so the cursor on whitespace/keyword inside an abstract/interface method body returned implementations for the **enclosing** symbol. Now mirrors the 6.11 find-references guard: only honor the scope fallback when the cursor lands on the symbol's own declaration identifier (`identifierRange`), not merely inside its scope body (`symbolRange`). Positive + negative regression tests added. |
| **F12-2** — namespace through cross-worker query | **DONE** | `resolveMissingNamesViaDataOwner` sent only `{ names }`. Threaded an optional `namespace`/qualifier hint from the call site through the helper into the `DataOwnerQuerySymbolByName` query payload for same-name disambiguation (the schema + `WorkerCoordinator` already accepted it). The `namespace` key is added only when supplied, so unqualified queries keep the exact prior wire shape. Applied identically to `worker.platform.ts` and `worker.platform.web.ts` — the enrichment/data-owner bodies remain **byte-identical** (verified). Two tests (present + absent namespace). |
| **F11-1** — generic-overload collapse | **DONE (verified + locked)** | Signature keying must use each param's `originalTypeString`, not erased `type.name`, so `f(List<String>)` and `f(List<Integer>)` are distinct. The canonical comparator `areMethodSignaturesIdentical` already keys on `originalTypeString`; added generic / array(varargs-style) / arity tests to lock that behavior so the future signature-keyed `findReferencesTo` builds on a proven base. |
| **F11-2** — per-overload reference separation | **PARTIAL (schema foundation)** | `SymbolReference` carried **no** call-site arg types, so signature-aware resolution had nothing to key on. Added an optional positional `argumentTypes` string field to `SymbolReference` / `EnhancedSymbolReference`, included it in `toJSON` (round-trips across the worker boundary as a plain field), and threaded it as an optional param through `createMethodCallReference`. Holds each arg's `originalTypeString` (so `List<Integer>` is not collapsed to `List`). Additive and non-breaking: absent `argumentTypes` ⇒ today's name-only keying. **Deferred:** parser *population* of `argumentTypes`, the signature-aware reverse-index re-keying in `ApexSymbolRefManager` (`addReference`/`findReferencesViaGraph` currently collapse overloads at insert time via name-only `findSymbolInFileByName`), and the overload-selecting resolver. These are the large/risky core changes; landing them here would produce an unreviewable diff and risk regressing the cross-file graph. |
| **F11-3** — qualifier-scoped last-segment retry | **DEFERRED** | A clean fix needs a new **public** `ISymbolManager` qualifier-scoped-member resolution method (resolve the qualifier, then look up the leaf as its member). `resolveMemberInContext` exists only as an internal op against the manager, not on the public interface `ReferencesProcessingService` consumes. Wiring it cleanly is itself meaningful core work that interacts with the same deferred resolution machinery as F11-2. Deferred rather than land a rushed partial that risks regressing leaf resolution. |

#### Residual work for a future PR
- F11-2 core: parser emission to populate `argumentTypes` from call-site argument expressions; signature-aware reverse-index keying in `ApexSymbolRefManager` (overload-distinct target resolution at `addReference` time + at `findReferencesViaGraph`); overload-selecting resolver; signature-keyed `findReferencesTo` cache key in `ApexSymbolManager` (currently `refs_to_${name}`).
- F11-3: public qualifier-scoped member-resolution API + `ReferencesProcessingService` retry that resolves the qualifier first.
- F12-2: optional data-owner-side consumption of the `namespace` hint to actually filter same-named matches (currently threaded but not yet consumed).

#### Verification
- `npm run typecheck` clean for all touched files in `apex-parser-ast`, `apex-ls`, and `lsp-compliant-services`. Pre-existing, unrelated typecheck failures remain in `lsp-compliant-services/test/queue/LSPQueueManager.test.ts` and `test/settings/ApexLanguageServerSettings.test.ts` (confirmed identical with these changes stashed — mock-shape drift from earlier 6.x work, not from this PR).
- `npm run lint` clean for touched files.
- Targeted suites pass: `ReferencesProcessingService`, `ImplementationProcessingService`, `resolveMissingNamesViaDataOwner`, `WorkerCoordinator.queryDataOwner`, `CrossWorkerQuerySymbolByName`, `implementorReferences`, `ApexSymbolRefManager`, `signatureKeying` (new), `MethodSignatureEquivalence`, `DuplicateMethodValidator`.
- Full husky pre-commit/pre-push suite ran green on every commit (no `--no-verify`).

#### Tests added
- `ImplementationProcessingService.test.ts`: F11-4 positive (cursor on declaration identifier ⇒ implementations) + negative (cursor in body ⇒ `[]`, no discovery).
- `resolveMissingNamesViaDataOwner.test.ts`: F12-2 namespace threaded into the batched query; namespace key omitted entirely when not supplied.
- `references/signatureKeying.test.ts` (new): F11-1 generic/array/arity distinctness on `areMethodSignaturesIdentical`; F11-2 `argumentTypes` flows through the factory and survives JSON serialization.

### What issues does this PR fix or reference?

@W-23133640@
