### PR TITLE
fix(apex-lsp-extension): cross-file find-references through the worker pool - W-22692429

### DIFF
--- a/docs/design/findreferences-poc-vs-pr503-findings.md
+++ b/docs/design/findreferences-poc-vs-pr503-findings.md
@@ -1,0 +1,86 @@
+# Find References: POC branch vs. PR #503 — Findings
+
+**Date:** 2026-06-26
+**Author:** Kyle Walker (drafted with Claude assistance)
+
+Comparison of two efforts on `textDocument/references`:
+
+- **POC branch** — `feature/find-references-algorithm-POC` (off an older `main`); design docs `docs/design/find-references-algorithm-completeness.md` and `docs/design/references-offload-to-enrichment-pool.md`.
+- **PR #503** — `feature/W-22692429-references-verification` (@W-22692429@), title *"fix(apex-lsp-extension): cross-file find-references through the worker pool"*.
+
+## TL;DR
+
+| | POC branch | PR #503 |
+|---|---|---|
+| Goal | **Discover & prototype** both (a) the algorithm-completeness fixes and (b) the enrichment-pool offload pipeline, end-to-end | **Verify** cross-file find-references through the worker pool, fixing the remaining *dispatch-layer* defects |
+| Touches `ReferencesProcessingService` | Yes — heavy rewrite (+151/−126) | **No** — unchanged from `main` |
+| Core data-layer algorithm fixes | Prototyped here first | **Already landed on `main`** (refined) — PR #503 builds on them |
+| Primary mechanism | `ReferencesProcessingService` chain-walk + position resolution + URI-field fixes; `drainAllDeferredReferencesSync`; `clearReferenceStateForFile` incoming-edge preservation; block-walk before deferral | 5 worker-pool dispatch fixes in `worker.platform.ts`/`.web.ts` + wire schema `content` field + canonical-URI keying |
+| Status | Manually verified vs `dreamhouse-lwc`; pre-commit hook bypassed; aspirational/experimental | Full suite green (4555 passed); adds integration + recipe + Playwright tests |
+
+The headline: **the POC's algorithm-completeness work has since been absorbed into `main`** (via the W-23133640 signature-keyed and W-23133526 eviction lines of work). PR #503 is the *offload-pipeline* capstone — it assumes the corrected data layer and fixes the five things that still broke when the request actually ran on a pool worker.
+
+## What the POC established
+
+The POC unmasked and fixed a *pre-existing algorithm-completeness bug*: Find All References returned only the declaration site, never the use sites. Root cause was missing cross-file edges in `ApexSymbolRefManager.reverseIndex`. POC fixes (see `find-references-algorithm-completeness.md`):
+
+1. **Cross-file edges populated on the data-owner** — `UpdateSymbolSubset` calls `resolveCrossFileReferencesForFile`; `WorkspaceBatchCompile` drains deferred refs post-batch.
+2. **Synchronous deferred drain** — `drainAllDeferredReferencesSync` bypasses the priority scheduler (the 5 tasks/sec rate limit caused 30s+ stalls).
+3. **Block sources walked to non-block before deferral** — `findContainingNonBlockSymbol`; otherwise `enqueueDeferredReference` silently dropped 118/146 deferrals on dreamhouse Test files.
+4. **`clearReferenceStateForFile` stops wiping incoming refs** — re-adding `Foo.cls` was deleting `Bar.cls → Foo.Member` edges on every enrichment write-back.
+5. **Position-based resolution for chained TypeReferences** — chain-node walk + `getSymbolAtPosition` fallback, in `ReferencesProcessingService.findReferences`.
+6. **URI field-name fix** — read `.fileUri` not `.filePath` in result extraction.
+
+The POC also built the *offload pipeline* (`references-offload-to-enrichment-pool.md`, M1–M11): new wire schemas (`CoordinatorEnsureWorkspaceLoaded`, `DataOwnerResolveDependentUris`), `IWorkspaceLoadCoordinator` injection (Local/Remote impls), `loadDependentsForReferences`, the beefed-up `DispatchReferences` handler, and the `references: 'enrichmentPool'` routing flip.
+
+The POC's own docs flagged it as not merge-ready: pre-commit hook bypassed (`--no-verify`) on commits 2–14, `RemoteWorkspaceLoadCoordinator` inlined into both worker platforms, and full cross-file E2E through the pool *deferred*.
+
+## What PR #503 actually changes
+
+PR #503 does **not** re-litigate the algorithm — `ReferencesProcessingService.ts` is byte-for-byte `main`. The corrected data layer (deferred drain, incoming-edge preservation, block-walk) is already on `main`. Instead, the PR fixes the five compounding defects that made cross-file find-references dispatched to the **stateless pool worker** return `[]`:
+
+1. **Content not threaded** — added `content: Schema.optional(Schema.String)` to the `DispatchReferences` wire schema (`workerWireSchemas.ts`), populated it in `WorkerCoordinator.buildLspRequestMessage` via `getDocumentContent?.(uri)`, and consumed it in the handler. Without it the pool worker's storage missed and the service hard-returned `[]`. (Same pattern documentSymbol/hover/completion already used.)
+2. **Cursor file at public-api** — `recompileCursorFileAtFullDetail` recompiles the open file from its text with `FullSymbolCollectorListener` (bodies present), so a cursor on an in-body usage resolves. The data-owner serves files at `public-api` (bodies stripped).
+3. **Wrong dependents loaded** — `declaringFileForCursorSymbol` resolves the cursor symbol's *declaring* file and loads *its* dependents. The old code loaded dependents of the cursor file, but find-references needs callers of the target symbol's declaring file.
+4. **URI-scheme mismatch** — the `ResolveDepUris` data-owner handler now keys wire entries by the table's canonical `getFileUri()` (`file:///test/X.cls`) instead of the schemeless lookup URI (`/test/X.cls`), so ingestion matches the references' targets and cross-file edges bind.
+5. **Resolved types skipped** — `loadReferencedTypesForFile` loads referenced *type tables* regardless of resolution state. The Phase-2 prefetch in `loadSymbolDataForEnrichment` only fetched *unresolved* types (fine for hover/definition's on-demand resolution, fatal for find-references which needs the target type's table present to enumerate its references). Also un-gated the post-prefetch `resolveCrossFileReferencesForFile` from the ingest count.
+
+Both worker platforms (`worker.platform.ts` and `worker.platform.web.ts`) get the new helpers and the rebuilt handler sequence:
+
+```
+loadSymbolDataForEnrichment(uri, content)
+recompileCursorFileAtFullDetail(uri, content)
+loadReferencedTypesForFile(uri)
+declaringFileForCursorSymbol(uri, position) → targetUri
+loadDependentsForReferences(targetUri ?? uri)
+recompileCursorFileAtFullDetail(uri, content)   // re-assert: deps load may have re-ingested cursor at public-api
+processReferences(...)
+writeBackEnrichedSymbols(...)
+```
+
+## Where the two diverge on shared files
+
+The POC and PR #503 both edited `ApexSymbolManager.ts` and `ApexSymbolRefManager.ts`, but on **different axes** (and PR #503's edits sit on top of the already-merged POC work):
+
+- **POC's `ApexSymbolManager`/`RefManager` edits** — deferred-drain machinery and block-walk. These (refined) are on `main` now: `drainAllDeferredReferencesSync` returns a count, `clearReferenceStateForFile` preserves incoming edges, and `removeIncomingReferencesToSymbols` is reserved for true deletion / stale-ID eviction (W-23133526).
+- **PR #503's `ApexSymbolManager`/`RefManager` edits** — *overload/arity separation* (F11-2, W-23133640): `argumentCount` added to `ReferenceEdge`/`ReferenceResult`/`RefStoreEntry`, `separateOverloadReferences` filters a method's results by call-site arity, and `buildReferencesToCacheKey` keys the `findReferencesTo` cache by `name@file:arity` instead of bare `name` (which collapsed overloads and same-named members across files).
+
+These are orthogonal: the POC fixed *whether cross-file edges exist at all*; PR #503 (continuing W-23133640) fixes *precision of which references a given overload returns*.
+
+## Tests
+
+- **POC:** wire round-trip, `LocalWorkspaceLoadCoordinator`, `RemoteWorkspaceLoadCoordinator`, 2 service coordinator-injection tests, `ResolveDependentUris` integration. Full cross-file E2E deferred.
+- **PR #503:**
+  - `ReferencesThroughWorkerTopology.node.test.ts` — cross-file location counts through the live worker topology (the named 6.13 deliverable).
+  - `referenceEnrichmentRecipe.node.test.ts` — handler recipe end-to-end at service level; proves the declaring-file step is load-bearing.
+  - `apex-find-references.spec.ts` — Playwright E2E (intra-file, cross-file, no-results, responsiveness) + `findReferences()`/`closePeek()` on `ApexEditorPage`.
+  - `overloadSeparation.test.ts`, `signatureKeying.test.ts`, qualifier-scoped resolution, `ReferencesProcessingService.test.ts` locals-only regression.
+
+## Deferred in PR #503
+
+- **Telemetry** on the references path — blocked on Jorje-parity #04 (W-22629622); tracked in W-22692429.
+- **Parity-table doc flip** — external Quip/GUS artifact, handled there.
+
+## Bottom line
+
+The POC was the *investigation + prototype*: it proved out both the algorithm-completeness fixes and the offload pipeline against `dreamhouse-lwc`, but as one large experimental branch with the hook bypassed. The work then split into mergeable lines that landed on `main` (signature-keying W-23133640, eviction W-23133526, deferred-drain/edge-preservation). **PR #503 is the disciplined capstone**: it leaves the now-correct data layer and `ReferencesProcessingService` alone, fixes only the five worker-pool dispatch defects that the POC's offload pipeline had papered over, and lands the verification tests (including the live-topology and Playwright coverage the POC explicitly deferred).

--- a/docs/design/findreferences-pr503-deep-analysis.md
+++ b/docs/design/findreferences-pr503-deep-analysis.md
@@ -1,0 +1,248 @@
+# Find References — PR #503 Deep Implementation Analysis & Gap Assessment
+
+**Date:** 2026-06-26
+**Branch analyzed:** `feature/W-22692429-references-verification` (PR #503), full working tree — not the diff
+**Companion doc:** `findreferences-poc-vs-pr503-findings.md` (POC vs PR comparison)
+**Method:** Read the current implementation of the dispatch path, the data layer, and the service layer end-to-end; verified the highest-severity findings directly against source.
+
+This goes beyond the PR description. The PR narrates five root-cause fixes; this document traces what the merged code *actually does* once those fixes are in place, where the node and web platforms have drifted, and which correctness gaps survive into the shipped implementation.
+
+---
+
+## 1. The handler is a six-step best-effort pipeline
+
+The `DispatchReferences` handler (node `worker.platform.ts:1474`, web `worker.platform.web.ts:1321`) runs this sequence on a **stateless pool worker** that starts with no document and only the data-owner's `public-api` (method-body-stripped) view:
+
+```
+1. loadSymbolDataForEnrichment(uri, content)      // data-owner subset + Phase-2 type prefetch
+2. recompileCursorFileAtFullDetail(uri, content)  // re-parse cursor file WITH bodies
+3. loadReferencedTypesForFile(uri)                // load target type TABLES (even if resolved)
+4. declaringFileForCursorSymbol(uri, position)    // → targetUri (where the symbol is DECLARED)
+5. loadDependentsForReferences(targetUri ?? uri)  // load caller files of the target
+6. recompileCursorFileAtFullDetail(uri, content)  // RE-ASSERT full detail (deps may have re-stripped it)
+   → processReferences(...) → writeBackEnrichedSymbols(...)
+```
+
+**Every one of steps 1–6 is best-effort.** Each catches its own errors and logs at `debug` only; no caller inspects a return value to decide whether to abort or degrade. The consequence: when any prerequisite silently no-ops, `processReferences` still runs — against an incomplete local graph — and returns `[]` or a partial set with no signal that the result is degraded rather than genuinely empty. This is the dominant structural property of the implementation and the root of most gaps below.
+
+### Why `recompileCursorFileAtFullDetail` is called twice (steps 2 and 6)
+
+The data-owner serves `public-api` detail (bodies stripped), so a cursor on an *in-body* usage (`RefUtil u = new RefUtil()`) resolves to nothing. Step 2 re-parses the cursor file from `content` with `FullSymbolCollectorListener` so in-body references exist. Step 5 (`loadDependentsForReferences`) can re-ingest the cursor file at `public-api` — because the cursor file may itself be a caller of the target — which strips the bodies again. Step 6 re-asserts full detail. The double call is **correct in intent and idempotent on the happy path** (same `content`, re-entrancy-guarded resolve).
+
+**The unhandled case:** the entire mechanism is gated on `content`. `recompileCursorFileAtFullDetail` returns `false` immediately when `content` is falsy (node `:1071`, web `:997`). If `content` is `undefined`, *both* recompiles no-op, the cursor file stays at `public-api`, the position lookup finds no in-body reference, and find-references returns `[]` silently. See §3.
+
+---
+
+## 2. Node ↔ Web platform drift (verified)
+
+The two worker platforms are supposed to mirror each other. The `DispatchReferences` handler body and the step sequence **are identical**. One helper has **drifted**, and it is load-bearing:
+
+### `declaringFileForCursorSymbol` — web is missing the fallback
+
+**Node** (`worker.platform.ts:1174`) tries precise position→symbol resolution, then **falls back** to by-name resolution when precise returns null:
+
+```ts
+const symbol = await svc.symbolManager.getSymbolAtPosition(uri, parserPosition, 'precise');
+const fileUri = (symbol as { fileUri?: string } | null)?.fileUri;
+if (fileUri && fileUri !== uri) return fileUri;
+
+// Fallback: 'precise' returns null when the cursor file's reference isn't yet
+// bound to a resolvedSymbolId. Resolve the NAME to its declaring file directly.
+const refs = await svc.symbolManager.getReferencesAtPosition(uri, parserPosition);
+const name = refs?.[0]?.name;
+if (!name) return null;
+const leaf = name.includes('.') ? name.split('.').pop()! : name;
+const named = await svc.symbolManager.findSymbolByName(leaf);
+const namedUri = (named as { fileUri?: string } | null)?.fileUri;
+return namedUri && namedUri !== uri ? namedUri : null;
+```
+
+**Web** (`worker.platform.web.ts:1078`) stops at the precise attempt:
+
+```ts
+const symbol = await svc.symbolManager.getSymbolAtPosition(uri, parserPosition, 'precise');
+const fileUri = (symbol as { fileUri?: string } | null)?.fileUri;
+return fileUri && fileUri !== uri ? fileUri : null;   // no fallback
+```
+
+**Impact:** the fallback exists precisely for the common case where the cursor sits on a cross-file usage whose reference is not yet bound to a `resolvedSymbolId` in the worker's partial graph. On node, find-references then loads the dependents of the *target's declaring file* (correct). On web, `declaringFileForCursorSymbol` returns `null`, so step 5 falls back to `loadDependentsForReferences(req.textDocument.uri)` — the **cursor file's** dependents, which root cause #3 in the PR identifies as the *wrong* set. **Net: cross-file find-references on a usage is liable to return fewer/no cross-file results in the web (browser) worker than in node.** The Playwright E2E runs against the desktop/node topology, so this drift is not covered by the PR's tests.
+
+> Note: the JSDoc comment block for the web function (web `:1059-1077`) describes the full node behavior including the fallback, but the body does not implement it — the comment was copied, the second half of the body was not.
+
+---
+
+## 3. The `content` dependency is a single point of silent failure
+
+`content` originates coordinator-side in `WorkerCoordinator.buildLspRequestMessage` (`WorkerCoordinator.ts:1149`):
+
+```ts
+content: getDocumentContent?.(r.textDocument.uri),
+```
+
+`getDocumentContent` is the coordinator's open-document accessor. It returns `undefined` whenever the coordinator does not hold live text for the URI — e.g. the document was never opened in the editor session, or the accessor isn't wired for that dispatch path. When `content` is `undefined`:
+
+- `loadSymbolDataForEnrichment` does not seed local storage with the document.
+- **Both** `recompileCursorFileAtFullDetail` calls return `false` at the guard.
+- The cursor file remains at `public-api`; in-body position resolution fails.
+- `processReferences` → `findReferences` calls `storage.getDocument(uri)`; if that is also empty it returns `[]` at the top (`ReferencesProcessingService.ts:256`).
+
+There is no fallback to fetch the document text from the data-owner inside the references path, and no diagnostic distinguishing "no references exist" from "couldn't get the file's body." For a file that is on disk and known to the workspace but not currently open in the editor, this is a real hole. **Recommended:** have the references handler fetch text from the data-owner / resource loader when `content` is absent, or surface a degraded-result signal.
+
+---
+
+## 4. Surviving data-layer correctness gaps
+
+These live in `ApexSymbolRefManager` / `ApexSymbolManager` / `ReferencesProcessingService`. Several predate PR #503 (the service file is unchanged from `main`), but they shape what the worker-pool path returns, so they are in scope for "gaps that may still exist."
+
+### 4.1 Constructor overloads alias in the `findReferencesTo` cache (verified — HIGH)
+
+`buildReferencesToCacheKey` (`ApexSymbolManager.ts:768`) keys by `refs_to_<name>@<file>[:arity]`, where the arity suffix is only added when `isMethodSymbolNarrowing(symbol)` is true:
+
+```ts
+const arityPart = isMethodSymbolNarrowing(symbol)
+  ? `:${symbol.parameters?.length ?? 0}`
+  : '';
+return `refs_to_${symbol.name}@${filePart}${arityPart}`;
+```
+
+`isMethodSymbol` narrows on `kind === SymbolKind.Method` *only* (`symbolNarrowing.ts:47`). **Constructors are `SymbolKind.Constructor`, a distinct kind** (`symbol.ts:29`). Therefore every constructor — including overloaded constructors `Foo()` and `Foo(String)` on the same class — gets the **same** cache key `refs_to_Foo@/path/Foo.cls` with no arity discriminator. The first overload queried populates the cache; subsequent queries for sibling constructor overloads receive the first overload's reference set. The companion overload-separation logic in `separateOverloadReferences` *also* gates on `isMethodSymbol` (§4.2), so constructors get neither the keying nor the filtering. **Constructor find-references on an overloaded class returns the wrong/merged set.** Fix is small: include arity in the key (and run overload separation) for `Constructor` kind too.
+
+### 4.2 `separateOverloadReferences` only disambiguates by arity (verified — MEDIUM)
+
+`ApexSymbolRefManager:1994`. The filter keeps a reference when `callArity === undefined || callArity === targetArity`. Documented and real limitations:
+
+- **Same-arity overloads stay unified.** `f(String)` vs `f(Integer)` cannot be separated by argument *count*; both report each other's call sites. The code comments flag call-site type capture as the follow-up.
+- **`undefined` argument count is always kept.** References parsed before the `argumentCount` field existed, and all non-call edges (type refs, inheritance, field access that happen to share the method name), pass the filter. This is the conservative choice (no false negatives) but admits false positives onto an overload's result set.
+- Only fires when the method has `>1` same-named sibling on the *same declaring type and file*; otherwise it's a pass-through (the common case is unchanged).
+
+### 4.3 No deduplication when assembling `Location[]` (verified — LOW/MEDIUM)
+
+`getReferenceLocationsEffect` (`ReferencesProcessingService.ts:462-516`) pushes locations from four independent sources with **no dedup**:
+
+1. the declaration (if `includeDeclaration`),
+2. every result of `findReferencesTo(symbol)`,
+3. every result of `findReferencesFrom(symbol)`,
+4. `getRelationshipTypeReferencesEffect(symbol)` (inheritance/relationship edges).
+
+A single edge that is reachable both "to" and "from" the symbol, or that appears in both the graph and the relationship traversal (e.g. an `extends`/`implements` edge), is emitted **twice**. The LSP client shows duplicate entries in the peek/references panel. This is `main`'s behavior, surfaced more often now that the worker path pre-loads dependents and relationship edges. A keyed `Set` on `(uri, range)` before return would close it.
+
+### 4.4 Stale incoming-edge window on rename-during-merge (LOW)
+
+`clearReferenceStateForFile` (`ApexSymbolRefManager.ts:955`) correctly preserves incoming edges on re-parse (the POC's fix, now refined on `main`); incoming edges are dropped only via `removeFile` or `evictStaleFileDeclarations` on an `accepted-replace` decision. On a **merge** decision (enrichment write-back), stale declarations are intentionally retained, so a symbol that was renamed/removed in the new parse but kept under a merge can leave an incoming edge pointing at the old symbol id until a true replace/delete evicts it. Narrow window, low likelihood, but it can surface a phantom reference. Not introduced by #503.
+
+### 4.5 Deferred-reference drain does not run on the pool worker (MEDIUM, architectural)
+
+`drainAllDeferredReferencesSync` (`ApexSymbolRefManager.ts:3879`) is invoked from `findSupertypes`/`findSubtypes` reads and at data-owner/coordinator quiescent points — **not** in the `DispatchReferences` worker path. The worker instead relies on `resolveCrossFileReferencesForFile(uri)` calls sprinkled through steps 1, 2, 3, and 5 to bind the specific edges it just loaded. This is deliberate (the worker holds a transient partial graph, not the whole workspace), and `findInstanceMethodReferences` does trigger a drain via the supertype/subtype read. But it means correctness on the pool depends on the handler having pre-loaded exactly the right tables: anything the four prerequisite steps failed to fetch will not be recovered by a later drain. If a cross-file edge's target table never lands in the worker (e.g. a dependents fetch that silently failed in §1), that reference is simply absent from the result — no retry.
+
+### 4.6 `pickDeferredTarget` resolves ambiguity by "first candidate" (LOW)
+
+When draining, an unresolved target name with multiple same-named candidates across files/namespaces and no same-file or namespace-hint match attaches the edge to the first candidate and logs a warning (`ApexSymbolRefManager` ~`:4042`). The wrong edge then persists. Rare in practice but a latent source of a misattributed cross-file reference.
+
+---
+
+## 4b. Fallback patterns — a recurring root-cause smell
+
+**Standard:** we avoid fallbacks by default. A fallback — code that substitutes a secondary path or a default value when a primary mechanism returns nothing / fails — is treated as a signal that the *real* defect lives at the layer where the primary should have succeeded. The §2 web/node drift was found because the node version carries a fallback the web version doesn't; that prompted a sweep of the whole find-references path. The sweep found that fallbacks are pervasive here, and each one is masking a specific upstream failure that is the better thing to fix. Listed worst-first by how strongly the fallback hides a real bug.
+
+### FB-1 — Position→symbol resolution falls back to by-name (two sites) (HIGH — wrong results)
+
+The same pattern appears in both the service and the worker helper:
+
+- **Service:** `ReferencesProcessingService.findReferences` (`ReferencesProcessingService.ts:314-328`) — `getSymbolAtPosition(..., 'precise')`, then when that is null, `resolveSymbol(symbolName, context)`.
+- **Worker (node only):** `declaringFileForCursorSymbol` (`worker.platform.ts:1186-1213`) — precise `getSymbolAtPosition`, then `getReferencesAtPosition` → `findSymbolByName(leaf)`.
+
+**Primary:** precise position resolution returns the exact symbol/reference under the cursor.
+**Fallback:** resolve the bare *name* instead.
+**Root cause being masked:** precise returns null only when the cursor file's reference is **not bound to a `resolvedSymbolId`** — i.e. cross-file edge materialization (the `recompileCursorFileAtFullDetail` + `resolveCrossFileReferencesForFile` steps) didn't complete for that reference before the lookup ran. The fix is to guarantee the binding exists (or to find out *why* it doesn't for that case), not to switch to a name lookup.
+**Why the fallback is worse than the bug:** by-name resolution is ambiguous. Two files (or two scopes) declaring the same name resolve to whichever `findSymbolByName`/`resolveSymbol` returns first — so find-references can silently target the **wrong symbol's** references and report them as correct. It converts a diagnosable "binding missing" into an undiagnosable "wrong answer." This is the same defect class as §2 (the web platform's *absence* of FB-1's second half is itself a drift bug), which is why fixing the root — reliable cross-file binding before the position lookup — would let *both* fallbacks be deleted and erase the drift.
+
+### FB-2 — `loadSymbolDataForEnrichment` swallows a failed data-owner subset load (HIGH — wrong results)
+
+`worker.platform.ts:850-851` (mirror in web): the entire data-owner `QuerySymbolSubset` round-trip is wrapped in `try { … } catch { /* Subset load failed; caller may still proceed with partial graph. */ }`.
+**Primary:** fetch the cursor file's symbol table from the data-owner.
+**Fallback:** swallow the error, continue with an empty/partial local graph.
+**Root cause being masked:** the only ways this throws are a broken coordinator-assistance channel, an IPC failure, or a data-owner that doesn't have the file — each a real condition the caller should know about. Proceeding silently means `processReferences` runs against a graph missing 100% of the file's symbols and returns `[]` that is indistinguishable from "no references exist." The catch should at minimum surface a degraded-result signal; better, the failure modes (channel down, file absent) should be handled explicitly at their source.
+
+### FB-3 — `ResolveDepUris` empty → escalate to `resolveMissingNamesViaDataOwner` (HIGH — slow + masks stale index)
+
+`worker.platform.ts:798-826`. Phase-2 prefetch asks the data-owner to map unresolved class names to files via its class→file index (`ResolveDepUris`); the result is wrapped in `try { … } catch { /* best-effort; resolution can still work on-demand */ }`, and then **regardless** of what came back, a second cross-worker pass `resolveMissingNamesViaDataOwner(svc, [...classNames])` runs.
+**Primary:** the data-owner's class→file index resolves every unresolved name in one pass.
+**Fallback:** a per-name cross-worker query for whatever the index missed.
+**Root cause being masked:** if `ResolveDepUris` can't map a name that genuinely exists in the workspace, the **class→file index is incomplete or stale** — that is the bug. The fallback papers over it with a second round-trip (latency on every keystroke-triggered references request for files with many types) and still doesn't fix the index, so the slow path runs every time. Fix the index maintenance and the second pass becomes unnecessary.
+
+### FB-4 — Best-effort helpers that return a default on any error (MEDIUM — hides diagnostics; see §1)
+
+`recompileCursorFileAtFullDetail` (`worker.platform.ts:1094`, returns `false`), `loadReferencedTypesForFile` (`:1154`, returns `0`), `loadDependentsForReferences` (`:1039-1040`, returns silently), and `resolveMissingNamesViaDataOwner` (`:952`) each catch all errors and return a neutral default, logging at `debug` only. Collectively these are the §1 "best-effort pipeline." Each `catch` masks a distinct real failure — uncompilable text, a missing local symbol table, a failed dependents fetch — and none of them is allowed to fail the request or mark the result degraded. The root issue is that the handler treats "couldn't load the inputs find-references needs" as equivalent to "find-references found nothing." These should fail loudly or carry a degraded-result flag, not return `[]`/`false`/`0`.
+
+### FB-5 — `getSymbolAtPositionWithinScope` Step-3/Step-4 spatial fallbacks (MEDIUM — wrong results, but NOT on the references path today)
+
+`ApexSymbolManager.ts:2920-3015`. The `'scope'` strategy cascades: exact reference at position → same-line *spanning* reference (Step 3) → containing-scope symbol by size heuristic (Step 4). Each later step is a looser spatial guess that loses column precision / reference-type context and can return the wrong symbol when the cursor sits between identifiers.
+**Important scoping note:** find-references deliberately calls `getSymbolAtPosition` with the **`'precise'`** strategy precisely to *avoid* this cascade — the code comment at `ReferencesProcessingService.ts:305-313` is explicit that the Step-4 scope fallback is left for Implementation, not references. So FB-5 does **not** currently affect find-references results. It is listed because (a) it is the same anti-pattern in a shared dependency, and (b) FB-1's by-name fallback is a *re-implementation* of the same "primary precise lookup failed, guess instead" idea one layer up — both trace to the same unreliable-binding root cause. If FB-1 is removed, this should be reviewed for the other callers that still depend on it.
+
+### FB-6 — `getSymbol` multi-layer id lookup chain (LOW/MED — slow + masks id-schema drift)
+
+`ApexSymbolRefManager.ts:1489-1543`. Lookup by id index → `getSymbolById` (legacy) → exhaustive scan for `id` or `key.unifiedId` → parse the id, match by name preferring non-block. Four tiers.
+**Root cause being masked:** a miss in the primary id index means a symbol was added but not indexed, or the id format drifted (three coexisting id shapes), or a stale id outlived eviction. The name-based last tier can return the wrong same-named symbol, and the exhaustive scans turn an O(1) lookup into O(n) per miss. The fix is a single canonical symbol-id scheme with a maintained index, after which the lower tiers can go.
+
+**Through-line:** FB-1, FB-5, and FB-6 are all the same shape — "the precise/keyed lookup failed, so guess by name/position/scan." They share one root cause: **the worker's local graph isn't reliably bound (cross-file edges + canonical ids) before lookups run.** Fixing the binding/id-scheme roots would let the majority of these fallbacks be deleted rather than maintained, and would remove the §2 node/web drift as a side effect.
+
+---
+
+## 5. What the PR's tests do and do not cover
+
+- **`ReferencesThroughWorkerTopology.node.test.ts`** — a self-contained 3-file fixture (`RefUtil` + `RefCallerA` + `RefCallerB`, three cross-file call sites). Asserts `locations.length >= 3` and that both caller URIs appear, plus an `includeDeclaration: false` variant that asserts the declaration is suppressed. This proves the **happy path end-to-end through the node topology**. It does not exercise: overloaded methods/constructors, same-arity overloads, the `content === undefined` path, the web worker, duplicate-location output, or large/realistic workspaces.
+- **`referenceEnrichmentRecipe.node.test.ts`** — service-level recipe with observability; proves the declaring-file step is load-bearing.
+- **`apex-find-references.spec.ts`** (Playwright) — intra-file, cross-file, no-results, responsiveness — desktop/node only.
+- **`overloadSeparation.test.ts` / `signatureKeying.test.ts`** — cover the arity discriminator at the parser-ast layer (W-23133640), i.e. §4.2's happy path, but not the **constructor** key collision (§4.1).
+
+**Coverage gaps that map directly to the findings above:** no test for the web `declaringFileForCursorSymbol` fallback drift (§2), the `content`-absent silent-empty path (§3), constructor overload cache aliasing (§4.1), or duplicate locations (§4.3).
+
+---
+
+## 6. Prioritized gap summary
+
+| # | Gap | Severity | Location | Status |
+|---|-----|----------|----------|--------|
+| §2 | Web `declaringFileForCursorSymbol` lacks the by-name fallback node has → fewer cross-file results in browser worker | **High** | `worker.platform.web.ts:1078` | Drift, untested |
+| §4.1 | Constructor overloads alias in `findReferencesTo` cache (no arity key, no overload separation) | **High** | `ApexSymbolManager.ts:768`, `symbolNarrowing.ts:47` | Bug, untested |
+| §3 | `content === undefined` → both recompiles no-op → silent `[]` for non-open files | **Med-High** | `WorkerCoordinator.ts:1149`, `worker.platform.ts:1071` | Silent failure, no fallback |
+| §4.5 | Deferred-drain never runs on pool worker; correctness depends on prerequisite fetches that fail silently | **Med** | `worker.platform.ts:1474` handler | Architectural |
+| §4.2 | Same-arity overloads stay unified; `undefined` arity always kept | **Med** | `ApexSymbolRefManager.ts:1994` | Documented limitation |
+| §4.3 | No dedup across declaration / to / from / relationship → duplicate Locations | **Med** | `ReferencesProcessingService.ts:462` | Pre-existing (main) |
+| §1 | Whole pipeline best-effort; failures log at `debug`, no degraded-result signal | **Med** | handler + all 5 helpers | By design, observability gap |
+| §4.4 | Stale incoming edge on rename-during-merge | **Low** | `ApexSymbolRefManager.ts:955` | Narrow window |
+| §4.6 | `pickDeferredTarget` first-candidate ambiguity | **Low** | `ApexSymbolRefManager.ts:~4042` | Latent |
+| FB-1 | Position→symbol resolution falls back to by-name (service + worker) | **High** | `ReferencesProcessingService.ts:314`, `worker.platform.ts:1186` | Fallback masks missing cross-file binding |
+| FB-2 | `loadSymbolDataForEnrichment` swallows failed subset load | **High** | `worker.platform.ts:850` | Fallback masks data-owner/IPC failure |
+| FB-3 | `ResolveDepUris` empty → escalate to per-name query | **High** | `worker.platform.ts:798` | Fallback masks stale class→file index |
+| FB-4 | Best-effort helpers return default on any error | **Med** | `worker.platform.ts:1094/1154/1039` | Fallbacks hide load failures (see §1) |
+| FB-5 | `getSymbolAtPositionWithinScope` Step-3/4 spatial fallback | **Med** | `ApexSymbolManager.ts:2920` | Same anti-pattern; not on references path today |
+| FB-6 | `getSymbol` multi-tier id lookup chain | **Low-Med** | `ApexSymbolRefManager.ts:1489` | Fallbacks mask id-schema drift |
+
+### Highest-value follow-ups
+0. **Fix the root the fallbacks share, then delete them** (§4b) — FB-1/FB-5/FB-6 all guess (by-name / by-scope / by-scan) because the worker's local graph isn't reliably bound (cross-file edges + canonical symbol ids) before lookups run. Guaranteeing that binding lets the fallbacks be removed *and* erases the §2 drift, rather than porting the fallback to a second platform. Prefer this over follow-up #1 if the binding work is tractable.
+1. **(If FB-1's root can't be fixed now) Port the node `declaringFileForCursorSymbol` fallback into the web platform** (§2) — stop-gap that closes the cross-platform behavior gap; a near-mechanical change, but it spreads the fallback rather than removing it.
+2. **Treat `Constructor` like `Method` in `buildReferencesToCacheKey` and `separateOverloadReferences`** (§4.1) — small, removes a wrong-results bug; add a constructor-overload test.
+3. **Fetch document text from the data-owner when `content` is absent** (§3), or at minimum log a distinguishable warning so "couldn't load body" isn't reported as "no references."
+4. **Dedup `Location[]` before returning** (§4.3) — one `Set` keyed on `(uri,startLine,startChar)`.
+5. **Add a "result is degraded" signal** out of the best-effort helpers (§1) so silent partials are observable in telemetry once the W-22629622 telemetry path lands.
+
+---
+
+## 7. Resolution status (branch `feature/W-22692429-references-fallback-cleanup`)
+
+Fixes landed on this branch, with the standard "fix the root, don't paper over it" applied:
+
+| # | What shipped | Root-cause vs. patch | Commit theme |
+|---|---|---|---|
+| §4.1 | Constructor overloads now separate in find-references. Found the *deeper* root: constructor-call refs never carried call-site arity at all — stamped `argumentCount` (new `countConstructorArguments`) in BOTH listeners, added `isMethodOrConstructorSymbol`, and keyed the cache + overload separation on it. | Root cause | `separate constructor overloads` |
+| §4.3 | `getReferenceLocationsEffect` now dedups exact `(uri, range)` across all four sources. | Root cause | `location dedup` |
+| FB-1 | **Root fixed.** Qualified cross-file refs (`Outer.Inner`) now bind via the FQN index to the leaf symbol, so `resolvedSymbolId` is set and `findReferencesTo` no longer misses qualified callers. New regression test. The by-name fallbacks are **kept** (documented) for the genuine partial-graph/ordering case the binding fix doesn't cover; §2 drift closed by porting the node fallback to web so both platforms match. | Root cause + documented fallback | `qualified-ref binding` |
+| §2 | Web `declaringFileForCursorSymbol` now carries the node by-name fallback verbatim — node/web parity restored. | Drift fixed | (with FB-1) |
+| FB-2 / FB-4 / §1 / §3 | Best-effort enrichment helpers now `warn` (not silent/`debug`) on real failures; the `content`-absent case is flagged explicitly. An empty result is now attributable to a load failure vs. a genuine no-match. Mirrored node + web. | Observability (fallbacks are by-design here) | `degraded-result signals` |
+
+Deferred, with rationale:
+
+- **FB-3 (stale class→file index for inner classes).** The qualified-binding root behind it is fixed (FB-1). The remaining piece — the data-owner indexing only public-api-visibility symbols, excluding inner classes — is a data-owner index-population change; the `resolveMissingNamesViaDataOwner` escalation is **kept** as the documented safety net per the "keep fallbacks" decision. Not a correctness regression after FB-1.
+- **FB-5 (`getSymbolAtPositionWithinScope` Step-3/4 cascade).** Not on the references path (references uses `'precise'`, which bypasses it); owned by Implementation. Left untouched.
+- **FB-6 (canonical symbol-id scheme).** Out of scope for this branch: ~70 id generation/parse sites and `getSymbol` consumed across 10+ files plus the worker wire format. A canonical-id rewrite is a multi-day, high-blast-radius change to the core graph layer and should be its own work item, not bundled into a references branch.

--- a/e2e-tests/pages/ApexEditorPage.ts
+++ b/e2e-tests/pages/ApexEditorPage.ts
@@ -178,6 +178,63 @@ export class ApexEditorPage extends BasePage {
   }
 
   /**
+   * Trigger find-all-references at the current cursor position (Shift+F12).
+   *
+   * VS Code surfaces references in a peek widget (the `references-view` /
+   * `.peekview-widget`). Returns the number of reference entries the peek
+   * lists, or 0 when none appear. The peek is left OPEN so callers can assert
+   * on its contents; close it with {@link closePeek} when done.
+   */
+  async findReferences(): Promise<number> {
+    // Ensure the Find widget is closed and the editor has focus (same hazard as
+    // goToDefinition: a left-open Find widget swallows the shortcut).
+    const findWidget = this.page.locator('.editor-widget.find-widget');
+    if (await findWidget.isVisible()) {
+      await this.page.keyboard.press('Escape');
+      await findWidget
+        .waitFor({ state: 'hidden', timeout: 3000 })
+        .catch(() => {});
+    }
+
+    await this.page.keyboard.press('Shift+F12');
+
+    // The references peek widget appears for any non-empty result set. Give the
+    // LSP time to answer (references can fan out cross-file).
+    const peekWidget = this.page.locator('.editor-widget.peekview-widget');
+    await peekWidget
+      .waitFor({ state: 'visible', timeout: this.defaultTimeout })
+      .catch(() => {});
+
+    if (!(await peekWidget.isVisible())) {
+      return 0;
+    }
+
+    // Each reference is a row in the peek's tree. Count the result entries
+    // (file/line rows), excluding the file-group headers.
+    const entries = peekWidget.locator(
+      '.monaco-list-row .referenceMatch, .monaco-list-row[role="treeitem"]',
+    );
+    const count = await entries.count().catch(() => 0);
+    return count;
+  }
+
+  /**
+   * Close any open peek widget (references / definition peek).
+   */
+  async closePeek(): Promise<void> {
+    const peekWidget = this.page.locator('.editor-widget.peekview-widget');
+    for (let i = 0; i < 3; i++) {
+      if (!(await peekWidget.isVisible())) {
+        return;
+      }
+      await this.page.keyboard.press('Escape');
+      await peekWidget
+        .waitFor({ state: 'hidden', timeout: 500 })
+        .catch(() => {});
+    }
+  }
+
+  /**
    * Trigger completion/IntelliSense at the current cursor position.
    * Uses Ctrl+Space keyboard shortcut.
    */

--- a/e2e-tests/tests/apex-find-references.spec.ts
+++ b/e2e-tests/tests/apex-find-references.spec.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { test, expect } from '../fixtures/apexFixtures';
+
+/**
+ * E2E tests for Apex Find All References (W-22692429 / 6.13).
+ *
+ * Exercises the LSP `textDocument/references` path end-to-end through the
+ * editor: position the cursor on a symbol, trigger Shift+F12, and assert the
+ * references peek widget surfaces results — including cross-file usages, which
+ * are dispatched through the enrichment worker pool when the topology is active.
+ *
+ * @group find-references
+ */
+
+test.describe('Apex Find All References', () => {
+  test('finds references to a symbol used within the same file', async ({
+    apexEditor,
+  }) => {
+    await test.step('Open a file with intra-file usages', async () => {
+      await apexEditor.openFile('ApexClassExample.cls');
+      await apexEditor.waitForLanguageServerReady();
+    });
+
+    await test.step('Position on a symbol that is used more than once', async () => {
+      // `sayHello` is declared and called within ApexClassExample.
+      await apexEditor.positionCursorOnWord('sayHello');
+    });
+
+    await test.step('Trigger find-references and assert results appear', async () => {
+      const count = await apexEditor.findReferences();
+      // At least the declaration + one call site.
+      expect(count).toBeGreaterThan(0);
+      console.log(`✅ Find-references returned ${count} entries`);
+      await apexEditor.closePeek();
+    });
+  });
+
+  test('finds cross-file references to a utility class', async ({
+    apexEditor,
+    hoverHelper,
+  }) => {
+    await test.step('Open the utility and caller files', async () => {
+      // Open the caller first so the LSP eagerly indexes the cross-file usage,
+      // then open the declaring file where we invoke find-references.
+      await apexEditor.openFile('CrossFileCaller.cls');
+      await apexEditor.waitForLanguageServerReady();
+      await apexEditor.openFile('CrossFileUtility.cls');
+      await apexEditor.waitForLanguageServerReady();
+    });
+
+    await test.step('Warm up cross-file resolution via hover', async () => {
+      // The Apex LSP lazily loads cross-file dependents; a hover primes the
+      // resolver (same warm-up the cross-file goto-definition tests use).
+      await hoverHelper.hoverAtWithResolution(9, 25);
+    });
+
+    await test.step('Find references to the utility class from its declaration', async () => {
+      // `CrossFileUtility` on its class declaration line (line 6, 1-based).
+      await apexEditor.goToPosition(6, 1);
+      await apexEditor.positionCursorOnWord('CrossFileUtility');
+
+      const count = await apexEditor.findReferences();
+      // The declaration plus the cross-file usages in CrossFileCaller.
+      expect(count).toBeGreaterThan(0);
+      console.log(`✅ Cross-file find-references returned ${count} entries`);
+      await apexEditor.closePeek();
+    });
+  });
+
+  test('does not crash when no references exist', async ({ apexEditor }) => {
+    await test.step('Open a file and add an unreferenced symbol', async () => {
+      await apexEditor.openFile('ApexClassExample.cls');
+      await apexEditor.waitForLanguageServerReady();
+      await apexEditor.goToPosition(1, 1);
+      await apexEditor.typeText('// UnreferencedXyz\n');
+      await apexEditor.positionCursorOnWord('UnreferencedXyz');
+    });
+
+    await test.step('Find-references returns nothing without crashing', async () => {
+      const count = await apexEditor.findReferences();
+      expect(count).toBe(0);
+      expect(await apexEditor.isApexFileOpen()).toBe(true);
+      await apexEditor.closePeek();
+      console.log('✅ Gracefully handled no-references case');
+    });
+  });
+
+  test('find-references is responsive', async ({ apexEditor }) => {
+    await apexEditor.openFile('ApexClassExample.cls');
+    await apexEditor.waitForLanguageServerReady();
+    await apexEditor.positionCursorOnWord('sayHello');
+
+    const startTime = Date.now();
+    await apexEditor.findReferences();
+    const elapsedTime = Date.now() - startTime;
+
+    // CI runners are slower; allow 12s there, 8s locally (mirrors the
+    // go-to-definition responsiveness test's budget).
+    const maxMs = process.env.CI ? 12000 : 8000;
+    expect(elapsedTime).toBeLessThan(maxMs);
+    await apexEditor.closePeek();
+    console.log(`✅ Find-references completed in ${elapsedTime}ms`);
+  });
+});

--- a/packages/apex-ls/src/server/WorkerCoordinator.ts
+++ b/packages/apex-ls/src/server/WorkerCoordinator.ts
@@ -1149,6 +1149,11 @@ function buildLspRequestMessage(
         context: {
           includeDeclaration: r.context?.includeDeclaration ?? false,
         },
+        // The pool worker's ReferencesProcessingService maps the cursor to a
+        // symbol via its local document; carry the live text so its storage
+        // isn't empty (same as documentSymbol). Without it find-references
+        // returns [] on the pool.
+        content: getDocumentContent?.(r.textDocument.uri),
       });
     }
     case 'implementation':

--- a/packages/apex-ls/src/worker.platform.ts
+++ b/packages/apex-ls/src/worker.platform.ts
@@ -820,9 +820,8 @@ async function loadSymbolDataForEnrichment(
           // this enrichment worker's LOCAL name index. Ask the data-owner
           // (which holds ALL workspace symbols) to resolve the remaining names
           // in one batched query and ingest the owning files' symbol tables.
-          const ingested = await resolveMissingNamesViaDataOwner(svc, [
-            ...classNames,
-          ]);
+          // The ingest count is intentionally not captured (see below).
+          await resolveMissingNamesViaDataOwner(svc, [...classNames]);
 
           // Ingestion alone only lands the owning files' SYMBOLS in the local
           // name index (addSymbolTable processes same-file refs only and defers
@@ -840,7 +839,6 @@ async function loadSymbolDataForEnrichment(
           // resolution), so resolve whenever ANY class dep was requested.
           // resolveCrossFileReferencesForFile is re-entrancy-guarded and
           // addReference de-dupes, so this is near-free when nothing changed.
-          void ingested;
           await Effect.runPromise(
             svc.symbolManager.resolveCrossFileReferencesForFile(uri),
           );
@@ -1137,26 +1135,43 @@ export async function loadReferencedTypesForFile(
       await import('@salesforce/apex-lsp-parser-ast');
     const st = await svc.symbolManager.getSymbolTableForFile(uri);
     if (!st) return 0;
-    const refs = (
-      st as unknown as {
-        getAllReferences: () => Array<{ name: string; context: number }>;
-      }
-    ).getAllReferences();
-    const typeNames = new Set<string>();
+    const refs = st.getAllReferences();
+    // Group the referenced type leaf names by their qualifier so the qualifier
+    // can be threaded to the data-owner as a disambiguation namespace hint. A
+    // qualified `MyNs.Foo` resolves by its LEAF (`Foo`) — the data-owner's name
+    // index is keyed on the simple name — while the head (`MyNs`) is the
+    // namespace hint. `declaringFileForCursorSymbol` strips to the same leaf.
+    // The undefined-qualifier bucket is the unqualified hot path; it stays a
+    // single batched, namespace-free query (byte-identical to before).
+    const namesByQualifier = new Map<string | undefined, Set<string>>();
     for (const ref of refs) {
       if (
         ref.context === ReferenceContext.CLASS_REFERENCE ||
         ref.context === ReferenceContext.CONSTRUCTOR_CALL ||
         ref.context === ReferenceContext.TYPE_DECLARATION
       ) {
-        // Strip a qualified prefix; the type owner is keyed by the leaf name.
-        typeNames.add(
-          ref.name.includes('.') ? ref.name.split('.')[0] : ref.name,
-        );
+        const dot = ref.name.lastIndexOf('.');
+        const leaf = dot >= 0 ? ref.name.slice(dot + 1) : ref.name;
+        const qualifier = dot >= 0 ? ref.name.slice(0, dot) : undefined;
+        const bucket = namesByQualifier.get(qualifier) ?? new Set<string>();
+        bucket.add(leaf);
+        namesByQualifier.set(qualifier, bucket);
       }
     }
-    if (typeNames.size === 0) return 0;
-    const ingested = await resolveMissingNamesViaDataOwner(svc, [...typeNames]);
+    if (namesByQualifier.size === 0) return 0;
+    // One batched query per distinct qualifier. In the common case a file's
+    // type refs share a single bucket (unqualified, or one managed package), so
+    // this is the same single round-trip as before; mixed qualifiers cost one
+    // hop each rather than collapsing namespaces onto one ambiguous query.
+    let ingested = 0;
+    for (const [qualifier, leaves] of namesByQualifier) {
+      ingested += await resolveMissingNamesViaDataOwner(
+        svc,
+        [...leaves],
+        undefined,
+        qualifier,
+      );
+    }
     // Bind the cursor file's references to the freshly-loaded type tables so the
     // reverse index + position-precise lookups resolve.
     await Effect.runPromise(
@@ -2150,6 +2165,23 @@ const handlers: WorkerRunner.SerializedRunner.Handlers<
               ),
             ];
 
+            // Optional namespace hint: a qualified reference (`MyNs.Foo`)
+            // carries its leading qualifier so the data-owner can disambiguate
+            // same-named matches across namespaces. Applied as a SOFT
+            // preference, not a hard filter — if no symbol's namespace matches
+            // the hint, fall back to all matches. This keeps inner-class
+            // qualifiers (`Outer.Inner`, where `Outer` is a type, not a
+            // namespace) working: nothing matches the hint, so all candidates
+            // are returned as before.
+            const nsHint = req.namespace?.toLowerCase();
+            const symbolNamespace = (s: {
+              namespace?: unknown;
+            }): string | undefined => {
+              const ns = s.namespace;
+              if (!ns) return undefined;
+              return (typeof ns === 'string' ? ns : String(ns)).toLowerCase();
+            };
+
             const matches: Array<{
               name: string;
               fileUri: string;
@@ -2162,15 +2194,21 @@ const handlers: WorkerRunner.SerializedRunner.Handlers<
               const symbols = yield* Effect.promise(() =>
                 sm.findSymbolByName(queryName),
               );
-              for (const symbol of symbols) {
-                if (!symbol?.fileUri) continue;
+              const withFile = symbols.filter((s) => !!s?.fileUri);
+              // Prefer the namespace-matched subset when the hint actually
+              // matches something; otherwise keep every candidate.
+              const nsMatched = nsHint
+                ? withFile.filter((s) => symbolNamespace(s) === nsHint)
+                : [];
+              const selected = nsMatched.length > 0 ? nsMatched : withFile;
+              for (const symbol of selected) {
                 matches.push({
                   name: symbol.name,
-                  fileUri: symbol.fileUri,
+                  fileUri: symbol.fileUri!,
                   kind:
                     typeof symbol.kind === 'string' ? symbol.kind : undefined,
                 });
-                uris.add(symbol.fileUri);
+                uris.add(symbol.fileUri!);
               }
             }
 

--- a/packages/apex-ls/src/worker.platform.ts
+++ b/packages/apex-ls/src/worker.platform.ts
@@ -830,14 +830,20 @@ async function loadSymbolDataForEnrichment(
           // on-demand name lookup, so the symbol is enough for them — but the
           // requesting file's TypeReference is still unresolved (no
           // resolvedSymbolId, no reverse-index edge). Materialize those edges
-          // now so reverse-index consumers see them too. Gated on a real
-          // ingest, and resolveCrossFileReferencesForFile is re-entrancy-guarded
-          // + addReference de-dupes, so this is near-free when nothing landed.
-          if (ingested > 0) {
-            await Effect.runPromise(
-              svc.symbolManager.resolveCrossFileReferencesForFile(uri),
-            );
-          }
+          // now so reverse-index + position-precise consumers see them too.
+          //
+          // NOT gated on resolveMissingNamesViaDataOwner's ingest count: the
+          // earlier ResolveDepUris pass may have already loaded every dep, which
+          // makes that count 0 even though the cursor file's references are
+          // still unbound. find-references' 'precise' position→symbol lookup
+          // needs those bindings (unlike hover/definition's on-demand by-name
+          // resolution), so resolve whenever ANY class dep was requested.
+          // resolveCrossFileReferencesForFile is re-entrancy-guarded and
+          // addReference de-dupes, so this is near-free when nothing changed.
+          void ingested;
+          await Effect.runPromise(
+            svc.symbolManager.resolveCrossFileReferencesForFile(uri),
+          );
         }
       }
     }
@@ -1038,6 +1044,175 @@ export async function loadDependentsForReferences(
       () => `[REFERENCES] Dependent pre-fetch failed for ${uri}: ${err}`,
     );
     return 0;
+  }
+}
+
+/**
+ * Recompile the cursor file at FULL detail into the worker's local symbol
+ * manager, then resolve its cross-file references.
+ *
+ * Find References maps the cursor POSITION to a symbol via
+ * getReferencesAtPosition / getSymbolAtPosition, which only see references that
+ * live inside method bodies when the file was parsed at full detail. The
+ * data-owner serves files at 'public-api' (bodies stripped), so a cursor on an
+ * in-body usage (`RefUtil u = new RefUtil()`) resolves to nothing and Find
+ * References returns []. documentSymbol hits the same wall and solves it by
+ * recompiling the open file from its text with FullSymbolCollectorListener;
+ * we do the same here so the cursor file carries its in-body references, then
+ * resolve cross-file edges so usages in OTHER files still resolve to it.
+ *
+ * Best-effort: a missing/uncompilable document leaves the public-api graph in
+ * place and Find References proceeds with whatever it has.
+ *
+ * @param svc Enrichment services (symbol manager).
+ * @param uri Cursor file URI to recompile.
+ * @param content Live document text; when absent, nothing is recompiled.
+ */
+export async function recompileCursorFileAtFullDetail(
+  svc: RequestServices,
+  uri: string,
+  content?: string,
+): Promise<boolean> {
+  if (!content) return false;
+  try {
+    const { CompilerService, FullSymbolCollectorListener, SymbolTable } =
+      await import('@salesforce/apex-lsp-parser-ast');
+    const table = new SymbolTable();
+    const listener = new FullSymbolCollectorListener(table);
+    const result = new CompilerService().compile(content, uri, listener, {
+      collectReferences: true,
+      resolveReferences: true,
+    });
+    const st = result?.result instanceof SymbolTable ? result.result : table;
+    await Effect.runPromise(svc.symbolManager.addSymbolTable(st, uri));
+    // Re-resolve so the freshly-parsed in-body references re-key into the
+    // cross-file reverse index (the public-api version's edges are superseded).
+    await Effect.runPromise(
+      svc.symbolManager.resolveCrossFileReferencesForFile(uri),
+    );
+    return true;
+  } catch (err) {
+    getLogger().debug(
+      () => `[REFERENCES] Full-detail recompile failed for ${uri}: ${err}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Load the symbol tables of every TYPE the cursor file references, regardless of
+ * whether those references already carry a resolvedSymbolId.
+ *
+ * loadSymbolDataForEnrichment's Phase-2 prefetch only fetches types whose
+ * references are UNRESOLVED (`!resolvedSymbolId`) — correct for hover/definition,
+ * which follow the resolvedSymbolId to the data-owner on demand. But Find
+ * References needs the referenced type's table PRESENT locally to enumerate that
+ * type's own references: a `RefUtil` usage already resolved by the data-owner
+ * still leaves RefUtil's table absent in the pool, so findReferencesTo(RefUtil)
+ * sees nothing. This loads those already-resolved type tables too.
+ *
+ * Best-effort: failures leave the partial graph in place.
+ *
+ * @param svc Enrichment services (symbol manager).
+ * @param uri Cursor file URI whose referenced types to load.
+ */
+export async function loadReferencedTypesForFile(
+  svc: RequestServices,
+  uri: string,
+): Promise<number> {
+  try {
+    const { ReferenceContext } =
+      await import('@salesforce/apex-lsp-parser-ast');
+    const st = await svc.symbolManager.getSymbolTableForFile(uri);
+    if (!st) return 0;
+    const refs = (
+      st as unknown as {
+        getAllReferences: () => Array<{ name: string; context: number }>;
+      }
+    ).getAllReferences();
+    const typeNames = new Set<string>();
+    for (const ref of refs) {
+      if (
+        ref.context === ReferenceContext.CLASS_REFERENCE ||
+        ref.context === ReferenceContext.CONSTRUCTOR_CALL ||
+        ref.context === ReferenceContext.TYPE_DECLARATION
+      ) {
+        // Strip a qualified prefix; the type owner is keyed by the leaf name.
+        typeNames.add(
+          ref.name.includes('.') ? ref.name.split('.')[0] : ref.name,
+        );
+      }
+    }
+    if (typeNames.size === 0) return 0;
+    const ingested = await resolveMissingNamesViaDataOwner(svc, [...typeNames]);
+    // Bind the cursor file's references to the freshly-loaded type tables so the
+    // reverse index + position-precise lookups resolve.
+    await Effect.runPromise(
+      svc.symbolManager.resolveCrossFileReferencesForFile(uri),
+    );
+    return ingested;
+  } catch (err) {
+    getLogger().debug(
+      () => `[REFERENCES] Referenced-type load failed for ${uri}: ${err}`,
+    );
+    return 0;
+  }
+}
+
+/**
+ * Resolve the symbol under the cursor and return the file URI it is DECLARED
+ * in. Find References on a usage must load callers of the TARGET symbol, which
+ * may live in a different file than the cursor (e.g. the cursor is on a
+ * `RefUtil` usage in CallerA, but the references span CallerB too). The target's
+ * dependents hang off its declaring file, so the handler loads dependents for
+ * THIS uri rather than the cursor file.
+ *
+ * Requires the cursor file to already be compiled at full detail locally (so
+ * the position resolves). Returns null when no symbol resolves or it carries no
+ * fileUri, in which case the caller falls back to the cursor file.
+ */
+export async function declaringFileForCursorSymbol(
+  svc: RequestServices,
+  uri: string,
+  position: { line: number; character: number },
+): Promise<string | null> {
+  try {
+    // LSP (0-based line) → parser (1-based line, 0-based column).
+    const parserPosition = {
+      line: position.line + 1,
+      character: position.character,
+    };
+
+    // Preferred: precise position→symbol resolution gives the declaring file
+    // directly.
+    const symbol = await svc.symbolManager.getSymbolAtPosition(
+      uri,
+      parserPosition,
+      'precise',
+    );
+    const fileUri = (symbol as { fileUri?: string } | null)?.fileUri;
+    if (fileUri && fileUri !== uri) return fileUri;
+
+    // Fallback: 'precise' can return null when the cursor file's reference
+    // isn't yet bound to a resolvedSymbolId (cross-file edges not fully
+    // materialized in the worker's partial graph). The reference under the
+    // cursor still carries the NAME, and the target symbol is loaded by name —
+    // so resolve the name to its declaring file directly. This is what lets
+    // find-references on a `RefUtil` usage reach RefUtil.cls's dependents.
+    const refs = await svc.symbolManager.getReferencesAtPosition(
+      uri,
+      parserPosition,
+    );
+    const name = refs?.[0]?.name;
+    if (!name) return null;
+    // Strip any qualified prefix (`Outer.Inner` → leaf segment is searched, but
+    // a type usage like `RefUtil` is already unqualified).
+    const leaf = name.includes('.') ? name.split('.').pop()! : name;
+    const named = await svc.symbolManager.findSymbolByName(leaf);
+    const namedUri = (named as { fileUri?: string } | null)?.fileUri;
+    return namedUri && namedUri !== uri ? namedUri : null;
+  } catch {
+    return null;
   }
 }
 
@@ -1301,14 +1476,55 @@ const requestHandlers = {
     async (svc, req) => {
       // Mirror the hover/definition enrichment shape:
       //   load symbol data → load caller-side dependents → process → write back.
+      // Thread req.content so the pool worker's storage holds the document:
+      // ReferencesProcessingService maps the cursor position to a symbol via
+      // storage.getDocument(), and returns [] when it's absent. The stateless
+      // pool worker has no document otherwise (same as documentSymbol).
       const { version, detailLevel } = await loadSymbolDataForEnrichment(
         svc,
         req.textDocument.uri,
+        req.content,
       );
 
-      // Find References needs the caller-side tables (files that reference the
-      // target's symbols), which loadSymbolDataForEnrichment does not fetch.
-      await loadDependentsForReferences(svc, req.textDocument.uri);
+      // Recompile the cursor file at FULL detail so its in-body references
+      // exist for position→symbol resolution. The data-owner serves public-api
+      // (bodies stripped), so without this a cursor on an in-body usage
+      // resolves to nothing and Find References returns [].
+      await recompileCursorFileAtFullDetail(
+        svc,
+        req.textDocument.uri,
+        req.content,
+      );
+
+      // Load the tables of every TYPE the cursor file references — even ones
+      // the data-owner already resolved (resolvedSymbolId set). Find References
+      // needs the target type's table PRESENT to enumerate its references; the
+      // resolved-only prefetch in loadSymbolDataForEnrichment skips them.
+      await loadReferencedTypesForFile(svc, req.textDocument.uri);
+
+      // Load the caller-side tables (files that reference the TARGET symbol).
+      // The target may be declared in a DIFFERENT file than the cursor: e.g.
+      // find-references on a `RefUtil` usage inside CallerA must surface usages
+      // in CallerB too. So resolve the cursor to its symbol, then load
+      // dependents of that symbol's DECLARING file — not the cursor file, whose
+      // own dependents are unrelated. Falls back to the cursor file when the
+      // symbol or its declaring file can't be determined.
+      const targetUri = await declaringFileForCursorSymbol(
+        svc,
+        req.textDocument.uri,
+        req.position,
+      );
+      await loadDependentsForReferences(svc, targetUri ?? req.textDocument.uri);
+
+      // Re-assert the cursor file at full detail: loadDependentsForReferences
+      // may have re-ingested it at public-api (the cursor file can itself be a
+      // caller of the target), which would strip the in-body references the
+      // position lookup needs. Idempotent + bounded, so cheap on the no-op path.
+      await recompileCursorFileAtFullDetail(
+        svc,
+        req.textDocument.uri,
+        req.content,
+      );
 
       // References resolve against protected members of dependent files, so a
       // 'protected' detail level matches the existing service behavior (see
@@ -1857,12 +2073,20 @@ const handlers: WorkerRunner.SerializedRunner.Handlers<
                 sm.getSymbolTableForFile(uri),
               );
               if (st) {
-                entries[uri] = cloneForWire({
+                // Key the entry by the table's CANONICAL fileUri, not the
+                // lookup `uri`. findFilesForSymbol strips the `file://` scheme
+                // (returns `/test/X.cls`), so keying by `uri` would make the
+                // requesting worker ingest the table under a schemeless URI that
+                // never matches its references' `file:///test/X.cls` targets —
+                // cross-file edges then fail to bind and find-references on a
+                // usage of this type returns []. getFileUri() preserves scheme.
+                const canonicalUri = st.getFileUri();
+                entries[canonicalUri] = cloneForWire({
                   symbols: st.getAllSymbols(),
                   references: st.getAllReferences(),
                   hierarchicalReferences: st.getAllHierarchicalReferences(),
                   metadata: st.getMetadata(),
-                  fileUri: st.getFileUri(),
+                  fileUri: canonicalUri,
                 });
               }
             }

--- a/packages/apex-ls/src/worker.platform.ts
+++ b/packages/apex-ls/src/worker.platform.ts
@@ -847,8 +847,15 @@ async function loadSymbolDataForEnrichment(
         }
       }
     }
-  } catch {
-    // Subset load failed; caller may still proceed with partial graph.
+  } catch (err) {
+    // Subset load failed (assistance channel down, IPC error, or the data-owner
+    // doesn't have the file). The caller proceeds on a partial/empty graph, so
+    // any request built on it (hover/definition/references/…) may silently
+    // return nothing. Warn — not debug — so an empty result has a breadcrumb
+    // distinguishing "real failure" from "genuinely nothing here".
+    getLogger().warn(
+      () => `[ENRICHMENT] Symbol-subset load failed for ${uri}: ${err}`,
+    );
   }
 
   return { version, detailLevel };
@@ -1038,9 +1045,11 @@ export async function loadDependentsForReferences(
     return ingested;
   } catch (err) {
     // Dependent pre-fetch is best-effort; reference search can still run on
-    // the tables already loaded (e.g. same-file references). Log at debug so a
-    // "cross-file references missing" report has a breadcrumb to follow.
-    getLogger().debug(
+    // the tables already loaded (e.g. same-file references). But reaching this
+    // catch means cross-file callers were NOT loaded, so the result is likely
+    // incomplete — warn so a "cross-file references missing" report has a
+    // breadcrumb to follow.
+    getLogger().warn(
       () => `[REFERENCES] Dependent pre-fetch failed for ${uri}: ${err}`,
     );
     return 0;
@@ -1092,7 +1101,10 @@ export async function recompileCursorFileAtFullDetail(
     );
     return true;
   } catch (err) {
-    getLogger().debug(
+    // The cursor file stays at public-api detail, so an in-body cursor won't
+    // resolve and Find References can return []. Warn so that empty result is
+    // attributable to a recompile failure rather than a genuine no-match.
+    getLogger().warn(
       () => `[REFERENCES] Full-detail recompile failed for ${uri}: ${err}`,
     );
     return false;
@@ -1152,7 +1164,9 @@ export async function loadReferencedTypesForFile(
     );
     return ingested;
   } catch (err) {
-    getLogger().debug(
+    // Target type tables may be absent locally, so findReferencesTo(type) can
+    // come back empty. Warn so the gap is attributable.
+    getLogger().warn(
       () => `[REFERENCES] Referenced-type load failed for ${uri}: ${err}`,
     );
     return 0;
@@ -1485,6 +1499,20 @@ const requestHandlers = {
         req.textDocument.uri,
         req.content,
       );
+
+      // The full-detail recompile (and therefore in-body position resolution)
+      // is gated on having the document text. The coordinator omits `content`
+      // when it isn't tracking the file as open, so an empty result here would
+      // be indistinguishable from a genuine no-match. Flag it explicitly.
+      const cursorTextAvailable = typeof req.content === 'string';
+      if (!cursorTextAvailable) {
+        getLogger().warn(
+          () =>
+            `[REFERENCES] No document text for ${req.textDocument.uri}; ` +
+            'cursor file cannot be recompiled at full detail and an in-body ' +
+            'cursor may yield no references. Result may be degraded.',
+        );
+      }
 
       // Recompile the cursor file at FULL detail so its in-body references
       // exist for position→symbol resolution. The data-owner serves public-api

--- a/packages/apex-ls/src/worker.platform.ts
+++ b/packages/apex-ls/src/worker.platform.ts
@@ -1080,7 +1080,12 @@ export async function recompileCursorFileAtFullDetail(
   uri: string,
   content?: string,
 ): Promise<boolean> {
-  if (!content) return false;
+  // Only TRULY-ABSENT content (undefined) skips the recompile. An empty string
+  // is a valid zero-length file — rejecting it with a `!content` falsy check
+  // would leave a freshly-opened empty `.cls` at public-api detail and silently
+  // return []. This mirrors the upstream `typeof req.content === 'string'` gate,
+  // which already treats '' as "content present".
+  if (content === undefined) return false;
   try {
     const { CompilerService, FullSymbolCollectorListener, SymbolTable } =
       await import('@salesforce/apex-lsp-parser-ast');
@@ -1517,27 +1522,45 @@ const requestHandlers = {
 
       // The full-detail recompile (and therefore in-body position resolution)
       // is gated on having the document text. The coordinator omits `content`
-      // when it isn't tracking the file as open, so an empty result here would
-      // be indistinguishable from a genuine no-match. Flag it explicitly.
+      // when it isn't tracking the file as open.
       const cursorTextAvailable = typeof req.content === 'string';
-      if (!cursorTextAvailable) {
-        getLogger().warn(
-          () =>
-            `[REFERENCES] No document text for ${req.textDocument.uri}; ` +
-            'cursor file cannot be recompiled at full detail and an in-body ' +
-            'cursor may yield no references. Result may be degraded.',
-        );
-      }
 
       // Recompile the cursor file at FULL detail so its in-body references
       // exist for position→symbol resolution. The data-owner serves public-api
       // (bodies stripped), so without this a cursor on an in-body usage
       // resolves to nothing and Find References returns [].
-      await recompileCursorFileAtFullDetail(
+      const cursorRecompiled = await recompileCursorFileAtFullDetail(
         svc,
         req.textDocument.uri,
         req.content,
       );
+
+      // Abort when content was absent rather than warn-then-continue. With no
+      // document text: (1) recompileCursorFileAtFullDetail skipped the recompile
+      // (returned false), so the cursor file stays at public-api detail; and
+      // (2) loadSymbolDataForEnrichment never stored a document, so the
+      // position→symbol lookup in ReferencesProcessingService returns [] no
+      // matter what dependent tables we load. Continuing would do a full round
+      // of cross-worker dependent loading on a state that cannot produce a
+      // result, and would emit a [] indistinguishable from a genuine no-match.
+      // Returning here makes the degradation explicit and attributable.
+      //
+      // Gated on !cursorTextAvailable specifically (not merely !cursorRecompiled)
+      // so a recompile that failed WITH content present — e.g. a transient
+      // compile error — still falls through: loadSymbolDataForEnrichment stored
+      // the document in that case, so a cursor on a declaration can still
+      // resolve against the public-api table.
+      if (!cursorRecompiled && !cursorTextAvailable) {
+        getLogger().warn(
+          () =>
+            `[REFERENCES] No document text for ${req.textDocument.uri}; ` +
+            'cursor file cannot be recompiled at full detail and the pool ' +
+            'worker has no stored document, so position resolution cannot ' +
+            'succeed. Aborting with an empty result (degraded, not a genuine ' +
+            'no-match).',
+        );
+        return [];
+      }
 
       // Load the tables of every TYPE the cursor file references — even ones
       // the data-owner already resolved (resolvedSymbolId set). Find References

--- a/packages/apex-ls/src/worker.platform.web.ts
+++ b/packages/apex-ls/src/worker.platform.web.ts
@@ -1006,7 +1006,10 @@ export async function recompileCursorFileAtFullDetail(
   uri: string,
   content?: string,
 ): Promise<boolean> {
-  if (!content) return false;
+  // Only truly-absent content (undefined) skips the recompile; '' is a valid
+  // zero-length file. See the Node platform for the full rationale — this
+  // mirrors the upstream `typeof req.content === 'string'` gate.
+  if (content === undefined) return false;
   try {
     const { CompilerService, FullSymbolCollectorListener, SymbolTable } =
       await import('@salesforce/apex-lsp-parser-ast');
@@ -1385,27 +1388,36 @@ const requestHandlers = {
 
       // The full-detail recompile (and therefore in-body position resolution)
       // is gated on having the document text. The coordinator omits `content`
-      // when it isn't tracking the file as open, so an empty result here would
-      // be indistinguishable from a genuine no-match. Flag it explicitly.
+      // when it isn't tracking the file as open.
       const cursorTextAvailable = typeof req.content === 'string';
-      if (!cursorTextAvailable) {
-        getLogger().warn(
-          () =>
-            `[REFERENCES] No document text for ${req.textDocument.uri}; ` +
-            'cursor file cannot be recompiled at full detail and an in-body ' +
-            'cursor may yield no references. Result may be degraded.',
-        );
-      }
 
       // Recompile the cursor file at FULL detail so its in-body references
       // exist for position→symbol resolution. The data-owner serves public-api
       // (bodies stripped), so without this a cursor on an in-body usage
       // resolves to nothing and Find References returns [].
-      await recompileCursorFileAtFullDetail(
+      const cursorRecompiled = await recompileCursorFileAtFullDetail(
         svc,
         req.textDocument.uri,
         req.content,
       );
+
+      // Abort when content was absent rather than warn-then-continue: with no
+      // document text the recompile is skipped AND loadSymbolDataForEnrichment
+      // never stored a document, so position resolution returns [] regardless.
+      // See the Node platform for the full rationale (gated on
+      // !cursorTextAvailable so a content-present recompile failure still falls
+      // through to a declaration-cursor lookup).
+      if (!cursorRecompiled && !cursorTextAvailable) {
+        getLogger().warn(
+          () =>
+            `[REFERENCES] No document text for ${req.textDocument.uri}; ` +
+            'cursor file cannot be recompiled at full detail and the pool ' +
+            'worker has no stored document, so position resolution cannot ' +
+            'succeed. Aborting with an empty result (degraded, not a genuine ' +
+            'no-match).',
+        );
+        return [];
+      }
 
       // Load the tables of every TYPE the cursor file references — even ones the
       // data-owner already resolved. Find References needs the target type's

--- a/packages/apex-ls/src/worker.platform.web.ts
+++ b/packages/apex-ls/src/worker.platform.web.ts
@@ -762,14 +762,20 @@ async function loadSymbolDataForEnrichment(
           // on-demand name lookup, so the symbol is enough for them — but the
           // requesting file's TypeReference is still unresolved (no
           // resolvedSymbolId, no reverse-index edge). Materialize those edges
-          // now so reverse-index consumers see them too. Gated on a real
-          // ingest, and resolveCrossFileReferencesForFile is re-entrancy-guarded
-          // + addReference de-dupes, so this is near-free when nothing landed.
-          if (ingested > 0) {
-            await Effect.runPromise(
-              svc.symbolManager.resolveCrossFileReferencesForFile(uri),
-            );
-          }
+          // now so reverse-index + position-precise consumers see them too.
+          //
+          // NOT gated on resolveMissingNamesViaDataOwner's ingest count: the
+          // earlier ResolveDepUris pass may have already loaded every dep, which
+          // makes that count 0 even though the cursor file's references are
+          // still unbound. find-references' 'precise' position→symbol lookup
+          // needs those bindings (unlike hover/definition's on-demand by-name
+          // resolution), so resolve whenever ANY class dep was requested.
+          // resolveCrossFileReferencesForFile is re-entrancy-guarded and
+          // addReference de-dupes, so this is near-free when nothing changed.
+          void ingested;
+          await Effect.runPromise(
+            svc.symbolManager.resolveCrossFileReferencesForFile(uri),
+          );
         }
       }
     }
@@ -973,6 +979,121 @@ export async function loadDependentsForReferences(
       () => `[REFERENCES] Dependent pre-fetch failed for ${uri}: ${err}`,
     );
     return 0;
+  }
+}
+
+/**
+ * Recompile the cursor file at FULL detail into the worker's local symbol
+ * manager, then resolve its cross-file references. See the Node platform's
+ * {@link recompileCursorFileAtFullDetail} for the full rationale: the
+ * data-owner serves public-api (method bodies stripped), so a cursor on an
+ * in-body usage resolves to nothing and Find References returns []. Recompiling
+ * from the live document text (as documentSymbol does) restores the in-body
+ * references for position→symbol resolution.
+ *
+ * Best-effort: a missing/uncompilable document leaves the public-api graph in
+ * place and Find References proceeds with whatever it has.
+ */
+export async function recompileCursorFileAtFullDetail(
+  svc: RequestServices,
+  uri: string,
+  content?: string,
+): Promise<boolean> {
+  if (!content) return false;
+  try {
+    const { CompilerService, FullSymbolCollectorListener, SymbolTable } =
+      await import('@salesforce/apex-lsp-parser-ast');
+    const table = new SymbolTable();
+    const listener = new FullSymbolCollectorListener(table);
+    const result = new CompilerService().compile(content, uri, listener, {
+      collectReferences: true,
+      resolveReferences: true,
+    });
+    const st = result?.result instanceof SymbolTable ? result.result : table;
+    await Effect.runPromise(svc.symbolManager.addSymbolTable(st, uri));
+    await Effect.runPromise(
+      svc.symbolManager.resolveCrossFileReferencesForFile(uri),
+    );
+    return true;
+  } catch (err) {
+    getLogger().debug(
+      () => `[REFERENCES] Full-detail recompile failed for ${uri}: ${err}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Load the symbol tables of every TYPE the cursor file references, regardless of
+ * resolvedSymbolId. See the Node platform's {@link loadReferencedTypesForFile}
+ * for the full rationale: Find References needs the referenced type's table
+ * PRESENT to enumerate its own references, but the resolved-only prefetch skips
+ * already-resolved type references.
+ */
+export async function loadReferencedTypesForFile(
+  svc: RequestServices,
+  uri: string,
+): Promise<number> {
+  try {
+    const { ReferenceContext } =
+      await import('@salesforce/apex-lsp-parser-ast');
+    const st = await svc.symbolManager.getSymbolTableForFile(uri);
+    if (!st) return 0;
+    const refs = (
+      st as unknown as {
+        getAllReferences: () => Array<{ name: string; context: number }>;
+      }
+    ).getAllReferences();
+    const typeNames = new Set<string>();
+    for (const ref of refs) {
+      if (
+        ref.context === ReferenceContext.CLASS_REFERENCE ||
+        ref.context === ReferenceContext.CONSTRUCTOR_CALL ||
+        ref.context === ReferenceContext.TYPE_DECLARATION
+      ) {
+        typeNames.add(
+          ref.name.includes('.') ? ref.name.split('.')[0] : ref.name,
+        );
+      }
+    }
+    if (typeNames.size === 0) return 0;
+    const ingested = await resolveMissingNamesViaDataOwner(svc, [...typeNames]);
+    await Effect.runPromise(
+      svc.symbolManager.resolveCrossFileReferencesForFile(uri),
+    );
+    return ingested;
+  } catch (err) {
+    getLogger().debug(
+      () => `[REFERENCES] Referenced-type load failed for ${uri}: ${err}`,
+    );
+    return 0;
+  }
+}
+
+/**
+ * Resolve the symbol under the cursor and return the file URI it is DECLARED
+ * in (or null to fall back to the cursor file). See the Node platform's
+ * {@link declaringFileForCursorSymbol} for the full rationale.
+ */
+async function declaringFileForCursorSymbol(
+  svc: RequestServices,
+  uri: string,
+  position: { line: number; character: number },
+): Promise<string | null> {
+  try {
+    const parserPosition = {
+      line: position.line + 1,
+      character: position.character,
+    };
+    const symbol = await svc.symbolManager.getSymbolAtPosition(
+      uri,
+      parserPosition,
+      'precise',
+    );
+    const fileUri = (symbol as { fileUri?: string } | null)?.fileUri;
+    return fileUri && fileUri !== uri ? fileUri : null;
+  } catch {
+    return null;
   }
 }
 
@@ -1202,14 +1323,50 @@ const requestHandlers = {
     async (svc, req) => {
       // Mirror the hover/definition enrichment shape:
       //   load symbol data → load caller-side dependents → process → write back.
+      // Thread req.content so the pool worker's storage holds the document:
+      // ReferencesProcessingService maps the cursor position to a symbol via
+      // storage.getDocument(), and returns [] when it's absent. The stateless
+      // pool worker has no document otherwise (same as documentSymbol).
       const { version, detailLevel } = await loadSymbolDataForEnrichment(
         svc,
         req.textDocument.uri,
+        req.content,
       );
 
-      // Find References needs the caller-side tables (files that reference the
-      // target's symbols), which loadSymbolDataForEnrichment does not fetch.
-      await loadDependentsForReferences(svc, req.textDocument.uri);
+      // Recompile the cursor file at FULL detail so its in-body references
+      // exist for position→symbol resolution. The data-owner serves public-api
+      // (bodies stripped), so without this a cursor on an in-body usage
+      // resolves to nothing and Find References returns [].
+      await recompileCursorFileAtFullDetail(
+        svc,
+        req.textDocument.uri,
+        req.content,
+      );
+
+      // Load the tables of every TYPE the cursor file references — even ones the
+      // data-owner already resolved. Find References needs the target type's
+      // table present to enumerate its references (see the Node platform).
+      await loadReferencedTypesForFile(svc, req.textDocument.uri);
+
+      // Load the caller-side tables (files that reference the TARGET symbol).
+      // The target may be declared in a DIFFERENT file than the cursor; resolve
+      // the cursor to its symbol, then load dependents of that symbol's
+      // DECLARING file (see the Node platform for the full rationale). Falls
+      // back to the cursor file when the symbol can't be determined.
+      const targetUri = await declaringFileForCursorSymbol(
+        svc,
+        req.textDocument.uri,
+        req.position,
+      );
+      await loadDependentsForReferences(svc, targetUri ?? req.textDocument.uri);
+
+      // Re-assert the cursor file at full detail in case loadDependents
+      // re-ingested it at public-api. Idempotent + bounded.
+      await recompileCursorFileAtFullDetail(
+        svc,
+        req.textDocument.uri,
+        req.content,
+      );
 
       // References resolve against protected members of dependent files, so a
       // 'protected' detail level matches the existing service behavior (see
@@ -1688,12 +1845,19 @@ const handlers: WorkerRunner.SerializedRunner.Handlers<
                 sm.getSymbolTableForFile(uri),
               );
               if (st) {
-                entries[uri] = cloneForWire({
+                // Key by the table's CANONICAL fileUri, not the schemeless
+                // lookup `uri` (findFilesForSymbol strips `file://`). Keying by
+                // `uri` makes the requesting worker ingest under a URI that
+                // never matches its references' targets, so cross-file edges
+                // fail to bind and find-references returns []. See the Node
+                // platform handler for the full rationale.
+                const canonicalUri = st.getFileUri();
+                entries[canonicalUri] = cloneForWire({
                   symbols: st.getAllSymbols(),
                   references: st.getAllReferences(),
                   hierarchicalReferences: st.getAllHierarchicalReferences(),
                   metadata: st.getMetadata(),
-                  fileUri: st.getFileUri(),
+                  fileUri: canonicalUri,
                 });
               }
             }

--- a/packages/apex-ls/src/worker.platform.web.ts
+++ b/packages/apex-ls/src/worker.platform.web.ts
@@ -779,8 +779,15 @@ async function loadSymbolDataForEnrichment(
         }
       }
     }
-  } catch {
-    // Subset load failed; caller may still proceed with partial graph.
+  } catch (err) {
+    // Subset load failed (assistance channel down, IPC error, or the data-owner
+    // doesn't have the file). The caller proceeds on a partial/empty graph, so
+    // any request built on it (hover/definition/references/…) may silently
+    // return nothing. Warn — not debug — so an empty result has a breadcrumb
+    // distinguishing "real failure" from "genuinely nothing here".
+    getLogger().warn(
+      () => `[ENRICHMENT] Symbol-subset load failed for ${uri}: ${err}`,
+    );
   }
 
   return { version, detailLevel };
@@ -973,9 +980,11 @@ export async function loadDependentsForReferences(
     return ingested;
   } catch (err) {
     // Dependent pre-fetch is best-effort; reference search can still run on
-    // the tables already loaded (e.g. same-file references). Log at debug so a
-    // "cross-file references missing" report has a breadcrumb to follow.
-    getLogger().debug(
+    // the tables already loaded (e.g. same-file references). But reaching this
+    // catch means cross-file callers were NOT loaded, so the result is likely
+    // incomplete — warn so a "cross-file references missing" report has a
+    // breadcrumb to follow.
+    getLogger().warn(
       () => `[REFERENCES] Dependent pre-fetch failed for ${uri}: ${err}`,
     );
     return 0;
@@ -1016,7 +1025,10 @@ export async function recompileCursorFileAtFullDetail(
     );
     return true;
   } catch (err) {
-    getLogger().debug(
+    // The cursor file stays at public-api detail, so an in-body cursor won't
+    // resolve and Find References can return []. Warn so that empty result is
+    // attributable to a recompile failure rather than a genuine no-match.
+    getLogger().warn(
       () => `[REFERENCES] Full-detail recompile failed for ${uri}: ${err}`,
     );
     return false;
@@ -1063,7 +1075,9 @@ export async function loadReferencedTypesForFile(
     );
     return ingested;
   } catch (err) {
-    getLogger().debug(
+    // Target type tables may be absent locally, so findReferencesTo(type) can
+    // come back empty. Warn so the gap is attributable.
+    getLogger().warn(
       () => `[REFERENCES] Referenced-type load failed for ${uri}: ${err}`,
     );
     return 0;
@@ -1085,13 +1099,35 @@ async function declaringFileForCursorSymbol(
       line: position.line + 1,
       character: position.character,
     };
+    // Preferred: precise position→symbol resolution gives the declaring file
+    // directly.
     const symbol = await svc.symbolManager.getSymbolAtPosition(
       uri,
       parserPosition,
       'precise',
     );
     const fileUri = (symbol as { fileUri?: string } | null)?.fileUri;
-    return fileUri && fileUri !== uri ? fileUri : null;
+    if (fileUri && fileUri !== uri) return fileUri;
+
+    // Fallback: 'precise' can return null when the cursor file's reference
+    // isn't yet bound to a resolvedSymbolId (cross-file edges not fully
+    // materialized in the worker's partial graph). The reference under the
+    // cursor still carries the NAME, and the target symbol is loaded by name —
+    // so resolve the name to its declaring file directly. This is what lets
+    // find-references on a `RefUtil` usage reach RefUtil.cls's dependents.
+    // (Kept in sync with the Node platform; without it the web worker loads the
+    // cursor file's dependents instead of the target's and misses cross-file
+    // usages.)
+    const refs = await svc.symbolManager.getReferencesAtPosition(
+      uri,
+      parserPosition,
+    );
+    const name = refs?.[0]?.name;
+    if (!name) return null;
+    const leaf = name.includes('.') ? name.split('.').pop()! : name;
+    const named = await svc.symbolManager.findSymbolByName(leaf);
+    const namedUri = (named as { fileUri?: string } | null)?.fileUri;
+    return namedUri && namedUri !== uri ? namedUri : null;
   } catch {
     return null;
   }
@@ -1332,6 +1368,20 @@ const requestHandlers = {
         req.textDocument.uri,
         req.content,
       );
+
+      // The full-detail recompile (and therefore in-body position resolution)
+      // is gated on having the document text. The coordinator omits `content`
+      // when it isn't tracking the file as open, so an empty result here would
+      // be indistinguishable from a genuine no-match. Flag it explicitly.
+      const cursorTextAvailable = typeof req.content === 'string';
+      if (!cursorTextAvailable) {
+        getLogger().warn(
+          () =>
+            `[REFERENCES] No document text for ${req.textDocument.uri}; ` +
+            'cursor file cannot be recompiled at full detail and an in-body ' +
+            'cursor may yield no references. Result may be degraded.',
+        );
+      }
 
       // Recompile the cursor file at FULL detail so its in-body references
       // exist for position→symbol resolution. The data-owner serves public-api

--- a/packages/apex-ls/src/worker.platform.web.ts
+++ b/packages/apex-ls/src/worker.platform.web.ts
@@ -752,9 +752,8 @@ async function loadSymbolDataForEnrichment(
           // this enrichment worker's LOCAL name index. Ask the data-owner
           // (which holds ALL workspace symbols) to resolve the remaining names
           // in one batched query and ingest the owning files' symbol tables.
-          const ingested = await resolveMissingNamesViaDataOwner(svc, [
-            ...classNames,
-          ]);
+          // The ingest count is intentionally not captured (see below).
+          await resolveMissingNamesViaDataOwner(svc, [...classNames]);
 
           // Ingestion alone only lands the owning files' SYMBOLS in the local
           // name index (addSymbolTable processes same-file refs only and defers
@@ -772,7 +771,6 @@ async function loadSymbolDataForEnrichment(
           // resolution), so resolve whenever ANY class dep was requested.
           // resolveCrossFileReferencesForFile is re-entrancy-guarded and
           // addReference de-dupes, so this is near-free when nothing changed.
-          void ingested;
           await Effect.runPromise(
             svc.symbolManager.resolveCrossFileReferencesForFile(uri),
           );
@@ -1051,25 +1049,41 @@ export async function loadReferencedTypesForFile(
       await import('@salesforce/apex-lsp-parser-ast');
     const st = await svc.symbolManager.getSymbolTableForFile(uri);
     if (!st) return 0;
-    const refs = (
-      st as unknown as {
-        getAllReferences: () => Array<{ name: string; context: number }>;
-      }
-    ).getAllReferences();
-    const typeNames = new Set<string>();
+    const refs = st.getAllReferences();
+    // Group the referenced type leaf names by their qualifier so the qualifier
+    // can be threaded to the data-owner as a disambiguation namespace hint. A
+    // qualified `MyNs.Foo` resolves by its LEAF (`Foo`) — the data-owner's name
+    // index is keyed on the simple name — while the head (`MyNs`) is the
+    // namespace hint. The undefined-qualifier bucket is the unqualified hot
+    // path; it stays a single batched, namespace-free query (see the Node
+    // platform for the full rationale).
+    const namesByQualifier = new Map<string | undefined, Set<string>>();
     for (const ref of refs) {
       if (
         ref.context === ReferenceContext.CLASS_REFERENCE ||
         ref.context === ReferenceContext.CONSTRUCTOR_CALL ||
         ref.context === ReferenceContext.TYPE_DECLARATION
       ) {
-        typeNames.add(
-          ref.name.includes('.') ? ref.name.split('.')[0] : ref.name,
-        );
+        const dot = ref.name.lastIndexOf('.');
+        const leaf = dot >= 0 ? ref.name.slice(dot + 1) : ref.name;
+        const qualifier = dot >= 0 ? ref.name.slice(0, dot) : undefined;
+        const bucket = namesByQualifier.get(qualifier) ?? new Set<string>();
+        bucket.add(leaf);
+        namesByQualifier.set(qualifier, bucket);
       }
     }
-    if (typeNames.size === 0) return 0;
-    const ingested = await resolveMissingNamesViaDataOwner(svc, [...typeNames]);
+    if (namesByQualifier.size === 0) return 0;
+    // One batched query per distinct qualifier (one round-trip in the common
+    // single-bucket case; one hop per qualifier otherwise).
+    let ingested = 0;
+    for (const [qualifier, leaves] of namesByQualifier) {
+      ingested += await resolveMissingNamesViaDataOwner(
+        svc,
+        [...leaves],
+        undefined,
+        qualifier,
+      );
+    }
     await Effect.runPromise(
       svc.symbolManager.resolveCrossFileReferencesForFile(uri),
     );
@@ -1943,6 +1957,21 @@ const handlers: WorkerRunner.SerializedRunner.Handlers<
               ),
             ];
 
+            // Optional namespace hint: a qualified reference (`MyNs.Foo`)
+            // carries its leading qualifier so the data-owner can disambiguate
+            // same-named matches across namespaces. Applied as a SOFT
+            // preference, not a hard filter — if no symbol's namespace matches
+            // the hint, fall back to all matches (see the Node platform for the
+            // full rationale, including the inner-class qualifier case).
+            const nsHint = req.namespace?.toLowerCase();
+            const symbolNamespace = (s: {
+              namespace?: unknown;
+            }): string | undefined => {
+              const ns = s.namespace;
+              if (!ns) return undefined;
+              return (typeof ns === 'string' ? ns : String(ns)).toLowerCase();
+            };
+
             const matches: Array<{
               name: string;
               fileUri: string;
@@ -1955,15 +1984,19 @@ const handlers: WorkerRunner.SerializedRunner.Handlers<
               const symbols = yield* Effect.promise(() =>
                 sm.findSymbolByName(queryName),
               );
-              for (const symbol of symbols) {
-                if (!symbol?.fileUri) continue;
+              const withFile = symbols.filter((s) => !!s?.fileUri);
+              const nsMatched = nsHint
+                ? withFile.filter((s) => symbolNamespace(s) === nsHint)
+                : [];
+              const selected = nsMatched.length > 0 ? nsMatched : withFile;
+              for (const symbol of selected) {
                 matches.push({
                   name: symbol.name,
-                  fileUri: symbol.fileUri,
+                  fileUri: symbol.fileUri!,
                   kind:
                     typeof symbol.kind === 'string' ? symbol.kind : undefined,
                 });
-                uris.add(symbol.fileUri);
+                uris.add(symbol.fileUri!);
               }
             }
 

--- a/packages/apex-ls/test/integration/ReferencesThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/ReferencesThroughWorkerTopology.node.test.ts
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * find-references through the live worker topology (W-22692429 / 6.13).
+ *
+ * EnrichmentRoundTrip.node.test.ts proves the references round-trip COMPLETES
+ * (a result comes back rather than hanging on an unsettled assistance call).
+ * This test goes one step further — the 6.13 deliverable — and asserts the
+ * RESULT COUNT: dispatch find-references on a method with known cross-file call
+ * sites and verify every call site comes back, across the worker boundary.
+ *
+ * The path under test is the production one: a request-pool worker handles
+ * `references`, reaches OUT over the assistance bus to the coordinator for the
+ * symbol subset (dataOwner:QuerySymbolSubset), the cross-file dependents
+ * (dataOwner:ResolveDependentUris), and stdlib (resourceLoader:*), then returns
+ * the LSP Location[]. The assistance bus is wired exactly as LCSAdapter wires it
+ * in production.
+ */
+
+import * as path from 'path';
+import {
+  initializeTopology,
+  makeNodeWorkerLayer,
+  makeWorkerDispatcher,
+  getRawWorkers,
+  getAssistancePorts,
+  getWorkerNames,
+  clearRawWorkers,
+  runRemoteStdlibWarmupPhase,
+  type WorkerTopology,
+} from '../../src/server/WorkerCoordinator';
+import { CoordinatorAssistanceMediator } from '../../src/server/CoordinatorAssistanceMediator';
+import { createPrimaryAssistanceHandler } from '../../src/server/CoordinatorPrimaryAssistanceHandler';
+import { ResourceLoaderProxy } from '../../src/server/ResourceLoaderProxy';
+import { getLogger } from '@salesforce/apex-lsp-shared';
+import { Effect } from 'effect';
+
+const WORKER_TS_ENTRY = path.resolve(__dirname, '../../src/worker.platform.ts');
+const TSX_OPTIONS = { execArgv: ['--import', 'tsx'] };
+
+// A utility class whose instance method `greet` is called from TWO other files,
+// twice in one of them — three cross-file call sites in total. Self-contained
+// except for String, which the resource loader serves. Instance calls (vs
+// static `RefUtil.greet()`) resolve through the cross-file reverse index; the
+// qualified-static call site is a separate, narrower resolution path.
+const UTIL_URI = 'file:///test/RefUtil.cls';
+const UTIL_SRC = `public class RefUtil {
+    public String greet(String input) {
+        return input;
+    }
+}`;
+
+const CALLER_A_URI = 'file:///test/RefCallerA.cls';
+const CALLER_A_SRC = `public class RefCallerA {
+    public String run() {
+        RefUtil u = new RefUtil();
+        return u.greet('a');
+    }
+}`;
+
+const CALLER_B_URI = 'file:///test/RefCallerB.cls';
+const CALLER_B_SRC = `public class RefCallerB {
+    public void run() {
+        RefUtil u = new RefUtil();
+        String x = u.greet('b');
+        String y = u.greet('c');
+    }
+}`;
+
+const ALL_ENTRIES = [
+  { uri: UTIL_URI, content: UTIL_SRC, languageId: 'apex', version: 1 },
+  { uri: CALLER_A_URI, content: CALLER_A_SRC, languageId: 'apex', version: 1 },
+  { uri: CALLER_B_URI, content: CALLER_B_SRC, languageId: 'apex', version: 1 },
+];
+
+const SOURCES: Record<string, string> = {
+  [UTIL_URI]: UTIL_SRC,
+  [CALLER_A_URI]: CALLER_A_SRC,
+  [CALLER_B_URI]: CALLER_B_SRC,
+};
+
+/**
+ * Minimal LSP connection stub for the primary handler's catch-all. The
+ * self-contained fixture fires no client RPCs; if one does, resolve it benignly
+ * so nothing hangs.
+ */
+const stubConnection = {
+  sendRequest: async () => null,
+  sendNotification: async () => undefined,
+};
+
+/**
+ * Wire the assistance bus exactly as LCSAdapter does: real primary handler
+ * (coordinator/* + resourceLoader/* via the proxy + catch-all) plus a
+ * dataOwnerHandler routing dataOwner:* to the data-owner worker.
+ */
+function wireProductionMediator(
+  topology: WorkerTopology,
+  dispatcher: ReturnType<typeof makeWorkerDispatcher>,
+  logger: ReturnType<typeof getLogger>,
+): CoordinatorAssistanceMediator {
+  const resourceLoaderProxy = topology.resourceLoader
+    ? new ResourceLoaderProxy(topology.resourceLoader, logger)
+    : undefined;
+  const mediator = new CoordinatorAssistanceMediator(
+    createPrimaryAssistanceHandler({
+      connection: stubConnection,
+      logger,
+      getResourceLoaderProxy: () => resourceLoaderProxy,
+    }),
+    logger,
+    (method, params) => dispatcher.queryDataOwner(method, params),
+  );
+  mediator.attachToWorkers(
+    getRawWorkers(),
+    getAssistancePorts(),
+    getWorkerNames(),
+  );
+  return mediator;
+}
+
+const toLocations = (
+  result: unknown,
+): Array<{ uri?: string; targetUri?: string }> =>
+  (Array.isArray(result) ? result : result ? [result] : []) as Array<{
+    uri?: string;
+    targetUri?: string;
+  }>;
+
+describe('find-references through the worker topology (location count)', () => {
+  const logger = getLogger();
+
+  afterEach(() => {
+    clearRawWorkers();
+  });
+
+  it('returns every cross-file usage of a type through the worker boundary', async () => {
+    const program = Effect.gen(function* () {
+      const topology = yield* initializeTopology({
+        poolSize: 1,
+        enableResourceLoader: true,
+        logger,
+        logLevel: 'error',
+      });
+      const dispatcher = makeWorkerDispatcher(
+        topology,
+        logger,
+        (uri) => SOURCES[uri],
+      );
+      wireProductionMediator(topology, dispatcher, logger);
+      yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+      // Cold-open the declaring file (the data-owner holds RefUtil's symbols),
+      // then load the workspace so the callers' cross-file method-call edges
+      // enter the data-owner reverse index.
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentOpen', {
+          document: {
+            uri: UTIL_URI,
+            languageId: 'apex',
+            version: 1,
+            getText: () => UTIL_SRC,
+          },
+          textDocument: { uri: UTIL_URI },
+          text: UTIL_SRC,
+        }),
+      );
+
+      const ingest = dispatcher.createBatchIngestionDispatcher();
+      const compile = dispatcher.createBatchCompileDispatcher();
+      yield* Effect.promise(() => ingest('wf-refs-count', ALL_ENTRIES));
+      yield* Effect.promise(() => compile('wf-refs-count', ALL_ENTRIES));
+
+      // find-references on the `RefUtil` TYPE usage in caller A — the cursor is
+      // on `RefUtil` in `RefUtil u = new RefUtil()` (line 2). find-references
+      // invoked from a usage resolves the cursor to the declared type, then the
+      // data-owner reverse index yields every cross-file usage. The dispatch
+      // threads the caller's document text so the pool worker's storage can map
+      // the position to a symbol.
+      const result = yield* Effect.promise(() =>
+        dispatcher.dispatch('references', {
+          textDocument: { uri: CALLER_A_URI },
+          position: { line: 2, character: 8 }, // on `RefUtil` in `RefUtil u = ...`
+          context: { includeDeclaration: true },
+        }),
+      );
+
+      return { result };
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(makeNodeWorkerLayer(WORKER_TS_ENTRY, TSX_OPTIONS)),
+    );
+
+    const { result } = await Effect.runPromise(program);
+    console.log('[D2]', JSON.stringify(result));
+
+    const locations = toLocations(result);
+    const uris = locations.map((l) => l.uri ?? l.targetUri ?? '');
+    console.log(
+      `[refs-topology] count=${locations.length} uris=${JSON.stringify(uris)}`,
+    );
+
+    // The crux: every cross-file usage of the RefUtil type comes back through
+    // the worker boundary, not just a single collapsed result.
+    //   - RefCallerA: two type usages (`RefUtil u`, `new RefUtil()`)
+    //   - RefCallerB: two type usages
+    //   - RefUtil:    the declaration (includeDeclaration: true)
+    expect(locations.length).toBeGreaterThanOrEqual(3);
+    expect(uris.some((u) => u.includes('RefCallerA'))).toBe(true);
+    expect(uris.some((u) => u.includes('RefCallerB'))).toBe(true);
+  }, 120_000);
+
+  it('omits the declaration when includeDeclaration is false', async () => {
+    const program = Effect.gen(function* () {
+      const topology = yield* initializeTopology({
+        poolSize: 1,
+        enableResourceLoader: true,
+        logger,
+        logLevel: 'error',
+      });
+      const dispatcher = makeWorkerDispatcher(
+        topology,
+        logger,
+        (uri) => SOURCES[uri],
+      );
+      wireProductionMediator(topology, dispatcher, logger);
+      yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentOpen', {
+          document: {
+            uri: UTIL_URI,
+            languageId: 'apex',
+            version: 1,
+            getText: () => UTIL_SRC,
+          },
+          textDocument: { uri: UTIL_URI },
+          text: UTIL_SRC,
+        }),
+      );
+
+      const ingest = dispatcher.createBatchIngestionDispatcher();
+      const compile = dispatcher.createBatchCompileDispatcher();
+      yield* Effect.promise(() => ingest('wf-refs-nodecl', ALL_ENTRIES));
+      yield* Effect.promise(() => compile('wf-refs-nodecl', ALL_ENTRIES));
+
+      const result = yield* Effect.promise(() =>
+        dispatcher.dispatch('references', {
+          textDocument: { uri: CALLER_A_URI },
+          position: { line: 2, character: 8 }, // on `RefUtil` usage in caller A
+          context: { includeDeclaration: false },
+        }),
+      );
+
+      return { result };
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(makeNodeWorkerLayer(WORKER_TS_ENTRY, TSX_OPTIONS)),
+    );
+
+    const { result } = await Effect.runPromise(program);
+
+    const locations = toLocations(result);
+    const uris = locations.map((l) => l.uri ?? l.targetUri ?? '');
+    console.log(
+      `[refs-topology:no-decl] count=${locations.length} uris=${JSON.stringify(uris)}`,
+    );
+
+    // The usages still resolve cross-file; the type declaration in RefUtil is
+    // suppressed. Every returned location is a usage in a caller file.
+    expect(locations.length).toBeGreaterThanOrEqual(3);
+    const declHit = locations.find((l) => {
+      const u = l.uri ?? l.targetUri ?? '';
+      // The declaration sits on line 0 (LSP) of RefUtil.cls; a usage never does.
+      const range = (l as { range?: { start?: { line?: number } } }).range;
+      return u.includes('RefUtil.cls') && range?.start?.line === 0;
+    });
+    // includeDeclaration:false → the RefUtil type declaration line is excluded.
+    expect(declHit).toBeUndefined();
+  }, 120_000);
+});

--- a/packages/apex-ls/test/server/referenceEnrichmentRecipe.node.test.ts
+++ b/packages/apex-ls/test/server/referenceEnrichmentRecipe.node.test.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Reference-enrichment recipe (W-22692429 / 6.13).
+ *
+ * find-references offloaded to an enrichment worker only returns correct
+ * cross-file results when the worker's local graph is assembled the right way.
+ * Three conditions must hold, and each was a distinct gap this story closed:
+ *
+ *  1. The CURSOR file must be parsed at FULL detail. The data-owner serves
+ *     files at 'public-api' (method bodies stripped), so a cursor on an in-body
+ *     usage (`RefUtil u = new RefUtil()`) resolves to no reference and Find
+ *     References returns []. recompileCursorFileAtFullDetail fixes this.
+ *  2. The caller-side tables loaded must be dependents of the TARGET symbol's
+ *     DECLARING file, not of the cursor file. A `RefUtil` usage in CallerA has
+ *     references in CallerB too, but CallerA has no dependents of its own.
+ *  3. Those caller tables' cross-file edges must be resolved into the reverse
+ *     index (loadDependentsForReferences does this per ingested table).
+ *
+ * These tests assemble a real ApexSymbolManager + real ReferencesProcessingService
+ * exactly as the worker's DispatchReferences handler does — driving the exported
+ * worker helpers and injecting the data-owner fetcher — so they verify the
+ * recipe end-to-end with full observability (no opaque worker boundary). The
+ * live worker-topology path is additionally smoke-covered by
+ * ReferencesThroughWorkerTopology.node.test.ts.
+ */
+
+import { Effect } from 'effect';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { getLogger, ApexSettingsManager } from '@salesforce/apex-lsp-shared';
+import {
+  ApexSymbolManager,
+  CompilerService,
+  VisibilitySymbolListener,
+  SymbolTable,
+  type SymbolTable as SymbolTableType,
+} from '@salesforce/apex-lsp-parser-ast';
+import {
+  ReferencesProcessingService,
+  ApexStorageManager,
+  ApexStorage,
+  type RequestServices,
+} from '@salesforce/apex-lsp-compliant-services';
+import {
+  loadDependentsForReferences,
+  recompileCursorFileAtFullDetail,
+  declaringFileForCursorSymbol,
+} from '../../src/worker.platform';
+
+const UTIL_URI = 'file:///t/RefUtil.cls';
+const CALLER_A_URI = 'file:///t/RefCallerA.cls';
+const CALLER_B_URI = 'file:///t/RefCallerB.cls';
+
+const UTIL_SRC = `public class RefUtil {
+  public String greet(String input) {
+    return input;
+  }
+}`;
+const CALLER_A_SRC = `public class RefCallerA {
+  public String run() {
+    RefUtil u = new RefUtil();
+    return u.greet('a');
+  }
+}`;
+const CALLER_B_SRC = `public class RefCallerB {
+  public void run() {
+    RefUtil u = new RefUtil();
+    String x = u.greet('b');
+  }
+}`;
+
+const SOURCES: Record<string, string> = {
+  [UTIL_URI]: UTIL_SRC,
+  [CALLER_A_URI]: CALLER_A_SRC,
+  [CALLER_B_URI]: CALLER_B_SRC,
+};
+
+/** Compile a file at public-api detail (what the data-owner stores/serves). */
+const compilePublicApi = (uri: string): SymbolTableType => {
+  const table = new SymbolTable();
+  new CompilerService().compile(
+    SOURCES[uri],
+    uri,
+    new VisibilitySymbolListener('public-api', table),
+    { collectReferences: true, resolveReferences: true },
+  );
+  return table;
+};
+
+const serialize = (st: SymbolTableType) => ({
+  symbols: st.getAllSymbols(),
+  references: st.getAllReferences(),
+  hierarchicalReferences: st.getAllHierarchicalReferences(),
+  metadata: st.getMetadata(),
+  fileUri: st.getFileUri(),
+});
+
+describe('reference-enrichment recipe (worker DispatchReferences path)', () => {
+  let symbolManager: ApexSymbolManager;
+  let svc: RequestServices;
+
+  beforeAll(() => {
+    // createResolutionContext reads ApexSettingsManager; initialize the
+    // singleton so the service doesn't throw on first getInstance().
+    ApexSettingsManager.resetInstance();
+    ApexSettingsManager.getInstance({}, 'desktop');
+  });
+
+  afterAll(() => {
+    ApexSettingsManager.resetInstance();
+  });
+
+  beforeEach(async () => {
+    symbolManager = new ApexSymbolManager();
+
+    // The data-owner holds every file at public-api. Seed the worker's local
+    // graph the way loadSymbolDataForEnrichment does: ingest public-api tables.
+    for (const uri of [UTIL_URI, CALLER_A_URI, CALLER_B_URI]) {
+      await Effect.runPromise(
+        symbolManager.addSymbolTable(compilePublicApi(uri), uri),
+      );
+    }
+
+    // The worker's storage serves the live cursor document; the position lookup
+    // (ReferencesProcessingService → ApexStorageManager.getInstance) reads it.
+    // Use real in-memory storage and seed every file's text.
+    ApexStorageManager.reset();
+    const storageManager = ApexStorageManager.getInstance({
+      storageFactory: () => ApexStorage.getInstance(),
+      autoPersistIntervalMs: 0,
+    });
+    await storageManager.initialize();
+    const storage = storageManager.getStorage();
+    for (const uri of [UTIL_URI, CALLER_A_URI, CALLER_B_URI]) {
+      await storage.setDocument(
+        uri,
+        TextDocument.create(uri, 'apex', 1, SOURCES[uri]),
+      );
+    }
+
+    svc = {
+      symbolManager,
+    } as unknown as RequestServices;
+  });
+
+  afterEach(() => {
+    ApexStorageManager.reset();
+  });
+
+  /** Data-owner ResolveDependentUris stub: dependents of `uri` keyed by symbol. */
+  const fetchDependents = jest.fn(async (_method: string, params: unknown) => {
+    const { uri } = params as { uri: string };
+    // Only RefUtil has dependents (the two callers). Callers have none.
+    if (uri === UTIL_URI) {
+      return {
+        entries: {
+          [CALLER_A_URI]: serialize(compilePublicApi(CALLER_A_URI)),
+          [CALLER_B_URI]: serialize(compilePublicApi(CALLER_B_URI)),
+        },
+      };
+    }
+    return { entries: {} };
+  });
+
+  it('returns every cross-file usage for a cursor on an in-body type usage', async () => {
+    const service = new ReferencesProcessingService(getLogger(), symbolManager);
+
+    // Cursor on `RefUtil` in CallerA's body: line 2 (0-based), col 4.
+    const position = { line: 2, character: 4 };
+
+    // --- the handler's recipe (mirrors DispatchReferences end-to-end) -----
+    // 1. Recompile the cursor file at full detail so the position resolves.
+    await recompileCursorFileAtFullDetail(svc, CALLER_A_URI, CALLER_A_SRC);
+    // 2. Resolve the cursor symbol's DECLARING file (RefUtil.cls, not CallerA).
+    const targetUri = await declaringFileForCursorSymbol(
+      svc,
+      CALLER_A_URI,
+      position,
+    );
+    expect(targetUri).toBe(UTIL_URI);
+    // 3. Load dependents of the TARGET — surfacing CallerB, which CallerA's own
+    //    (empty) dependents never would.
+    await loadDependentsForReferences(
+      svc,
+      targetUri ?? CALLER_A_URI,
+      undefined,
+      fetchDependents,
+    );
+    // 4. Re-assert the cursor file at full detail (step 3 may re-ingest it).
+    await recompileCursorFileAtFullDetail(svc, CALLER_A_URI, CALLER_A_SRC);
+    // ----------------------------------------------------------------------
+
+    const locations = await service.processReferences({
+      textDocument: { uri: CALLER_A_URI },
+      position,
+      context: { includeDeclaration: true },
+    });
+    const uris = locations.map((l) => l.uri);
+
+    // Cross-file usages from BOTH callers surface, plus the declaration.
+    expect(uris).toContain(UTIL_URI);
+    expect(uris.some((u) => u.includes('RefCallerA'))).toBe(true);
+    expect(uris.some((u) => u.includes('RefCallerB'))).toBe(true);
+    expect(locations.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('misses CallerB when dependents load for the cursor file, not the target (gap #3 load-bearing)', async () => {
+    const service = new ReferencesProcessingService(getLogger(), symbolManager);
+    const position = { line: 2, character: 4 };
+
+    await recompileCursorFileAtFullDetail(svc, CALLER_A_URI, CALLER_A_SRC);
+
+    // The WRONG behavior the fix corrects: load dependents of the CURSOR file
+    // (CallerA) rather than the resolved target's declaring file (RefUtil).
+    // CallerA has no dependents, so CallerB's usages never enter the pool's
+    // graph and are missing from the result.
+    await loadDependentsForReferences(
+      svc,
+      CALLER_A_URI,
+      undefined,
+      fetchDependents,
+    );
+    await recompileCursorFileAtFullDetail(svc, CALLER_A_URI, CALLER_A_SRC);
+
+    const locations = await service.processReferences({
+      textDocument: { uri: CALLER_A_URI },
+      position,
+      context: { includeDeclaration: true },
+    });
+    const uris = locations.map((l) => l.uri);
+
+    // CallerB is absent — exactly the bug the declaring-file resolution fixes.
+    expect(uris.some((u) => u.includes('RefCallerB'))).toBe(false);
+  });
+});

--- a/packages/apex-ls/test/server/referenceEnrichmentRecipe.node.test.ts
+++ b/packages/apex-ls/test/server/referenceEnrichmentRecipe.node.test.ts
@@ -238,4 +238,41 @@ describe('reference-enrichment recipe (worker DispatchReferences path)', () => {
     // CallerB is absent — exactly the bug the declaring-file resolution fixes.
     expect(uris.some((u) => u.includes('RefCallerB'))).toBe(false);
   });
+
+  // recompileCursorFileAtFullDetail content-guard contract (review finding 1):
+  // the recompile must distinguish TRULY-ABSENT content (undefined → skip) from
+  // an empty zero-length file ('' → recompile). The DispatchReferences handler
+  // keys its abort-vs-continue decision on the boolean this returns.
+  describe('recompileCursorFileAtFullDetail content guard', () => {
+    const EMPTY_URI = 'file:///t/Empty.cls';
+
+    it('returns false when content is undefined (truly absent)', async () => {
+      const recompiled = await recompileCursorFileAtFullDetail(
+        svc,
+        CALLER_A_URI,
+        undefined,
+      );
+      expect(recompiled).toBe(false);
+    });
+
+    it('returns true for an empty string (valid zero-length file)', async () => {
+      // '' is a real, compilable (empty) document — not "no content". A falsy
+      // `!content` guard would wrongly reject it and leave the file degraded.
+      const recompiled = await recompileCursorFileAtFullDetail(
+        svc,
+        EMPTY_URI,
+        '',
+      );
+      expect(recompiled).toBe(true);
+    });
+
+    it('returns true when real content is recompiled', async () => {
+      const recompiled = await recompileCursorFileAtFullDetail(
+        svc,
+        CALLER_A_URI,
+        CALLER_A_SRC,
+      );
+      expect(recompiled).toBe(true);
+    });
+  });
 });

--- a/packages/apex-lsp-shared/src/workerWireSchemas.ts
+++ b/packages/apex-lsp-shared/src/workerWireSchemas.ts
@@ -643,6 +643,13 @@ export class DispatchReferences extends Schema.TaggedRequest<DispatchReferences>
       context: Schema.Struct({
         includeDeclaration: Schema.Boolean,
       }),
+      // Live (possibly unsaved) document text. ReferencesProcessingService reads
+      // the document from the worker's local storage to map the cursor position
+      // to a symbol; the stateless request-pool worker has no document unless we
+      // thread the text in (same as DispatchDocumentSymbol). Without it the pool
+      // worker's storage misses and find-references returns [] for every cursor
+      // — including cross-file usages.
+      content: Schema.optional(Schema.String),
     },
   },
 ) {}

--- a/packages/apex-lsp-shared/src/workerWireSchemas.ts
+++ b/packages/apex-lsp-shared/src/workerWireSchemas.ts
@@ -929,8 +929,11 @@ export class DataOwnerQuerySymbolByName extends Schema.TaggedRequest<DataOwnerQu
       // naturally carries the tables for all matched names at once.
       names: Schema.optional(Schema.Array(Schema.String)),
       // Optional namespace/qualifier hint (e.g. the leading qualifier of a
-      // qualified TypeReference). Accepted now to avoid a wire-schema break
-      // later; the data-owner may use it to disambiguate name matches.
+      // qualified TypeReference). The data-owner uses it as a SOFT preference
+      // to disambiguate same-named matches across namespaces: matches whose
+      // namespace equals the hint are preferred, but if none match it falls
+      // back to all matches (so an inner-class qualifier like `Outer` in
+      // `Outer.Inner`, which is not a namespace, does not drop valid results).
       namespace: Schema.optional(Schema.String),
     },
   },

--- a/packages/apex-parser-ast/src/parser/listeners/ApexReferenceCollectorListener.ts
+++ b/packages/apex-parser-ast/src/parser/listeners/ApexReferenceCollectorListener.ts
@@ -46,6 +46,7 @@ import {
   isDotExpressionContext,
   isContextType,
   countCallArguments,
+  countConstructorArguments,
 } from '../../utils/contextTypeGuards';
 import { HierarchicalReferenceResolver } from '../../types/hierarchicalReference';
 
@@ -1863,6 +1864,9 @@ export class ApexReferenceCollectorListener extends BaseApexParserListener<Symbo
         parentContext,
         preciseLocations.length > 1 ? preciseLocations : undefined,
       );
+      // Overload discriminator: constructor call-site arity (F11-2). Lets
+      // findReferencesTo separate `new Foo()` from `new Foo(x)`.
+      reference.argumentCount = countConstructorArguments(ctx);
 
       // Check if this constructor call has arguments (classCreatorRest)
       const classCreatorRest = (creator as any).classCreatorRest?.();

--- a/packages/apex-parser-ast/src/parser/listeners/ApexSymbolCollectorListener.ts
+++ b/packages/apex-parser-ast/src/parser/listeners/ApexSymbolCollectorListener.ts
@@ -150,6 +150,7 @@ import {
   isMethodCallContext,
   getTypeNameFromCreatedName,
   countCallArguments,
+  countConstructorArguments,
 } from '../../utils/contextTypeGuards';
 import { ResourceLoader } from '../../utils/resourceLoader';
 import { DEFAULT_SALESFORCE_API_VERSION } from '../../constants/constants';
@@ -6009,6 +6010,9 @@ export class ApexSymbolCollectorListener
         parentContext,
         preciseLocations.length > 1 ? preciseLocations : undefined,
       );
+      // Overload discriminator: constructor call-site arity (F11-2). Lets
+      // findReferencesTo separate `new Foo()` from `new Foo(x)`.
+      ctorRef.argumentCount = countConstructorArguments(ctx);
       this.symbolTable.addTypeReference(ctorRef);
 
       // Check if this constructor call has arguments (classCreatorRest)

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
@@ -3493,6 +3493,23 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
             }
 
             if (!targetSymbol) {
+              // A qualified reference (`Outer.Inner`) is stored under its full
+              // dotted name, which findSymbolByName (keyed on the leaf segment)
+              // can't match — leaving the edge unbound so findReferencesTo on the
+              // inner type misses the qualified caller entirely. The FQN index
+              // DOES key on the dotted name, so try it first for dotted names and
+              // bind to the actual leaf symbol (Inner), not its qualifier.
+              if (typeRef.name.includes('.')) {
+                const byFqn = yield* Effect.promise(() =>
+                  self.findSymbolByFQN(typeRef.name),
+                );
+                if (byFqn) {
+                  targetSymbol = byFqn;
+                }
+              }
+            }
+
+            if (!targetSymbol) {
               const symbols = yield* Effect.promise(() =>
                 self.findSymbolByName(typeRef.name),
               );

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolRefManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolRefManager.ts
@@ -52,7 +52,11 @@ import {
   keyToString,
   inTypeSymbolGroup,
 } from '../types/symbol';
-import { isBlockSymbol, isMethodSymbol } from '../utils/symbolNarrowing';
+import {
+  isBlockSymbol,
+  isMethodSymbol,
+  isMethodOrConstructorSymbol,
+} from '../utils/symbolNarrowing';
 import { calculateFQN } from '../utils/FQNUtils';
 import { ResourceLoader } from '../utils/resourceLoader';
 import { isApexKeyword } from '../utils/ApexKeywords';
@@ -1990,17 +1994,20 @@ export class ApexSymbolRefManager {
    * - Same-arity overloads (`f(String)` vs `f(Integer)`) cannot be separated by
    *   arity alone and remain unified; call-site type capture is the documented
    *   follow-up.
+   * - Applies to constructors as well as methods: constructor overloads
+   *   (`Foo()` vs `Foo(String)`) are separated by call-site arity the same way.
    */
   private separateOverloadReferences(
     symbol: ApexSymbol,
     results: ReferenceResult[],
   ): ReferenceResult[] {
-    if (!isMethodSymbol(symbol)) {
+    if (!isMethodOrConstructorSymbol(symbol)) {
       return results;
     }
 
-    // Count same-named method siblings on the same declaring type. Only when
-    // there is more than one is disambiguation meaningful.
+    // Count same-named invocable siblings (methods/constructors) on the same
+    // declaring type. Only when there is more than one is disambiguation
+    // meaningful.
     const declaringType = this.findDeclaringTypeForMember(symbol);
     if (!declaringType) {
       return results;
@@ -2014,7 +2021,7 @@ export class ApexSymbolRefManager {
     const siblings = this.getSymbolsInFile(symbol.fileUri).filter(
       (s) =>
         s.name === symbol.name &&
-        isMethodSymbol(s) &&
+        isMethodOrConstructorSymbol(s) &&
         this.findDeclaringTypeForMember(s)?.id === declaringType.id,
     );
     if (siblings.length <= 1) {

--- a/packages/apex-parser-ast/src/symbols/referenceCacheKey.ts
+++ b/packages/apex-parser-ast/src/symbols/referenceCacheKey.ts
@@ -8,7 +8,7 @@
 
 import type { ApexSymbol } from '../types/symbol';
 import { extractFilePathFromUri } from '../types/UriBasedIdGenerator';
-import { isMethodSymbol } from '../utils/symbolNarrowing';
+import { isMethodOrConstructorSymbol } from '../utils/symbolNarrowing';
 
 /**
  * Shared cache-key builders for the `findReferencesTo` / `findReferencesFrom`
@@ -26,8 +26,10 @@ import { isMethodSymbol } from '../utils/symbolNarrowing';
  * query for one would serve another's cached results. The key therefore also
  * carries the declaring file (normalized the same way symbol IDs and the
  * reverse index are, via {@link extractFilePathFromUri}, so two spellings of
- * one URI don't drift into separate entries) and — for methods — the declared
- * arity, the same discriminator the reverse-index overload separation uses.
+ * one URI don't drift into separate entries) and — for methods AND constructors
+ * — the declared arity, the same discriminator the reverse-index overload
+ * separation uses. Constructors are overloadable by parameter list too
+ * (`Foo()` vs `Foo(String)`), so they need the arity discriminator as well.
  *
  * The `refs_to_` / `refs_from_` prefixes are load-bearing: the relationship
  * cache is invalidated wholesale by the `^refs_(to|from)_` pattern in
@@ -39,7 +41,7 @@ function discriminator(symbol: ApexSymbol): string {
   const filePart = symbol.fileUri
     ? extractFilePathFromUri(symbol.fileUri)
     : 'no-file';
-  const arityPart = isMethodSymbol(symbol)
+  const arityPart = isMethodOrConstructorSymbol(symbol)
     ? `:${symbol.parameters?.length ?? 0}`
     : '';
   return `${symbol.name}@${filePart}${arityPart}`;

--- a/packages/apex-parser-ast/src/utils/contextTypeGuards.ts
+++ b/packages/apex-parser-ast/src/utils/contextTypeGuards.ts
@@ -255,3 +255,23 @@ export function countCallArguments(
 ): number {
   return ctx.expressionList()?.expression_list()?.length ?? 0;
 }
+
+/**
+ * Count the call-site arguments of a constructor call (`new Foo(a, b)`).
+ *
+ * Grammar: `newExpression` → `creator` → `classCreatorRest` →
+ * `arguments` (`LPAREN expressionList? RPAREN`), whose `expression_list()` is
+ * the positional argument array. A no-arg `new Foo()` still has a
+ * `classCreatorRest` with an empty `arguments`, so this returns `0`; a creator
+ * with no `classCreatorRest` (array/map/set creators) also returns `0`.
+ *
+ * This is the constructor call-site *arity* — the overload discriminator that
+ * lets `findReferencesTo` separate `Foo()` from `Foo(String)` the same way
+ * {@link countCallArguments} does for method overloads (F11-2). Without it,
+ * constructor-call references carry no `argumentCount` and constructor
+ * overloads collapse onto one another.
+ */
+export function countConstructorArguments(ctx: NewExpressionContext): number {
+  const rest = ctx.creator()?.classCreatorRest?.();
+  return rest?.arguments()?.expressionList()?.expression_list()?.length ?? 0;
+}

--- a/packages/apex-parser-ast/src/utils/symbolNarrowing.ts
+++ b/packages/apex-parser-ast/src/utils/symbolNarrowing.ts
@@ -59,6 +59,21 @@ export const isConstructorSymbol = (
 } => !!symbol && symbol.kind === SymbolKind.Constructor;
 
 /**
+ * Type predicate for any invocable symbol — a method OR a constructor. Both are
+ * MethodSymbol-shaped (they carry `parameters`, so arity is well defined), and
+ * both can be overloaded by parameter list. Use this anywhere overload/arity
+ * handling must treat constructors the same as methods (e.g. the
+ * `findReferencesTo` cache key and overload separation); `isMethodSymbol` alone
+ * narrows on `SymbolKind.Method` and silently excludes constructors, which
+ * collapses constructor overloads onto one another.
+ */
+export const isMethodOrConstructorSymbol = (
+  symbol: ApexSymbol | undefined | null,
+): symbol is MethodSymbol =>
+  !!symbol &&
+  (symbol.kind === SymbolKind.Method || symbol.kind === SymbolKind.Constructor);
+
+/**
  * Type predicate to check if a symbol is a ClassSymbol
  */
 export const isClassSymbol = (

--- a/packages/apex-parser-ast/test/references/overloadSeparation.test.ts
+++ b/packages/apex-parser-ast/test/references/overloadSeparation.test.ts
@@ -199,6 +199,61 @@ describe('per-overload reference separation (F11-2 core)', () => {
     expect(arity1Calls.length).toBeGreaterThanOrEqual(2);
   });
 
+  /** Find a constructor symbol by declared parameter count. */
+  const constructorByArity = async (
+    fileUri: string,
+    arity: number,
+  ): Promise<ApexSymbol> => {
+    const symbols = await symbolManager.findSymbolsInFile(fileUri);
+    const match = symbols.find(
+      (s) =>
+        s.kind === SymbolKind.Constructor &&
+        ((s as { parameters?: unknown[] }).parameters?.length ?? 0) === arity,
+    );
+    if (!match) {
+      throw new Error(`No constructor/${arity} found in ${fileUri}`);
+    }
+    return match;
+  };
+
+  it('separates references to arity-distinct constructor overloads', async () => {
+    const URI = 'file:///test/CtorOverloads.cls';
+    // Ctor() and Ctor(String) are two constructor overloads; build() invokes
+    // each once. Before the fix, both collapsed onto one findReferencesTo cache
+    // key (no arity discriminator for SymbolKind.Constructor) and overload
+    // separation was skipped, so a query for one returned the other's calls too.
+    await compileAndAdd(
+      `public class CtorOverloads {
+         public CtorOverloads() {}
+         public CtorOverloads(String msg) {}
+         public static CtorOverloads build() {
+           CtorOverloads a = new CtorOverloads();
+           CtorOverloads b = new CtorOverloads('hi');
+           return a;
+         }
+       }`,
+      URI,
+    );
+    await resolveCrossFile(URI);
+
+    const ctorNoArg = await constructorByArity(URI, 0);
+    const ctorOneArg = await constructorByArity(URI, 1);
+
+    const refsToNoArg = await symbolManager.findReferencesTo(ctorNoArg);
+    const refsToOneArg = await symbolManager.findReferencesTo(ctorOneArg);
+
+    const noArgCallArities = refsToNoArg.map((r) => r.context?.argumentCount);
+    const oneArgCallArities = refsToOneArg.map((r) => r.context?.argumentCount);
+
+    // The zero-arg constructor must not pick up the new CtorOverloads('hi')
+    // call, and vice versa. (Distinct results prove the cache key no longer
+    // aliases the two overloads onto one entry.)
+    expect(noArgCallArities).not.toContain(1);
+    expect(oneArgCallArities).not.toContain(0);
+    expect(noArgCallArities).toContain(0);
+    expect(oneArgCallArities).toContain(1);
+  });
+
   // LISTENER-DRIFT GUARD. The compileAndAdd helper uses
   // ApexSymbolCollectorListener, but the worker topology collects references
   // via VisibilitySymbolListener + { collectReferences: true } — a DIFFERENT

--- a/packages/apex-parser-ast/test/references/qualifiedReferenceBinding.test.ts
+++ b/packages/apex-parser-ast/test/references/qualifiedReferenceBinding.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Cross-file binding for QUALIFIED type references (e.g. `Outer.Inner`).
+ *
+ * A qualified reference is stored under its full dotted name (`Outer.Inner`).
+ * The cross-file binding pass (resolveCrossFileReferencesForFile →
+ * processSymbolReferenceToGraphEffect) previously resolved a target only via
+ * findSymbolByName, which is keyed on the LEAF segment and so never matched the
+ * dotted name. The reference stayed unbound: no resolvedSymbolId, and — fatally
+ * for find-references — no reverse-index edge, so findReferencesTo(Inner)
+ * missed the qualified caller entirely.
+ *
+ * The fix resolves dotted names through the FQN index (which DOES key on the
+ * dotted name) and binds the edge to the actual leaf symbol (Inner), not its
+ * qualifier (Outer). These tests lock that in: they would fail with a 0-count /
+ * unbound reference before the fix.
+ *
+ * This binding correctness is also what lets find-references' precise
+ * position→symbol resolution succeed on a qualified usage WITHOUT a by-name
+ * fallback (the resolvedSymbolId is now set), so the worker path no longer
+ * needs to guess by name.
+ */
+
+import { ApexSymbolManager } from '../../src/symbols/ApexSymbolManager';
+import { CompilerService } from '../../src/parser/compilerService';
+import { FullSymbolCollectorListener } from '../../src/parser/listeners/FullSymbolCollectorListener';
+import {
+  SymbolKind,
+  SymbolTable,
+  type ApexSymbol,
+} from '../../src/types/symbol';
+import { Effect } from 'effect';
+
+describe('qualified cross-file reference binding', () => {
+  let sm: ApexSymbolManager;
+
+  beforeEach(() => {
+    sm = new ApexSymbolManager();
+  });
+
+  const add = async (code: string, uri: string): Promise<void> => {
+    const table = new SymbolTable();
+    new CompilerService().compile(
+      code,
+      uri,
+      new FullSymbolCollectorListener(table),
+      {
+        collectReferences: true,
+        resolveReferences: true,
+      },
+    );
+    await Effect.runPromise(sm.addSymbolTable(table, uri));
+  };
+
+  const resolveCrossFile = async (uri: string): Promise<void> => {
+    await Effect.runPromise(
+      (
+        sm as unknown as {
+          resolveCrossFileReferencesForFile: (
+            u: string,
+          ) => Effect.Effect<void, never, never>;
+        }
+      ).resolveCrossFileReferencesForFile(uri),
+    );
+  };
+
+  const innerClassSymbol = async (): Promise<ApexSymbol> => {
+    const syms = await sm.findSymbolsInFile('file:///t/Outer.cls');
+    const inner = syms.find(
+      (s) => s.name === 'Inner' && s.kind === SymbolKind.Class,
+    );
+    if (!inner) throw new Error('Inner class symbol not found');
+    return inner;
+  };
+
+  it('findReferencesTo(Inner) surfaces a cross-file `Outer.Inner` caller', async () => {
+    await add(
+      'public class Outer { public class Inner { public Inner() {} } }',
+      'file:///t/Outer.cls',
+    );
+    await add(
+      'public class CallerD { void m() { Outer.Inner x = new Outer.Inner(); } }',
+      'file:///t/CallerD.cls',
+    );
+    await resolveCrossFile('file:///t/Outer.cls');
+    await resolveCrossFile('file:///t/CallerD.cls');
+
+    const refs = await sm.findReferencesTo(await innerClassSymbol());
+
+    expect(refs.length).toBeGreaterThanOrEqual(1);
+    const callerHit = refs.find((r) =>
+      (r.fileUri ?? r.symbol?.fileUri ?? '').includes('CallerD'),
+    );
+    expect(callerHit).toBeDefined();
+  });
+
+  it('precise position resolution lands on Inner for a qualified usage', async () => {
+    await add(
+      'public class Outer { public class Inner { public static void go() {} } }',
+      'file:///t/Outer.cls',
+    );
+    await add(
+      'public class CallerC { void m() { Outer.Inner x = new Outer.Inner(); } }',
+      'file:///t/CallerC.cls',
+    );
+    await resolveCrossFile('file:///t/Outer.cls');
+    await resolveCrossFile('file:///t/CallerC.cls');
+
+    // Cursor on the `Inner` segment of `Outer.Inner` (1-based parser line).
+    const symbol = await sm.getSymbolAtPosition(
+      'file:///t/CallerC.cls',
+      { line: 1, character: 41 },
+      'precise',
+    );
+
+    expect(symbol).not.toBeNull();
+    expect((symbol as ApexSymbol).name).toBe('Inner');
+    expect((symbol as ApexSymbol).fileUri).toContain('Outer.cls');
+  });
+});

--- a/packages/lsp-compliant-services/src/services/ReferencesProcessingService.ts
+++ b/packages/lsp-compliant-services/src/services/ReferencesProcessingService.ts
@@ -534,13 +534,19 @@ export class ReferencesProcessingService implements IReferencesProcessor {
     const deduped: Location[] = [];
     for (const loc of locations) {
       const { start, end } = loc.range;
-      const key = [
+      // JSON.stringify rather than a `join('|')`: a `|` delimiter is unsafe
+      // because URIs can legally contain pipes (legacy Windows drive URIs like
+      // `file:///C|/path`, or percent-encoded `%7C`), so a raw join could let a
+      // URI's own pipe align with a field boundary and collapse two distinct
+      // locations onto one key. JSON quotes the URI and preserves array
+      // structure, making the key unambiguous for any character.
+      const key = JSON.stringify([
         loc.uri,
         start.line,
         start.character,
         end.line,
         end.character,
-      ].join('|');
+      ]);
       if (seen.has(key)) {
         continue;
       }

--- a/packages/lsp-compliant-services/src/services/ReferencesProcessingService.ts
+++ b/packages/lsp-compliant-services/src/services/ReferencesProcessingService.ts
@@ -513,8 +513,41 @@ export class ReferencesProcessingService implements IReferencesProcessor {
         self.logger.debug(() => `Error getting reference locations: ${error}`);
       }
 
-      return locations;
+      // The four sources above (declaration, references-to, references-from,
+      // relationship edges) can surface the same physical location more than
+      // once — e.g. an `extends`/`implements` edge appears in both the graph
+      // reverse index and the relationship traversal, and a self-referential
+      // symbol can appear in both references-to and references-from. The LSP
+      // client renders each Location as a distinct entry, so collapse exact
+      // (uri, range) duplicates before returning.
+      return self.dedupeLocations(locations);
     });
+  }
+
+  /**
+   * Collapse Locations that point at the exact same (uri, range). Order is
+   * preserved (first occurrence wins) so the declaration — pushed first when
+   * requested — stays at the head of the list.
+   */
+  private dedupeLocations(locations: Location[]): Location[] {
+    const seen = new Set<string>();
+    const deduped: Location[] = [];
+    for (const loc of locations) {
+      const { start, end } = loc.range;
+      const key = [
+        loc.uri,
+        start.line,
+        start.character,
+        end.line,
+        end.character,
+      ].join('|');
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      deduped.push(loc);
+    }
+    return deduped;
   }
 
   /**

--- a/packages/lsp-compliant-services/test/services/ReferencesProcessingService.test.ts
+++ b/packages/lsp-compliant-services/test/services/ReferencesProcessingService.test.ts
@@ -768,6 +768,72 @@ describe('ReferencesProcessingService', () => {
     });
   });
 
+  describe('locals-only references (single-file scope)', () => {
+    const localsUri = 'file:///test/LocalsOnly.cls';
+    // `total` is a local declared once and read on the next two lines. Find
+    // References on it must stay WITHIN the method — never escaping to the
+    // same-named field or to another method's local.
+    const localsSrc = [
+      'public class LocalsOnly {',
+      '    public Integer compute() {',
+      '        Integer total = 0;',
+      '        total = total + 1;',
+      '        return total;',
+      '    }',
+      '    public Integer other() {',
+      '        Integer total = 99;',
+      '        return total;',
+      '    }',
+      '}',
+    ].join('\n');
+
+    beforeEach(async () => {
+      const compilerService = new CompilerService();
+      const symbolTable = new SymbolTable();
+      compilerService.compile(
+        localsSrc,
+        localsUri,
+        new FullSymbolCollectorListener(symbolTable),
+      );
+      await Effect.runPromise(
+        symbolManager.addSymbolTable(symbolTable, localsUri),
+      );
+      mockStorage.getDocument.mockResolvedValue(
+        TextDocument.create(localsUri, 'apex', 1, localsSrc),
+      );
+    });
+
+    const findRefs = (lspLine: number, lspChar: number) =>
+      (service as any).findReferences({
+        textDocument: { uri: localsUri },
+        position: { line: lspLine, character: lspChar },
+        context: { includeDeclaration: true },
+      }) as Promise<Location[]>;
+
+    it('resolves a local variable to its in-method usages only', async () => {
+      // Cursor on `total` in `total = total + 1;` (line 3, 0-based) col 8.
+      const locations = await findRefs(3, 8);
+
+      expect(Array.isArray(locations)).toBe(true);
+      expect(locations.length).toBeGreaterThan(0);
+
+      // Every location is in this file (a local never resolves cross-file).
+      for (const loc of locations) {
+        expect(loc.uri).toBe(localsUri);
+      }
+
+      // All hits fall within compute()'s body (LSP lines 2–4); none leak into
+      // other()'s same-named local on lines 7–8.
+      const lines = locations.map((l) => l.range.start.line).sort();
+      for (const line of lines) {
+        expect(line).toBeGreaterThanOrEqual(2);
+        expect(line).toBeLessThanOrEqual(4);
+      }
+      // other()'s `total` declaration (line 7) must NOT appear.
+      expect(lines).not.toContain(7);
+    });
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
     // Reset scheduler service instance (scheduler is not initialized in tests)

--- a/packages/lsp-compliant-services/test/services/ReferencesProcessingService.test.ts
+++ b/packages/lsp-compliant-services/test/services/ReferencesProcessingService.test.ts
@@ -547,6 +547,51 @@ describe('ReferencesProcessingService', () => {
         );
         expect(derivedHits).toHaveLength(1);
       });
+
+      // Review finding 3: the dedup key must not use an unescaped delimiter that
+      // can appear inside a URI. Legacy Windows drive URIs (`file:///C|/...`) and
+      // percent-encoded `%7C` both contain pipes, so a raw `join('|')` could let
+      // a URI's pipe align with a field boundary and collapse two DISTINCT
+      // locations onto one key.
+      it('does not collapse distinct pipe-containing URIs (delimiter safety)', () => {
+        // Two genuinely different locations. Under a naive `join('|')`:
+        //   'file:///C|/A.cls' + '|' + 0 + '|' + 0 + '|' + 0 + '|' + 10
+        //   'file:///C'        + '|' + '/A.cls|0' ...  (pipe in URI shifts fields)
+        // a crafted pair can produce the same joined string. JSON.stringify
+        // quotes the URI, so the two stay distinct.
+        const locA: Location = {
+          uri: 'file:///C|/A.cls',
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 10 },
+          },
+        };
+        const locB: Location = {
+          uri: 'file:///C',
+          range: {
+            start: { line: 0, character: 0 }, // '/A.cls' would be folded in
+            end: { line: 0, character: 10 },
+          },
+        };
+
+        const deduped = (service as any).dedupeLocations([locA, locB]);
+        expect(deduped).toHaveLength(2);
+      });
+
+      it('still collapses exact duplicates whose URI contains a pipe', () => {
+        const loc: Location = {
+          uri: 'file:///C|/path/With%7CPipe.cls',
+          range: {
+            start: { line: 3, character: 2 },
+            end: { line: 3, character: 9 },
+          },
+        };
+        const deduped = (service as any).dedupeLocations([
+          loc,
+          { ...loc, range: { ...loc.range } },
+        ]);
+        expect(deduped).toHaveLength(1);
+      });
     });
 
     describe('getSymbolFileUri', () => {

--- a/packages/lsp-compliant-services/test/services/ReferencesProcessingService.test.ts
+++ b/packages/lsp-compliant-services/test/services/ReferencesProcessingService.test.ts
@@ -504,6 +504,51 @@ describe('ReferencesProcessingService', () => {
       });
     });
 
+    describe('getReferenceLocations dedup', () => {
+      it('collapses the same (uri, range) surfaced by multiple sources', async () => {
+        // One physical reference reachable through BOTH findReferencesTo and
+        // findReferencesFrom (e.g. an extends/implements edge). It must appear
+        // once, not twice, in the returned Location[].
+        const dupRef = {
+          name: 'Base',
+          fileUri: 'file:///test/Derived.cls',
+          location: makeLocation(2, 21, 2, 25),
+        };
+        const uniqueRef = {
+          name: 'Base',
+          fileUri: 'file:///test/Other.cls',
+          location: makeLocation(9, 4, 9, 8),
+        };
+
+        jest
+          .spyOn(symbolManager, 'findReferencesTo')
+          .mockResolvedValue([dupRef, uniqueRef] as any);
+        jest
+          .spyOn(symbolManager, 'findReferencesFrom')
+          .mockResolvedValue([dupRef] as any);
+
+        const symbol = {
+          name: 'Base',
+          fileUri: 'file:///test/Base.cls',
+        };
+
+        const locations = await (service as any).getReferenceLocations(
+          symbol,
+          false,
+        );
+
+        // dupRef once + uniqueRef once = 2, not 3.
+        expect(locations).toHaveLength(2);
+        const derivedHits = locations.filter(
+          (l: any) =>
+            l.uri === 'file:///test/Derived.cls' &&
+            l.range.start.line === 1 &&
+            l.range.start.character === 21,
+        );
+        expect(derivedHits).toHaveLength(1);
+      });
+    });
+
     describe('getSymbolFileUri', () => {
       it('prefers fileUri when present', async () => {
         const uri = await (service as any).getSymbolFileUri({


### PR DESCRIPTION
## What does this PR do?

6.13 verification capstone for `textDocument/references`. The end-to-end verification work surfaced — and this PR fixes — a real defect: **cross-file find-references dispatched to the enrichment worker pool returned `[]`**. Five compounding root causes, all fixed:

1. **Content not threaded** — the `references` dispatch never carried document text to the stateless pool worker (unlike documentSymbol/hover/completion), so the worker's storage missed and `ReferencesProcessingService` hard-returned `[]`. Added `content` to the `DispatchReferences` wire schema + coordinator + both worker platforms.
2. **Cursor file at public-api** — the pool held the cursor file with method bodies stripped, so an in-body usage resolved to nothing. Recompile the cursor file at full detail from its text (`recompileCursorFileAtFullDetail`), as documentSymbol already does.
3. **Wrong dependents loaded** — the handler loaded dependents of the *cursor* file, but find-references needs callers of the *target symbol's declaring file*. Resolve the cursor symbol's declaring file and load its dependents (`declaringFileForCursorSymbol`).
4. **URI-scheme mismatch** — `ResolveDepUris` keyed wire entries by the schemeless URI from `findFilesForSymbol` (`/test/X.cls`), so ingestion never matched the references' `file:///test/X.cls` targets and cross-file edges failed to bind. Key entries by the table's canonical `getFileUri()`.
5. **Resolved types skipped** — the Phase-2 prefetch skipped types whose references were already resolved (fine for hover/definition, fatal for find-references, which needs the target type's *table* present to enumerate its references). Load referenced types regardless of resolution state (`loadReferencedTypesForFile`).

## Verification (6.13 deliverables)

- **`ReferencesThroughWorkerTopology.node.test.ts`** — asserts cross-file location counts through the live worker topology (the named deliverable).
- **`referenceEnrichmentRecipe.node.test.ts`** — verifies the handler recipe end-to-end at the service level with full observability, and proves the declaring-file step is load-bearing.
- **`apex-find-references.spec.ts`** — Playwright E2E (intra-file, cross-file, no-results, responsiveness) + `findReferences()`/`closePeek()` on `ApexEditorPage`.
- **Regression**: locals-only resolution test; cancellation already covered by `LSPQueueManager.test.ts`.

Full monorepo suite green via pre-commit hook (4555 passed, 0 failed).

### Deferred (out of scope for this PR)
- **Telemetry on the references path** — blocked on Jorje-parity #04 (telemetry plumbing, W-22629622, not started); tracked in the W-22692429 story.
- **Parity-table doc flip** — the design-doc parity table is an external (Quip/GUS) artifact, not an in-repo markdown table; flip handled there.

## Follow-on fallback cleanup (merged from #515)

Additional find-references fixes landed on this branch via #515, applying the standard "fix the cause, don't add a fallback." A companion analysis under `docs/design/` records the full fallback sweep (FB-1..FB-6) and what was deferred.

- **Constructor overloads now separate.** Root went deeper than a cache-key tweak: constructor-call references never carried call-site arity. Stamped `argumentCount` (`countConstructorArguments`) on `CONSTRUCTOR_CALL` refs in both listeners, added `isMethodOrConstructorSymbol`, and keyed the `findReferencesTo` cache + overload separation on it. Previously `Foo()` and `Foo(String)` aliased onto one result set.
- **Qualified cross-file references now bind (FB-1 root).** `Outer.Inner` was stored under its dotted name but bound only via leaf-keyed `findSymbolByName`, so it never bound and `findReferencesTo(Inner)` missed the qualified caller. Resolve dotted names through the FQN index and bind to the leaf symbol; `resolvedSymbolId` is now set so precise resolution works without a by-name guess. By-name fallbacks kept (documented) for the genuine partial-graph case; node/web `declaringFileForCursorSymbol` drift closed by porting the node fallback to web.
- **Duplicate reference locations removed.** `getReferenceLocationsEffect` now collapses exact `(uri, range)` duplicates across declaration / references-to / references-from / relationship edges.
- **Degraded results now attributable.** Best-effort enrichment helpers that silently swallowed failures (subset load logged nothing; recompile / referenced-type / dependent fetch at `debug`) now `warn`, and the no-document-text case is flagged. Mirrored node + web.

Deferred with rationale (see `docs/design/findreferences-pr503-deep-analysis.md` §7): FB-3 (data-owner inner-class index population; the qualified-binding root behind it is fixed, escalation kept as documented safety net), FB-5 (not on the references path — uses `'precise'`), FB-6 (canonical symbol-id rewrite — ~70 id sites + worker wire format, its own work item).

### What issues does this PR fix or reference?
@W-22692429@
