### PR TITLE
feat(apex-lsp-parser-ast): type-aware separation of same-arity overloads - W-23182862

### DIFF
--- a/packages/apex-parser-ast/src/parser/listeners/ApexReferenceCollectorListener.ts
+++ b/packages/apex-parser-ast/src/parser/listeners/ApexReferenceCollectorListener.ts
@@ -1958,8 +1958,9 @@ export class ApexReferenceCollectorListener extends BaseApexParserListener<Symbo
             chainNode.name,
             chainNode.location,
             finalContext,
-            undefined,
-            parentContext,
+            {
+              parentContext,
+            },
           );
           this.symbolTable.addTypeReference(memberRef);
         });
@@ -2040,12 +2041,14 @@ export class ApexReferenceCollectorListener extends BaseApexParserListener<Symbo
                   node.name,
                   node.location,
                   node.context,
-                  node.resolvedSymbolId,
-                  node.parentContext,
-                  nodeAccess,
-                  node.isStatic,
-                  node.literalValue,
-                  node.literalType,
+                  {
+                    resolvedSymbolId: node.resolvedSymbolId,
+                    parentContext: node.parentContext,
+                    access: nodeAccess,
+                    isStatic: node.isStatic,
+                    literalValue: node.literalValue,
+                    literalType: node.literalType,
+                  },
                 );
               }
               return node;
@@ -2055,18 +2058,14 @@ export class ApexReferenceCollectorListener extends BaseApexParserListener<Symbo
               fullExpression,
               chainedExpressionLocation,
               finalNode.context, // Use final node's context
-              undefined, // resolvedSymbolId - will be set during second-pass resolution
-              parentContext,
-              finalAccess, // Overall chain access
-              finalNode.isStatic,
-              undefined,
-              undefined,
-              nodesWithAccess, // Attach chainNodes to final node
-              undefined, // resolvedTypeId
-              undefined, // resolutionTier
-              undefined, // isFullyResolved
-              undefined, // validatedAccess
-              'syntax_only', // accessValidationState
+              {
+                // resolvedSymbolId set during second-pass resolution
+                parentContext,
+                access: finalAccess, // Overall chain access
+                isStatic: finalNode.isStatic,
+                chainNodes: nodesWithAccess, // Attach chainNodes to final node
+                accessValidationState: 'syntax_only',
+              },
             );
 
             this.symbolTable.addTypeReference(finalRef);
@@ -2119,12 +2118,14 @@ export class ApexReferenceCollectorListener extends BaseApexParserListener<Symbo
               baseNode.name,
               baseNode.location,
               baseNode.context,
-              baseNode.resolvedSymbolId,
-              baseNode.parentContext,
-              'read',
-              baseNode.isStatic,
-              baseNode.literalValue,
-              baseNode.literalType,
+              {
+                resolvedSymbolId: baseNode.resolvedSymbolId,
+                parentContext: baseNode.parentContext,
+                access: 'read',
+                isStatic: baseNode.isStatic,
+                literalValue: baseNode.literalValue,
+                literalType: baseNode.literalType,
+              },
             )
           : baseNode;
 
@@ -2138,12 +2139,14 @@ export class ApexReferenceCollectorListener extends BaseApexParserListener<Symbo
             node.name,
             node.location,
             node.context,
-            node.resolvedSymbolId,
-            node.parentContext,
-            nodeAccess,
-            node.isStatic,
-            node.literalValue,
-            node.literalType,
+            {
+              resolvedSymbolId: node.resolvedSymbolId,
+              parentContext: node.parentContext,
+              access: nodeAccess,
+              isStatic: node.isStatic,
+              literalValue: node.literalValue,
+              literalType: node.literalType,
+            },
           );
         }
         return node;
@@ -2186,18 +2189,14 @@ export class ApexReferenceCollectorListener extends BaseApexParserListener<Symbo
         fullExpression,
         chainedExpression,
         finalNode.context, // Use final node's context (FIELD_ACCESS, METHOD_CALL, etc.)
-        undefined, // resolvedSymbolId - will be set during second-pass resolution
-        this.getCurrentMethodName(),
-        finalAccess, // Overall chain access matches final node
-        finalNode.isStatic,
-        undefined,
-        undefined,
-        analyzedChainNodes, // Attach chainNodes to final node
-        undefined, // resolvedTypeId - will be set during TIER 2
-        undefined, // resolutionTier - will be set during resolution
-        undefined, // isFullyResolved - will be set during TIER 2
-        undefined, // validatedAccess - will be set during TIER 2
-        'syntax_only', // accessValidationState - TIER 1 capture only
+        {
+          // resolvedSymbolId set during second-pass resolution
+          parentContext: this.getCurrentMethodName(),
+          access: finalAccess, // Overall chain access matches final node
+          isStatic: finalNode.isStatic,
+          chainNodes: analyzedChainNodes, // Attach chainNodes to final node
+          accessValidationState: 'syntax_only', // TIER 1 capture only
+        },
       );
 
       this.symbolTable.addTypeReference(finalRef);
@@ -2737,14 +2736,10 @@ export class ApexReferenceCollectorListener extends BaseApexParserListener<Symbo
     context: ReferenceContext,
     access?: 'read' | 'write' | 'readwrite',
   ): SymbolReference {
-    return new EnhancedSymbolReference(
-      name,
-      location,
-      context,
-      undefined,
-      this.getCurrentMethodName(),
+    return new EnhancedSymbolReference(name, location, context, {
+      parentContext: this.getCurrentMethodName(),
       access,
-    );
+    });
   }
 
   private createPreciseBaseLocation(

--- a/packages/apex-parser-ast/src/parser/listeners/ApexReferenceCollectorListener.ts
+++ b/packages/apex-parser-ast/src/parser/listeners/ApexReferenceCollectorListener.ts
@@ -47,6 +47,8 @@ import {
   isContextType,
   countCallArguments,
   countConstructorArguments,
+  callArgumentExpressions,
+  constructorArgumentExpressions,
 } from '../../utils/contextTypeGuards';
 import { HierarchicalReferenceResolver } from '../../types/hierarchicalReference';
 
@@ -248,6 +250,9 @@ export class ApexReferenceCollectorListener extends BaseApexParserListener<Symbo
       // Overload discriminator: call-site arity (F11-2). Set post-construction
       // rather than via the already-long factory/constructor positional list.
       reference.argumentCount = countCallArguments(ctx);
+      // Raw argument source texts — input to semantic argument-type resolution
+      // (same-arity overload separation). Type derivation happens later.
+      reference.argumentExpressions = callArgumentExpressions(ctx);
 
       this.methodCallStack.push({
         callRef: reference,
@@ -315,6 +320,7 @@ export class ApexReferenceCollectorListener extends BaseApexParserListener<Symbo
       );
       // Overload discriminator: call-site arity (F11-2).
       reference.argumentCount = countCallArguments(ctx);
+      reference.argumentExpressions = callArgumentExpressions(ctx);
 
       this.methodCallStack.push({
         callRef: reference,
@@ -1867,6 +1873,7 @@ export class ApexReferenceCollectorListener extends BaseApexParserListener<Symbo
       // Overload discriminator: constructor call-site arity (F11-2). Lets
       // findReferencesTo separate `new Foo()` from `new Foo(x)`.
       reference.argumentCount = countConstructorArguments(ctx);
+      reference.argumentExpressions = constructorArgumentExpressions(ctx);
 
       // Check if this constructor call has arguments (classCreatorRest)
       const classCreatorRest = (creator as any).classCreatorRest?.();
@@ -2251,6 +2258,7 @@ export class ApexReferenceCollectorListener extends BaseApexParserListener<Symbo
         );
         // Overload discriminator: call-site arity (F11-2).
         reference.argumentCount = countCallArguments(ctx);
+        reference.argumentExpressions = callArgumentExpressions(ctx);
         this.symbolTable.addTypeReference(reference);
       }
     } catch (error) {

--- a/packages/apex-parser-ast/src/parser/listeners/ApexSymbolCollectorListener.ts
+++ b/packages/apex-parser-ast/src/parser/listeners/ApexSymbolCollectorListener.ts
@@ -151,6 +151,8 @@ import {
   getTypeNameFromCreatedName,
   countCallArguments,
   countConstructorArguments,
+  callArgumentExpressions,
+  constructorArgumentExpressions,
 } from '../../utils/contextTypeGuards';
 import { ResourceLoader } from '../../utils/resourceLoader';
 import { DEFAULT_SALESFORCE_API_VERSION } from '../../constants/constants';
@@ -3077,6 +3079,9 @@ export class ApexSymbolCollectorListener
       // Overload discriminator: call-site arity (F11-2). Set post-construction
       // rather than via the already-long factory/constructor positional list.
       reference.argumentCount = countCallArguments(ctx);
+      // Raw argument source texts — input to semantic argument-type resolution
+      // (same-arity overload separation). Type derivation happens later.
+      reference.argumentExpressions = callArgumentExpressions(ctx);
 
       // Push onto method call stack for parameter tracking
       // This happens BEFORE ExpressionListContext is entered, so parameters
@@ -3148,6 +3153,7 @@ export class ApexSymbolCollectorListener
       );
       // Overload discriminator: call-site arity (F11-2).
       reference.argumentCount = countCallArguments(ctx);
+      reference.argumentExpressions = callArgumentExpressions(ctx);
 
       // Push onto method call stack for parameter tracking
       this.methodCallStack.push({
@@ -6013,6 +6019,7 @@ export class ApexSymbolCollectorListener
       // Overload discriminator: constructor call-site arity (F11-2). Lets
       // findReferencesTo separate `new Foo()` from `new Foo(x)`.
       ctorRef.argumentCount = countConstructorArguments(ctx);
+      ctorRef.argumentExpressions = constructorArgumentExpressions(ctx);
       this.symbolTable.addTypeReference(ctorRef);
 
       // Check if this constructor call has arguments (classCreatorRest)
@@ -6961,6 +6968,7 @@ export class ApexSymbolCollectorListener
         );
         // Overload discriminator: call-site arity (F11-2).
         methodRef.argumentCount = countCallArguments(ctx);
+        methodRef.argumentExpressions = callArgumentExpressions(ctx);
 
         this.symbolTable.addTypeReference(methodRef);
 
@@ -6999,6 +7007,7 @@ export class ApexSymbolCollectorListener
         );
         // Overload discriminator: call-site arity (F11-2).
         reference.argumentCount = countCallArguments(ctx);
+        reference.argumentExpressions = callArgumentExpressions(ctx);
         this.symbolTable.addTypeReference(reference);
       }
     } catch (error) {

--- a/packages/apex-parser-ast/src/parser/listeners/ApexSymbolCollectorListener.ts
+++ b/packages/apex-parser-ast/src/parser/listeners/ApexSymbolCollectorListener.ts
@@ -7047,8 +7047,10 @@ export class ApexSymbolCollectorListener
             memberName,
             memberLocation,
             context,
-            undefined, // resolvedSymbolId - will be set during second-pass resolution
-            parentContext,
+            {
+              // resolvedSymbolId set during second-pass resolution
+              parentContext,
+            },
           );
 
           this.symbolTable.addTypeReference(memberRef);
@@ -7109,18 +7111,14 @@ export class ApexSymbolCollectorListener
           },
         },
         finalNode.context, // Use final node's context
-        undefined, // resolvedSymbolId - will be set during second-pass resolution
-        this.getCurrentMethodName(),
-        undefined, // access - will be set if in LHS context
-        finalNode.isStatic,
-        undefined,
-        undefined,
-        analyzedChainNodes, // Attach chainNodes to final node
-        undefined, // resolvedTypeId
-        undefined, // resolutionTier
-        undefined, // isFullyResolved
-        undefined, // validatedAccess
-        'syntax_only', // accessValidationState
+        {
+          // resolvedSymbolId set during second-pass resolution
+          parentContext: this.getCurrentMethodName(),
+          // access - will be set if in LHS context
+          isStatic: finalNode.isStatic,
+          chainNodes: analyzedChainNodes, // Attach chainNodes to final node
+          accessValidationState: 'syntax_only',
+        },
       );
 
       this.symbolTable.addTypeReference(finalRef);
@@ -7361,18 +7359,14 @@ export class ApexSymbolCollectorListener
           },
         },
         finalNode.context, // Use final node's context
-        undefined, // resolvedSymbolId - will be set during second-pass resolution
-        this.getCurrentMethodName(),
-        undefined, // access - will be set if in LHS context
-        finalNode.isStatic,
-        undefined,
-        undefined,
-        analyzedChainNodes, // Attach chainNodes to final node
-        undefined, // resolvedTypeId
-        undefined, // resolutionTier
-        undefined, // isFullyResolved
-        undefined, // validatedAccess
-        'syntax_only', // accessValidationState
+        {
+          // resolvedSymbolId set during second-pass resolution
+          parentContext: this.getCurrentMethodName(),
+          // access - will be set if in LHS context
+          isStatic: finalNode.isStatic,
+          chainNodes: analyzedChainNodes, // Attach chainNodes to final node
+          accessValidationState: 'syntax_only',
+        },
       );
 
       this.symbolTable.addTypeReference(finalRef);
@@ -7462,8 +7456,10 @@ export class ApexSymbolCollectorListener
         memberName,
         memberLocation,
         context,
-        undefined, // resolvedSymbolId - will be set during second-pass resolution
-        parentContext,
+        {
+          // resolvedSymbolId set during second-pass resolution
+          parentContext,
+        },
       );
 
       this.symbolTable.addTypeReference(memberRef);

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
@@ -3253,7 +3253,14 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
             ? scopeHierarchy[scopeHierarchy.length - 1]
             : null;
         const lookupType = (identifier: string): string | undefined => {
-          const symbol = symbolTable.lookup(identifier, innermostScope);
+          // Resolve through the lexical scope CHAIN only (scope → parents →
+          // roots). Must NOT use lookup(), whose child-scope descent could
+          // resolve the argument to a same-named local in an unrelated nested
+          // block and feed a wrong type into overload separation.
+          const symbol = symbolTable.lookupInScopeChain(
+            identifier,
+            innermostScope,
+          );
           if (isVariableSymbol(symbol)) {
             return (
               symbol.type?.originalTypeString ?? symbol.type?.name ?? undefined

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
@@ -95,7 +95,9 @@ import {
   inTypeSymbolGroup,
   isChainedSymbolReference,
   isBlockSymbol,
+  isVariableSymbol,
 } from '../utils/symbolNarrowing';
+import { resolveArgumentTypes } from '../utils/argumentTypeResolution';
 import {
   buildReferencesToCacheKey,
   buildReferencesFromCacheKey,
@@ -2074,6 +2076,13 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
       // wholesale invalidation of the family is correct and cheap to rebuild.
       self.unifiedCache.invalidatePattern('^refs_(to|from)_');
 
+      // Derive positional argumentTypes for call references BEFORE building any
+      // graph edges: the reverse-index edges copy each reference's argumentTypes
+      // into their context, so the signature key (used to separate same-arity
+      // overloads, W-23182862) must be populated first or it never reaches the
+      // edge. File-local and synchronous, so this is the natural place.
+      yield* self.resolveArgumentTypesEffect(finalSymbolTable);
+
       // Process same-file references immediately (cheap, synchronous, needed for graph edges)
       // Skip cross-file references to avoid queue pressure - they'll be resolved on-demand
       yield* self.processSameFileReferencesToGraphEffect(
@@ -2651,6 +2660,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
             methodName: typeRef.parentContext,
             isStatic: isStatic,
             argumentCount: typeRef.argumentCount,
+            argumentTypes: typeRef.argumentTypes,
           },
         );
         if (stats) {
@@ -3110,6 +3120,10 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
           return;
         }
 
+        // Argument-type derivation for same-arity overload separation
+        // (W-23182862) already ran for this file's references at ingest
+        // (addSymbolTable → resolveArgumentTypesEffect), before its edges were
+        // built; it is idempotent and file-local, so it is not repeated here.
         yield* self.processSymbolReferencesToGraphEffect(
           symbolTable,
           normalizedUri,
@@ -3187,6 +3201,73 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
               `to inherited method in ${resolved.fileUri ?? 'unknown'}`,
           );
           yield* Effect.yieldNow();
+        }
+      }
+    });
+  }
+
+  /**
+   * Phase B of type-aware overload separation (W-23182862): derive positional
+   * `argumentTypes` for each call reference from the raw argument source texts
+   * (`argumentExpressions`) the parser captured in Phase A.
+   *
+   * For each METHOD_CALL / CONSTRUCTOR_CALL reference that has captured argument
+   * texts but no `argumentTypes` yet, resolve each argument:
+   * - literals → their literal type (String/Integer/Boolean/…);
+   * - bare identifiers → the declared type of the local / parameter / field
+   *   they name, looked up in the reference's enclosing scope.
+   *
+   * `argumentTypes` is set only when EVERY argument resolves; if any argument
+   * cannot be typed at this depth (a method-call result, a member chain, a
+   * cast, `new T()`, or an identifier not in scope) the reference is left
+   * without a signature key, so its overload set stays unified — the
+   * conservative, correct degradation rather than a wrong split.
+   *
+   * Runs purely against the file's own symbol table (locals/params/fields are
+   * file-local), so it needs no cross-file graph; it executes after graph
+   * processing only to share the single resolution pass.
+   */
+  private resolveArgumentTypesEffect(
+    symbolTable: SymbolTable,
+  ): Effect.Effect<void, never, never> {
+    return Effect.sync(() => {
+      for (const ref of symbolTable.getAllReferences()) {
+        if (
+          ref.argumentTypes !== undefined ||
+          ref.argumentExpressions === undefined ||
+          (ref.context !== ReferenceContext.METHOD_CALL &&
+            ref.context !== ReferenceContext.CONSTRUCTOR_CALL)
+        ) {
+          continue;
+        }
+
+        // Resolve a bare identifier to the declared type string of the local /
+        // parameter / field it names, searched from the call's enclosing scope.
+        const position = {
+          line: ref.location.identifierRange.startLine,
+          character: ref.location.identifierRange.startColumn,
+        };
+        const scopeHierarchy = symbolTable.getScopeHierarchy(position);
+        const innermostScope =
+          scopeHierarchy.length > 0
+            ? scopeHierarchy[scopeHierarchy.length - 1]
+            : null;
+        const lookupType = (identifier: string): string | undefined => {
+          const symbol = symbolTable.lookup(identifier, innermostScope);
+          if (isVariableSymbol(symbol)) {
+            return (
+              symbol.type?.originalTypeString ?? symbol.type?.name ?? undefined
+            );
+          }
+          return undefined;
+        };
+
+        const argumentTypes = resolveArgumentTypes(
+          ref.argumentExpressions,
+          lookupType,
+        );
+        if (argumentTypes !== undefined) {
+          ref.argumentTypes = argumentTypes;
         }
       }
     });
@@ -3569,6 +3650,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
                     methodName: typeRef.parentContext,
                     isStatic: isStatic,
                     argumentCount: typeRef.argumentCount,
+                    argumentTypes: typeRef.argumentTypes,
                   },
                 );
                 return; // Successfully resolved and added to graph
@@ -3605,6 +3687,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
                 methodName: typeRef.parentContext,
                 isStatic: isStatic,
                 argumentCount: typeRef.argumentCount,
+                argumentTypes: typeRef.argumentTypes,
               },
             );
           }
@@ -3724,6 +3807,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
               methodName: typeRef.parentContext,
               isStatic: isStatic,
               argumentCount: typeRef.argumentCount,
+              argumentTypes: typeRef.argumentTypes,
             },
           );
           return;
@@ -3744,6 +3828,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
             methodName: typeRef.parentContext,
             isStatic: isStatic,
             argumentCount: typeRef.argumentCount,
+            argumentTypes: typeRef.argumentTypes,
           },
         );
       } catch (error) {

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolRefManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolRefManager.ts
@@ -58,6 +58,7 @@ import {
   isMethodOrConstructorSymbol,
 } from '../utils/symbolNarrowing';
 import { calculateFQN } from '../utils/FQNUtils';
+import { doesSignatureMatch } from '../semantics/validation/utils/methodSignatureUtils';
 import { ResourceLoader } from '../utils/resourceLoader';
 import { isApexKeyword } from '../utils/ApexKeywords';
 import { isStandardApexUri } from '../types/ProtocolHandler';
@@ -148,6 +149,11 @@ export interface ReferenceEdge {
     namespace?: string;
     /** Call-site arity, used as the overload discriminator (F11-2). */
     argumentCount?: number;
+    /**
+     * Positional call-site argument type strings, the signature key that
+     * separates same-arity overloads (`f(String)` vs `f(Integer)`, W-23182862).
+     */
+    argumentTypes?: string[];
   };
 }
 
@@ -167,6 +173,11 @@ export interface ReferenceResult {
     namespace?: string;
     /** Call-site arity, used as the overload discriminator (F11-2). */
     argumentCount?: number;
+    /**
+     * Positional call-site argument type strings, the signature key that
+     * separates same-arity overloads (`f(String)` vs `f(Integer)`, W-23182862).
+     */
+    argumentTypes?: string[];
   };
 }
 
@@ -232,6 +243,11 @@ export interface RefStoreEntry {
     namespace?: string;
     /** Call-site arity, used as the overload discriminator (F11-2). */
     argumentCount?: number;
+    /**
+     * Positional call-site argument type strings, the signature key that
+     * separates same-arity overloads (`f(String)` vs `f(Integer)`, W-23182862).
+     */
+    argumentTypes?: string[];
   };
 }
 
@@ -352,6 +368,7 @@ export class ApexSymbolRefManager {
         isStatic?: boolean;
         namespace?: string;
         argumentCount?: number;
+        argumentTypes?: string[];
       };
     }>
   > = new CaseInsensitiveHashMap();
@@ -369,6 +386,7 @@ export class ApexSymbolRefManager {
         isStatic?: boolean;
         namespace?: string;
         argumentCount?: number;
+        argumentTypes?: string[];
       };
     }>
   > = new CaseInsensitiveHashMap();
@@ -844,6 +862,7 @@ export class ApexSymbolRefManager {
       isStatic?: boolean;
       namespace?: string;
       argumentCount?: number;
+      argumentTypes?: string[];
     },
   ): boolean {
     const refEntry: RefStoreEntry = {
@@ -862,6 +881,7 @@ export class ApexSymbolRefManager {
             isStatic: context.isStatic,
             namespace: context.namespace,
             argumentCount: context.argumentCount,
+            argumentTypes: context.argumentTypes,
           }
         : undefined,
     };
@@ -1819,6 +1839,7 @@ export class ApexSymbolRefManager {
       isStatic?: boolean;
       namespace?: string;
       argumentCount?: number;
+      argumentTypes?: string[];
     },
   ): void {
     // Enforce source artifact invariant and normalize URI for stable matching.
@@ -1991,9 +2012,12 @@ export class ApexSymbolRefManager {
    *   whose `context.argumentCount` is undefined (parsed before this field
    *   existed, or non-call edges) are kept — we cannot prove they belong to a
    *   different overload, so we never drop them.
-   * - Same-arity overloads (`f(String)` vs `f(Integer)`) cannot be separated by
-   *   arity alone and remain unified; call-site type capture is the documented
-   *   follow-up.
+   * - Same-arity overloads (`f(String)` vs `f(Integer)`) are separated by
+   *   call-site argument TYPES when those types resolve (W-23182862): a
+   *   reference is dropped only when its `context.argumentTypes` matches a
+   *   different same-arity overload's signature but not the target's. When the
+   *   argument types are unresolved, or match no overload, the reference is
+   *   kept — the set stays unified rather than risk a wrong split.
    * - Applies to constructors as well as methods: constructor overloads
    *   (`Foo()` vs `Foo(String)`) are separated by call-site arity the same way.
    */
@@ -2029,11 +2053,53 @@ export class ApexSymbolRefManager {
     }
 
     const targetArity = symbol.parameters?.length ?? 0;
+
+    // Same-arity siblings (other than the target) are the overloads that arity
+    // alone cannot separate — e.g. `f(String)` vs `f(Integer)`. They drive the
+    // type-aware step below (W-23182862).
+    const sameAritySiblings = siblings.filter(
+      (s) =>
+        s.id !== symbol.id &&
+        isMethodOrConstructorSymbol(s) &&
+        (s.parameters?.length ?? 0) === targetArity,
+    );
+
     return results.filter((r) => {
       const callArity = r.context?.argumentCount;
-      // Keep references we cannot attribute to a specific arity (undefined) and
-      // those whose call-site arity matches this overload's parameter count.
-      return callArity === undefined || callArity === targetArity;
+      // Drop references whose call-site arity is known and differs from this
+      // overload's parameter count.
+      if (callArity !== undefined && callArity !== targetArity) {
+        return false;
+      }
+
+      // Arity matches (or is unknown). When the call-site has resolved argument
+      // types AND there are same-arity siblings, separate by signature: drop
+      // this reference only if its argument types match a DIFFERENT same-arity
+      // overload but NOT the target. If they match the target, or match no
+      // sibling (ambiguous / unresolved), keep it — we never split on a guess.
+      const callArgumentTypes = r.context?.argumentTypes;
+      if (
+        callArity === targetArity &&
+        callArgumentTypes !== undefined &&
+        sameAritySiblings.length > 0
+      ) {
+        const matchesTarget = doesSignatureMatch(
+          symbol,
+          symbol.name,
+          callArgumentTypes,
+        );
+        if (matchesTarget) {
+          return true;
+        }
+        const matchesOtherOverload = sameAritySiblings.some((s) =>
+          doesSignatureMatch(s, s.name, callArgumentTypes),
+        );
+        // Attributable to a different overload and not the target → drop.
+        return !matchesOtherOverload;
+      }
+
+      // No type info, no same-arity ambiguity, or unknown arity: keep.
+      return true;
     });
   }
 
@@ -3599,6 +3665,7 @@ export class ApexSymbolRefManager {
       isStatic?: boolean;
       namespace?: string;
       argumentCount?: number;
+      argumentTypes?: string[];
     },
   ): void {
     if (!sourceSymbol.fileUri) {
@@ -3648,6 +3715,7 @@ export class ApexSymbolRefManager {
       isStatic?: boolean;
       namespace?: string;
       argumentCount?: number;
+      argumentTypes?: string[];
     },
   ): void {
     const virtualSymbolId = generateSymbolId(
@@ -3729,6 +3797,7 @@ export class ApexSymbolRefManager {
       isStatic?: boolean;
       namespace?: string;
       argumentCount?: number;
+      argumentTypes?: string[];
     },
   ): void {
     // Don't create reference entries for scope symbols (they're structural, not semantic)
@@ -3775,6 +3844,7 @@ export class ApexSymbolRefManager {
             isStatic: context.isStatic,
             namespace: context.namespace,
             argumentCount: context.argumentCount,
+            argumentTypes: context.argumentTypes,
           }
         : undefined,
     };
@@ -3803,6 +3873,7 @@ export class ApexSymbolRefManager {
       isStatic?: boolean;
       namespace?: string;
       argumentCount?: number;
+      argumentTypes?: string[];
     },
   ): void {
     if (!sourceSymbol.fileUri) {
@@ -3865,6 +3936,7 @@ export class ApexSymbolRefManager {
           isStatic?: boolean;
           namespace?: string;
           argumentCount?: number;
+          argumentTypes?: string[];
         };
       }>
     | undefined {

--- a/packages/apex-parser-ast/src/symbols/ops/chainResolution.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/chainResolution.ts
@@ -1047,7 +1047,7 @@ export async function resolveFirstNodeAsClass(
     firstNodeName,
     dummyLocation,
     ReferenceContext.CLASS_REFERENCE,
-    undefined, // resolvedSymbolId - will be set during second-pass resolution
+    // resolvedSymbolId set during second-pass resolution
   );
   const builtInSymbol = await self.resolveStandardLibraryType(typeRef);
   if (builtInSymbol) {

--- a/packages/apex-parser-ast/src/symbols/referenceCacheKey.ts
+++ b/packages/apex-parser-ast/src/symbols/referenceCacheKey.ts
@@ -6,7 +6,7 @@
  * repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import type { ApexSymbol } from '../types/symbol';
+import type { ApexSymbol, MethodSymbol } from '../types/symbol';
 import { extractFilePathFromUri } from '../types/UriBasedIdGenerator';
 import { isMethodOrConstructorSymbol } from '../utils/symbolNarrowing';
 
@@ -27,24 +27,38 @@ import { isMethodOrConstructorSymbol } from '../utils/symbolNarrowing';
  * carries the declaring file (normalized the same way symbol IDs and the
  * reverse index are, via {@link extractFilePathFromUri}, so two spellings of
  * one URI don't drift into separate entries) and — for methods AND constructors
- * — the declared arity, the same discriminator the reverse-index overload
- * separation uses. Constructors are overloadable by parameter list too
- * (`Foo()` vs `Foo(String)`), so they need the arity discriminator as well.
+ * — the declared signature: parameter count plus parameter type strings.
+ * Constructors are overloadable by parameter list too (`Foo()` vs
+ * `Foo(String)`), so they need the discriminator as well. The parameter TYPES
+ * (not just the count) are load-bearing now that same-arity overloads are
+ * separated by signature (W-23182862): `use(String)` and `use(Integer)` are
+ * distinct targets with distinct reference sets, so an arity-only key would
+ * collide them and serve one overload's filtered results for the other.
  *
  * The `refs_to_` / `refs_from_` prefixes are load-bearing: the relationship
  * cache is invalidated wholesale by the `^refs_(to|from)_` pattern in
  * `ApexSymbolManager`, so both builders must keep those prefixes.
  */
 
-/** File + arity discriminator shared by both key shapes. */
+/** File + signature discriminator shared by both key shapes. */
 function discriminator(symbol: ApexSymbol): string {
   const filePart = symbol.fileUri
     ? extractFilePathFromUri(symbol.fileUri)
     : 'no-file';
-  const arityPart = isMethodOrConstructorSymbol(symbol)
-    ? `:${symbol.parameters?.length ?? 0}`
-    : '';
-  return `${symbol.name}@${filePart}${arityPart}`;
+  let signaturePart = '';
+  if (isMethodOrConstructorSymbol(symbol)) {
+    const params = (symbol as MethodSymbol).parameters ?? [];
+    // Arity, then the parameter type strings, so same-arity overloads
+    // (`use(String)` vs `use(Integer)`) get distinct keys. Lowercased to match
+    // the case-insensitive signature comparison used in overload separation.
+    const paramTypes = params
+      .map((p) =>
+        (p.type?.originalTypeString ?? p.type?.name ?? '').toLowerCase(),
+      )
+      .join(',');
+    signaturePart = `:${params.length}(${paramTypes})`;
+  }
+  return `${symbol.name}@${filePart}${signaturePart}`;
 }
 
 /** Build the `findReferencesTo` relationship cache key. */

--- a/packages/apex-parser-ast/src/symbols/services/referenceStore.ts
+++ b/packages/apex-parser-ast/src/symbols/services/referenceStore.ts
@@ -37,6 +37,7 @@ export interface ReferenceStoreShape {
       isStatic?: boolean;
       namespace?: string;
       argumentCount?: number;
+      argumentTypes?: string[];
     },
   ) => Effect.Effect<void>;
   readonly findReferencesTo: (

--- a/packages/apex-parser-ast/src/types/symbol.ts
+++ b/packages/apex-parser-ast/src/types/symbol.ts
@@ -1751,6 +1751,53 @@ export class SymbolTable {
   }
 
   /**
+   * Lookup a symbol by name through the lexical scope CHAIN only: the starting
+   * scope, its parent scopes, then file-level roots. Unlike {@link lookup},
+   * this does NOT descend into child/sibling scopes.
+   *
+   * This models real Apex name resolution at a given program point: an
+   * identifier is visible only if declared in the current block, an enclosing
+   * block, or file scope — never in a deeper or sibling block. Callers that
+   * resolve a name AS USED AT A POSITION (e.g. argument-type resolution) must
+   * use this, not {@link lookup}, whose child-descent fallback can wrongly
+   * resolve a name to a same-named local in an unrelated nested block (which is
+   * only reachable from code that does not compile, but still yields a wrong
+   * type at the AST layer).
+   *
+   * @param name The name of the symbol to find
+   * @param startingScope The starting scope (null when at file level)
+   * @returns The symbol if found in the scope chain, undefined otherwise
+   */
+  lookupInScopeChain(
+    name: string,
+    startingScope?: ScopeSymbol | null,
+  ): ApexSymbol | undefined {
+    // Search from the starting scope up through parent scopes.
+    let scope: ScopeSymbol | null = startingScope ?? null;
+    while (scope) {
+      const symbol = this.findSymbolInScope(scope.id, name);
+      if (symbol) {
+        return symbol;
+      }
+      if (scope.parentId) {
+        const parentResult = this.symbolMap.get(scope.parentId);
+        const parent = Array.isArray(parentResult)
+          ? parentResult[0]
+          : parentResult;
+        scope =
+          parent && parent.kind === SymbolKind.Block
+            ? (parent as ScopeSymbol)
+            : null;
+      } else {
+        scope = null;
+      }
+    }
+
+    // Fall back to file-level roots. No child-scope descent.
+    return this.findSymbolInScope(null, name);
+  }
+
+  /**
    * Lookup a symbol by key
    * @param key The key of the symbol to find
    * @returns The symbol if found, undefined otherwise

--- a/packages/apex-parser-ast/src/types/symbolReference.ts
+++ b/packages/apex-parser-ast/src/types/symbolReference.ts
@@ -121,47 +121,93 @@ export interface ChainedSymbolReference extends SymbolReference {
 }
 
 /**
+ * Optional fields of a {@link SymbolReference}, supplied as a single options
+ * object to {@link EnhancedSymbolReference}'s constructor.
+ *
+ * Replaces the former 13-parameter positional optional tail (Peter Hale's #497
+ * review note): a new optional field is added here by name rather than by
+ * widening — and threading `undefined` placeholders through — a long positional
+ * list. The three always-present fields (`name`, `location`, `context`) stay
+ * positional; everything else lives here.
+ */
+export interface SymbolReferenceOptions {
+  resolvedSymbolId?: string;
+  parentContext?: string;
+  access?: 'read' | 'write' | 'readwrite';
+  isStatic?: boolean;
+  literalValue?: string | number | boolean | null;
+  literalType?: 'Integer' | 'Long' | 'Decimal' | 'String' | 'Boolean' | 'Null';
+  chainNodes?: SymbolReference[];
+  resolvedTypeId?: string;
+  resolutionTier?: 'TIER_1' | 'TIER_2';
+  isFullyResolved?: boolean;
+  validatedAccess?: 'read' | 'write' | 'readwrite' | 'invalid';
+  accessValidationState?:
+    | 'syntax_only'
+    | 'partially_validated'
+    | 'fully_validated';
+  argumentTypes?: string[];
+  /** Call-site arity (see {@link SymbolReference.argumentCount}). */
+  argumentCount?: number;
+}
+
+/**
  * Enhanced SymbolReference implementation with computed properties
  */
 export class EnhancedSymbolReference implements SymbolReference {
   private _logger = getLogger();
 
+  public resolvedSymbolId?: string;
+  public parentContext?: string;
+  public access?: 'read' | 'write' | 'readwrite';
+  public isStatic?: boolean;
+  public literalValue?: string | number | boolean | null;
+  public literalType?:
+    | 'Integer'
+    | 'Long'
+    | 'Decimal'
+    | 'String'
+    | 'Boolean'
+    | 'Null';
+  public chainNodes?: SymbolReference[];
+  public resolvedTypeId?: string;
+  public resolutionTier?: 'TIER_1' | 'TIER_2';
+  public isFullyResolved?: boolean;
+  public validatedAccess?: 'read' | 'write' | 'readwrite' | 'invalid';
+  public accessValidationState?:
+    | 'syntax_only'
+    | 'partially_validated'
+    | 'fully_validated';
+  public argumentTypes?: string[];
+  /**
+   * Call-site arity (see {@link SymbolReference.argumentCount}). Like the other
+   * optional fields it is set via the options object; it remains separately
+   * assignable so the parser listener can stamp it after construction once the
+   * argument list is counted.
+   */
+  public argumentCount?: number;
+
   constructor(
     public name: string,
     public location: SymbolLocation,
     public context: ReferenceContext,
-    public resolvedSymbolId?: string,
-    public parentContext?: string,
-    public access?: 'read' | 'write' | 'readwrite',
-    public isStatic?: boolean,
-    public literalValue?: string | number | boolean | null,
-    public literalType?:
-      | 'Integer'
-      | 'Long'
-      | 'Decimal'
-      | 'String'
-      | 'Boolean'
-      | 'Null',
-    public chainNodes?: SymbolReference[],
-    public resolvedTypeId?: string,
-    public resolutionTier?: 'TIER_1' | 'TIER_2',
-    public isFullyResolved?: boolean,
-    public validatedAccess?: 'read' | 'write' | 'readwrite' | 'invalid',
-    public accessValidationState?:
-      | 'syntax_only'
-      | 'partially_validated'
-      | 'fully_validated',
-    public argumentTypes?: string[],
-  ) {}
-
-  /**
-   * Call-site arity (see {@link SymbolReference.argumentCount}). Declared as a
-   * plain assignable field rather than a constructor parameter: the positional
-   * constructor is already long (15+ optional params), so new
-   * discriminator-style fields are set after construction (e.g. by the parser
-   * listener once the argument list is counted) instead of widening it further.
-   */
-  public argumentCount?: number;
+    options: SymbolReferenceOptions = {},
+  ) {
+    this.resolvedSymbolId = options.resolvedSymbolId;
+    this.parentContext = options.parentContext;
+    this.access = options.access;
+    this.isStatic = options.isStatic;
+    this.literalValue = options.literalValue;
+    this.literalType = options.literalType;
+    this.chainNodes = options.chainNodes;
+    this.resolvedTypeId = options.resolvedTypeId;
+    this.resolutionTier = options.resolutionTier;
+    this.isFullyResolved = options.isFullyResolved;
+    this.validatedAccess = options.validatedAccess;
+    this.accessValidationState = options.accessValidationState;
+    this.argumentTypes = options.argumentTypes;
+    this.argumentCount = options.argumentCount;
+  }
 
   // Custom JSON serialization to avoid circular references
   toJSON(): any {
@@ -262,19 +308,12 @@ export class SymbolReferenceFactory {
       methodName,
       location,
       ReferenceContext.METHOD_CALL,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
-      undefined,
-      isStatic,
-      undefined, // literalValue
-      undefined, // literalType
-      undefined, // chainNodes
-      undefined, // resolvedTypeId
-      undefined, // resolutionTier
-      undefined, // isFullyResolved
-      undefined, // validatedAccess
-      undefined, // accessValidationState
-      argumentTypes,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+        isStatic,
+        argumentTypes,
+      },
     );
 
     // Note: For simple qualified references, we don't need complex chain structures
@@ -297,10 +336,11 @@ export class SymbolReferenceFactory {
       methodName,
       methodLocation,
       ReferenceContext.METHOD_CALL,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
-      undefined,
-      isStatic,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+        isStatic,
+      },
     );
 
     return methodRef;
@@ -338,8 +378,10 @@ export class SymbolReferenceFactory {
           isLast
             ? ReferenceContext.CLASS_REFERENCE
             : ReferenceContext.NAMESPACE,
-          undefined, // resolvedSymbolId - will be set during second-pass resolution
-          parentContext,
+          {
+            // resolvedSymbolId set during second-pass resolution
+            parentContext,
+          },
         );
 
         chainNodes.push(nodeRef);
@@ -359,8 +401,10 @@ export class SymbolReferenceFactory {
       typeName,
       location,
       ReferenceContext.TYPE_DECLARATION,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+      },
     );
   }
 
@@ -443,13 +487,10 @@ export class SymbolReferenceFactory {
       return ref;
     }
 
-    return new EnhancedSymbolReference(
-      typeName,
-      location,
-      context,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
+    return new EnhancedSymbolReference(typeName, location, context, {
+      // resolvedSymbolId set during second-pass resolution
       parentContext,
-    );
+    });
   }
 
   /**
@@ -466,10 +507,11 @@ export class SymbolReferenceFactory {
       fieldName,
       location,
       ReferenceContext.FIELD_ACCESS,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
-      access,
-      undefined,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+        access,
+      },
     );
 
     // Note: For simple field access, we don't need complex chain structures
@@ -492,10 +534,11 @@ export class SymbolReferenceFactory {
       fieldName,
       fieldLocation,
       ReferenceContext.FIELD_ACCESS,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
-      access,
-      undefined,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+        access,
+      },
     );
 
     // Note: For simple hierarchical field access, we don't need complex chain structures
@@ -536,8 +579,10 @@ export class SymbolReferenceFactory {
           isLast
             ? ReferenceContext.CONSTRUCTOR_CALL
             : ReferenceContext.NAMESPACE,
-          undefined, // resolvedSymbolId - will be set during second-pass resolution
-          parentContext,
+          {
+            // resolvedSymbolId set during second-pass resolution
+            parentContext,
+          },
         );
 
         chainNodes.push(nodeRef);
@@ -565,13 +610,12 @@ export class SymbolReferenceFactory {
           },
         },
         ReferenceContext.CONSTRUCTOR_CALL, // Final context is CONSTRUCTOR_CALL
-        undefined, // resolvedSymbolId - will be set during second-pass resolution
-        parentContext,
-        undefined,
-        false, // Not static by default
-        undefined,
-        undefined,
-        chainNodes, // Attach chainNodes to final node
+        {
+          // resolvedSymbolId set during second-pass resolution
+          parentContext,
+          isStatic: false, // Not static by default
+          chainNodes, // Attach chainNodes to final node
+        },
       );
 
       return finalRef;
@@ -582,8 +626,10 @@ export class SymbolReferenceFactory {
       typeName,
       location,
       ReferenceContext.CONSTRUCTOR_CALL,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+      },
     );
   }
 
@@ -619,8 +665,10 @@ export class SymbolReferenceFactory {
           isLast
             ? ReferenceContext.CLASS_REFERENCE
             : ReferenceContext.NAMESPACE,
-          undefined, // resolvedSymbolId - will be set during second-pass resolution
-          parentContext,
+          {
+            // resolvedSymbolId set during second-pass resolution
+            parentContext,
+          },
         );
 
         chainNodes.push(nodeRef);
@@ -648,13 +696,12 @@ export class SymbolReferenceFactory {
           },
         },
         ReferenceContext.CLASS_REFERENCE, // Final context is CLASS_REFERENCE
-        undefined, // resolvedSymbolId - will be set during second-pass resolution
-        parentContext,
-        undefined,
-        false, // Not static by default
-        undefined,
-        undefined,
-        chainNodes, // Attach chainNodes to final node
+        {
+          // resolvedSymbolId set during second-pass resolution
+          parentContext,
+          isStatic: false, // Not static by default
+          chainNodes, // Attach chainNodes to final node
+        },
       );
 
       return finalRef;
@@ -665,8 +712,10 @@ export class SymbolReferenceFactory {
       className,
       location,
       ReferenceContext.CLASS_REFERENCE,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+      },
     );
   }
 
@@ -683,9 +732,11 @@ export class SymbolReferenceFactory {
       variableName,
       location,
       ReferenceContext.VARIABLE_USAGE,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
-      access,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+        access,
+      },
     );
   }
 
@@ -701,8 +752,10 @@ export class SymbolReferenceFactory {
       variableName,
       location,
       ReferenceContext.VARIABLE_DECLARATION,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+      },
     );
   }
 
@@ -738,8 +791,10 @@ export class SymbolReferenceFactory {
           isLast
             ? ReferenceContext.CLASS_REFERENCE
             : ReferenceContext.CLASS_REFERENCE,
-          undefined, // resolvedSymbolId - will be set during second-pass resolution
-          parentContext,
+          {
+            // resolvedSymbolId set during second-pass resolution
+            parentContext,
+          },
         );
 
         chainNodes.push(nodeRef);
@@ -759,8 +814,10 @@ export class SymbolReferenceFactory {
       typeName,
       location,
       ReferenceContext.PARAMETER_TYPE,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+      },
     );
   }
 
@@ -776,8 +833,10 @@ export class SymbolReferenceFactory {
       typeName,
       location,
       ReferenceContext.GENERIC_PARAMETER_TYPE,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+      },
     );
   }
 
@@ -793,8 +852,10 @@ export class SymbolReferenceFactory {
       typeName,
       location,
       ReferenceContext.CAST_TYPE_REFERENCE,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+      },
     );
   }
 
@@ -810,8 +871,10 @@ export class SymbolReferenceFactory {
       typeName,
       location,
       ReferenceContext.INSTANCEOF_TYPE_REFERENCE,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+      },
     );
   }
 
@@ -833,15 +896,12 @@ export class SymbolReferenceFactory {
 
     if (parts.length === 1) {
       // Single part - no hierarchy needed
-      return new EnhancedSymbolReference(
-        parts[0],
-        locations[0],
-        context,
-        undefined, // resolvedSymbolId - will be set during second-pass resolution
+      return new EnhancedSymbolReference(parts[0], locations[0], context, {
+        // resolvedSymbolId set during second-pass resolution
         parentContext,
         access,
         isStatic,
-      );
+      });
     }
 
     // Create the main reference (the last part)
@@ -849,10 +909,12 @@ export class SymbolReferenceFactory {
       parts[parts.length - 1],
       locations[locations.length - 1],
       context,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
-      access,
-      isStatic,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+        access,
+        isStatic,
+      },
     );
 
     return mainRef;
@@ -902,13 +964,13 @@ export class SymbolReferenceFactory {
         },
       },
       finalNode.context, // Use final node's context (FIELD_ACCESS, METHOD_CALL, etc.)
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
-      finalNode.access, // Use final node's access
-      finalNode.isStatic,
-      undefined,
-      undefined,
-      chainNodes, // Attach chainNodes to final node
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+        access: finalNode.access, // Use final node's access
+        isStatic: finalNode.isStatic,
+        chainNodes, // Attach chainNodes to final node
+      },
     );
 
     return finalRef;
@@ -958,13 +1020,12 @@ export class SymbolReferenceFactory {
         },
       },
       finalNode.context, // Use final node's context (typically CLASS_REFERENCE)
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
-      undefined,
-      false, // Not static by default
-      undefined,
-      undefined,
-      chainNodes, // Attach chainNodes to final node
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+        isStatic: false, // Not static by default
+        chainNodes, // Attach chainNodes to final node
+      },
     );
 
     return finalRef;
@@ -1003,8 +1064,10 @@ export class SymbolReferenceFactory {
           isLast
             ? ReferenceContext.CLASS_REFERENCE
             : ReferenceContext.NAMESPACE,
-          undefined, // resolvedSymbolId - will be set during second-pass resolution
-          parentContext,
+          {
+            // resolvedSymbolId set during second-pass resolution
+            parentContext,
+          },
         );
 
         chainNodes.push(nodeRef);
@@ -1024,8 +1087,10 @@ export class SymbolReferenceFactory {
       typeName,
       location,
       ReferenceContext.RETURN_TYPE,
-      undefined, // resolvedSymbolId - will be set during second-pass resolution
-      parentContext,
+      {
+        // resolvedSymbolId set during second-pass resolution
+        parentContext,
+      },
     );
   }
 

--- a/packages/apex-parser-ast/src/types/symbolReference.ts
+++ b/packages/apex-parser-ast/src/types/symbolReference.ts
@@ -84,6 +84,17 @@ export interface SymbolReference {
    */
   argumentTypes?: string[];
   /**
+   * Optional: raw source text of each positional call-site argument for a
+   * METHOD_CALL / CONSTRUCTOR_CALL reference, in order (e.g. `['"hi"', 'x']`
+   * for `f("hi", x)`). Captured syntactically at parse time as the *input* to
+   * semantic argument-type resolution: the argument-expression AST does not
+   * survive the listener walk, so the text is lifted onto the reference here so
+   * the semantic phase can resolve each argument to a type and populate
+   * {@link argumentTypes}. Not a signature key itself — once {@link argumentTypes}
+   * is derived this is no longer consulted. Undefined for non-call references.
+   */
+  argumentExpressions?: string[];
+  /**
    * Optional: number of call-site arguments for a METHOD_CALL / CONSTRUCTOR_CALL
    * reference (the call's own arity, e.g. `2` for `f('x', y)`). Unlike
    * {@link argumentTypes} this is statically knowable at parse time without type
@@ -186,6 +197,13 @@ export class EnhancedSymbolReference implements SymbolReference {
    * argument list is counted.
    */
   public argumentCount?: number;
+  /**
+   * Raw call-site argument source texts (see
+   * {@link SymbolReference.argumentExpressions}). Stamped by the parser listener
+   * after construction, alongside {@link argumentCount}; consumed by semantic
+   * resolution to populate {@link argumentTypes}.
+   */
+  public argumentExpressions?: string[];
 
   constructor(
     public name: string,
@@ -229,6 +247,7 @@ export class EnhancedSymbolReference implements SymbolReference {
       accessValidationState: this.accessValidationState,
       argumentTypes: this.argumentTypes,
       argumentCount: this.argumentCount,
+      argumentExpressions: this.argumentExpressions,
     };
 
     // Add chained expression info without circular references

--- a/packages/apex-parser-ast/src/utils/argumentTypeResolution.ts
+++ b/packages/apex-parser-ast/src/utils/argumentTypeResolution.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Semantic resolution of call-site argument source texts to type strings, the
+ * second phase of type-aware overload separation (W-23182862).
+ *
+ * Phase A (parser listeners) captures each argument's raw source text onto the
+ * reference as `argumentExpressions`. This module turns those texts into the
+ * positional `argumentTypes` signature key used to separate same-arity
+ * overloads (`f(String)` vs `f(Integer)`).
+ *
+ * Scope (deliberate): literal arguments and simple identifier arguments
+ * (locals, parameters, fields) only. Anything that would require deeper
+ * resolution — method-call results `f(g())`, member chains `f(a.b)`, casts,
+ * `new T()` — is intentionally NOT resolved here. When any one argument cannot
+ * be typed, the whole call's `argumentTypes` is left undefined so the overload
+ * set stays unified: a conservative, correct degradation rather than a wrong
+ * split. This is not a fallback papering over a defect — it is the right answer
+ * when static type information is genuinely absent at this resolution depth.
+ */
+
+/**
+ * Type string of a simple Apex literal, or `undefined` if the text is not a
+ * literal this resolver recognizes (it may still be an identifier — see
+ * {@link resolveArgumentType}).
+ *
+ * Mirrors the literal kinds the parser records in
+ * `SymbolReference.literalType`: String, Boolean, Null, Long, Integer, Decimal.
+ * Operates on the trimmed argument source text as captured by `getText()`.
+ */
+export const literalTypeOfExpression = (text: string): string | undefined => {
+  const t = text.trim();
+  if (t.length === 0) return undefined;
+
+  // String literal: single-quoted (Apex has no double-quoted strings).
+  if (t.length >= 2 && t.startsWith("'") && t.endsWith("'")) {
+    return 'String';
+  }
+  if (t === 'true' || t === 'false') return 'Boolean';
+  if (t === 'null') return 'Null';
+
+  // Numeric literals. Apex: Long has an `l`/`L` suffix; a decimal point (or
+  // exponent-free fractional) is Decimal; otherwise an integer literal.
+  if (/^-?\d+[lL]$/.test(t)) return 'Long';
+  if (/^-?\d+$/.test(t)) return 'Integer';
+  if (/^-?\d*\.\d+$/.test(t) || /^-?\d+\.\d*$/.test(t)) return 'Decimal';
+
+  return undefined;
+};
+
+/**
+ * True when the text is a bare identifier (a candidate local/parameter/field
+ * name), as opposed to a literal, a dotted chain, a call, or any other
+ * expression. Only bare identifiers are resolved via scope lookup.
+ */
+export const isBareIdentifier = (text: string): boolean =>
+  /^[A-Za-z_]\w*$/.test(text.trim());
+
+/**
+ * Resolve a single argument's source text to its type string.
+ *
+ * 1. Recognized literal → its literal type ({@link literalTypeOfExpression}).
+ * 2. Bare identifier → `lookupType(name)`, the declared type of the local /
+ *    parameter / field it names (caller supplies the scope-aware lookup).
+ * 3. Anything else (or an identifier that does not resolve) → `undefined`.
+ *
+ * @param text The trimmed argument source text (one entry of
+ *   `SymbolReference.argumentExpressions`).
+ * @param lookupType Resolves a bare identifier name to its declared type
+ *   string, or `undefined` if not found in scope.
+ */
+export const resolveArgumentType = (
+  text: string,
+  lookupType: (identifier: string) => string | undefined,
+): string | undefined => {
+  const literal = literalTypeOfExpression(text);
+  if (literal) return literal;
+
+  const t = text.trim();
+  if (isBareIdentifier(t)) {
+    return lookupType(t);
+  }
+
+  return undefined;
+};
+
+/**
+ * Resolve every argument of a call to its type string, returning the positional
+ * `argumentTypes` signature key — or `undefined` if ANY argument cannot be
+ * typed (so the call stays name-/arity-keyed and its overload set unified).
+ *
+ * An empty `argumentExpressions` (a no-arg call `f()`) yields `[]`: a fully
+ * known, zero-length signature.
+ *
+ * @param argumentExpressions Per-argument source texts (Phase A capture).
+ * @param lookupType Scope-aware identifier→type resolver (see
+ *   {@link resolveArgumentType}).
+ */
+export const resolveArgumentTypes = (
+  argumentExpressions: readonly string[],
+  lookupType: (identifier: string) => string | undefined,
+): string[] | undefined => {
+  const resolved: string[] = [];
+  for (const expr of argumentExpressions) {
+    const type = resolveArgumentType(expr, lookupType);
+    if (type === undefined) {
+      return undefined;
+    }
+    resolved.push(type);
+  }
+  return resolved;
+};

--- a/packages/apex-parser-ast/src/utils/contextTypeGuards.ts
+++ b/packages/apex-parser-ast/src/utils/contextTypeGuards.ts
@@ -275,3 +275,42 @@ export function countConstructorArguments(ctx: NewExpressionContext): number {
   const rest = ctx.creator()?.classCreatorRest?.();
   return rest?.arguments()?.expressionList()?.expression_list()?.length ?? 0;
 }
+
+/**
+ * Raw source text of each positional argument in an `expressionList`, in order.
+ *
+ * This is a purely *syntactic* capture — `expr.getText()` of each argument
+ * expression, e.g. `['"hi"', 'x', 'new Account()']` for `f("hi", x, new
+ * Account())`. It deliberately does NOT resolve types: an identifier argument
+ * stays as its source name (`x`), to be resolved to a declared type later
+ * during semantic resolution. Capturing it here is necessary because the
+ * argument-expression AST does not survive the parser listener walk — only the
+ * reference object persists — so the raw text must be lifted onto the reference
+ * now for the semantic phase to work with.
+ */
+const argumentExpressionTexts = (
+  list: ExpressionListContext | null,
+): string[] => (list?.expression_list() ?? []).map((expr) => expr.getText());
+
+/**
+ * Positional source texts of a method call's arguments (see
+ * {@link argumentExpressionTexts}). Mirrors {@link countCallArguments}; returns
+ * `[]` for a bare call `f()`.
+ */
+export function callArgumentExpressions(
+  ctx: MethodCallContext | DotMethodCallContext,
+): string[] {
+  return argumentExpressionTexts(ctx.expressionList());
+}
+
+/**
+ * Positional source texts of a constructor call's arguments (see
+ * {@link argumentExpressionTexts}). Mirrors {@link countConstructorArguments};
+ * returns `[]` for `new Foo()` or a non-class creator.
+ */
+export function constructorArgumentExpressions(
+  ctx: NewExpressionContext,
+): string[] {
+  const rest = ctx.creator()?.classCreatorRest?.();
+  return argumentExpressionTexts(rest?.arguments()?.expressionList() ?? null);
+}

--- a/packages/apex-parser-ast/test/references/overloadSeparation.test.ts
+++ b/packages/apex-parser-ast/test/references/overloadSeparation.test.ts
@@ -16,9 +16,12 @@
  * through the reverse index, and findReferencesTo filters the union down to the
  * call sites whose arity matches the requested overload's parameter count.
  *
- * Scope: arity-distinct overloads (f() vs f(x) vs f(x, y)) — the common case.
- * Same-arity / different-type overloads (f(String) vs f(Integer)) cannot be
- * separated by arity alone and remain unified (documented follow-up).
+ * Scope: arity-distinct overloads (f() vs f(x) vs f(x, y)) — the common case —
+ * AND same-arity / different-type overloads (f(String) vs f(Integer)), which
+ * are separated by call-site argument TYPES once those types resolve
+ * (W-23182862). When a call's argument types do not resolve, that call stays
+ * attributed to every same-arity overload (the conservative, no-wrong-split
+ * degradation).
  */
 
 import { ApexSymbolManager } from '../../src/symbols/ApexSymbolManager';
@@ -173,11 +176,29 @@ describe('per-overload reference separation (F11-2 core)', () => {
     expect(callSite).toBeDefined();
   });
 
-  it('keeps same-arity overloads unified (documented arity-only limit)', async () => {
+  /** Find a `use`/1 overload by its single parameter's declared type. */
+  const useOverloadByParamType = async (
+    fileUri: string,
+    paramType: string,
+  ): Promise<ApexSymbol> => {
+    const symbols = await symbolManager.findSymbolsInFile(fileUri);
+    const match = symbols.find(
+      (s) =>
+        s.kind === SymbolKind.Method &&
+        s.name === 'use' &&
+        isMethodSymbol(s) &&
+        s.parameters?.[0]?.type?.originalTypeString === paramType,
+    );
+    if (!match) {
+      throw new Error(`No use(${paramType}) overload found in ${fileUri}`);
+    }
+    return match;
+  };
+
+  it('separates same-arity overloads by literal argument type (F11-2 type-aware)', async () => {
     const URI = 'file:///test/SameArity.cls';
-    // Two one-arg overloads distinguished only by type. Arity cannot separate
-    // them, so a query for either returns both call sites — the documented
-    // limit until call-site type capture lands.
+    // Two one-arg overloads distinguished only by parameter type. Arity cannot
+    // separate them; call-site argument TYPES (String vs Integer literal) do.
     await compileAndAdd(
       `public class SameArity {
          public void use(String s) {}
@@ -191,12 +212,72 @@ describe('per-overload reference separation (F11-2 core)', () => {
     );
     await resolveCrossFile(URI);
 
-    const useString = await methodByArity(URI, 'use', 1);
+    const useString = await useOverloadByParamType(URI, 'String');
+    const useInteger = await useOverloadByParamType(URI, 'Integer');
+
+    const refsToString = await symbolManager.findReferencesTo(useString);
+    const refsToInteger = await symbolManager.findReferencesTo(useInteger);
+
+    // Each overload sees only its own call site.
+    expect(refsToString.map((r) => r.context?.argumentTypes)).toEqual([
+      ['String'],
+    ]);
+    expect(refsToInteger.map((r) => r.context?.argumentTypes)).toEqual([
+      ['Integer'],
+    ]);
+  });
+
+  it('separates same-arity overloads by local-variable argument type', async () => {
+    const URI = 'file:///test/SameArityVars.cls';
+    // Arguments are locals, not literals: their types are resolved from the
+    // enclosing scope during semantic resolution (Phase B).
+    await compileAndAdd(
+      `public class SameArityVars {
+         public void use(String s) {}
+         public void use(Integer i) {}
+         public void caller() {
+           String text = 'x';
+           Integer num = 1;
+           use(text);
+           use(num);
+         }
+       }`,
+      URI,
+    );
+    await resolveCrossFile(URI);
+
+    const useString = await useOverloadByParamType(URI, 'String');
+    const useInteger = await useOverloadByParamType(URI, 'Integer');
+
+    expect(await symbolManager.findReferencesTo(useString)).toHaveLength(1);
+    expect(await symbolManager.findReferencesTo(useInteger)).toHaveLength(1);
+  });
+
+  it('keeps same-arity overloads unified when an argument type is unresolved', async () => {
+    const URI = 'file:///test/SameArityUnresolved.cls';
+    // The argument is a method-call result, which Phase B intentionally does
+    // NOT resolve. With no signature key, neither overload can claim the call,
+    // so it stays attributed to both — the conservative, no-wrong-split path.
+    await compileAndAdd(
+      `public class SameArityUnresolved {
+         public void use(String s) {}
+         public void use(Integer i) {}
+         public String mk() { return 'x'; }
+         public void caller() {
+           use(mk());
+         }
+       }`,
+      URI,
+    );
+    await resolveCrossFile(URI);
+
+    const useString = await useOverloadByParamType(URI, 'String');
     const refs = await symbolManager.findReferencesTo(useString);
 
-    // Both same-arity call sites surface (arity 1 each); not separated.
-    const arity1Calls = refs.filter((r) => r.context?.argumentCount === 1);
-    expect(arity1Calls.length).toBeGreaterThanOrEqual(2);
+    // The unresolved-argument call site is retained (not dropped on a guess).
+    const callSite = refs.find((r) => r.context?.argumentCount === 1);
+    expect(callSite).toBeDefined();
+    expect(callSite?.context?.argumentTypes).toBeUndefined();
   });
 
   /** Find a constructor symbol by declared parameter count. */
@@ -257,10 +338,11 @@ describe('per-overload reference separation (F11-2 core)', () => {
   // LISTENER-DRIFT GUARD. The compileAndAdd helper uses
   // ApexSymbolCollectorListener, but the worker topology collects references
   // via VisibilitySymbolListener + { collectReferences: true } — a DIFFERENT
-  // pass (ApexReferenceCollectorListener). The argumentCount discriminator was
-  // added to BOTH listeners; this asserts the worker pass also stamps it, so
-  // the two cannot drift apart and silently disable overload separation live.
-  it('worker reference pass stamps call-site argumentCount on METHOD_CALL refs', () => {
+  // pass (ApexReferenceCollectorListener). The argumentCount discriminator AND
+  // the argumentExpressions capture were added to BOTH listeners; this asserts
+  // the worker pass also stamps them, so the two cannot drift apart and
+  // silently disable overload separation live.
+  it('worker reference pass stamps call-site argumentCount + argumentExpressions on METHOD_CALL refs', () => {
     const table = new SymbolTable();
     const listener = new VisibilitySymbolListener('public-api', table);
     const result = compilerService.compile(
@@ -286,5 +368,14 @@ describe('per-overload reference separation (F11-2 core)', () => {
       .map((r) => r.argumentCount)
       .sort((a, b) => (a ?? -1) - (b ?? -1));
     expect(arities).toEqual([0, 1, 2]);
+
+    // The worker pass must also capture raw argument source texts (Phase A),
+    // the input semantic resolution turns into the argumentTypes signature key.
+    const exprsByArity = new Map(
+      callRefs.map((r) => [r.argumentCount, r.argumentExpressions]),
+    );
+    expect(exprsByArity.get(0)).toEqual([]);
+    expect(exprsByArity.get(1)).toEqual(["'hi'"]);
+    expect(exprsByArity.get(2)).toEqual(["'a'", "'b'"]);
   });
 });

--- a/packages/apex-parser-ast/test/references/signatureKeying.test.ts
+++ b/packages/apex-parser-ast/test/references/signatureKeying.test.ts
@@ -185,3 +185,34 @@ describe('signature keying — F11-2 SymbolReference.argumentCount', () => {
     expect(wire.argumentCount).toBe(3);
   });
 });
+
+describe('signature keying — W-23182862 SymbolReference.argumentExpressions', () => {
+  it('argumentExpressions is a plain post-construction field', () => {
+    // Stamped by the parser listener after construction (alongside
+    // argumentCount); the raw arg texts are the input to semantic argument-type
+    // resolution.
+    const ref = SymbolReferenceFactory.createMethodCallReference(
+      'f',
+      LOCATION,
+      'caller',
+    );
+    expect(ref.argumentExpressions).toBeUndefined();
+
+    ref.argumentExpressions = ["'hi'", 'x'];
+    expect(ref.argumentExpressions).toEqual(["'hi'", 'x']);
+  });
+
+  it('argumentExpressions survives JSON serialization (worker pass captures, data-owner resolves)', () => {
+    // Phase A runs on the (possibly worker) reference pass; Phase B resolves on
+    // the data-owner. The captured texts must cross the wire intact.
+    const ref = new EnhancedSymbolReference(
+      'f',
+      LOCATION,
+      ReferenceContext.METHOD_CALL,
+    );
+    ref.argumentExpressions = ["'hi'", 'x'];
+
+    const wire = JSON.parse(JSON.stringify(ref));
+    expect(wire.argumentExpressions).toEqual(["'hi'", 'x']);
+  });
+});

--- a/packages/apex-parser-ast/test/references/signatureKeying.test.ts
+++ b/packages/apex-parser-ast/test/references/signatureKeying.test.ts
@@ -146,19 +146,11 @@ describe('signature keying — F11-2 SymbolReference.argumentTypes', () => {
       'f',
       LOCATION,
       ReferenceContext.METHOD_CALL,
-      undefined,
-      'caller',
-      undefined,
-      false,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      ['String', 'List<Integer>'],
+      {
+        parentContext: 'caller',
+        isStatic: false,
+        argumentTypes: ['String', 'List<Integer>'],
+      },
     );
 
     const wire = JSON.parse(JSON.stringify(ref));

--- a/packages/apex-parser-ast/test/symbols/CrossFileEdgePopulation.test.ts
+++ b/packages/apex-parser-ast/test/symbols/CrossFileEdgePopulation.test.ts
@@ -243,11 +243,11 @@ describe('Cross-file edge population (W-22692421)', () => {
         },
       };
       symbolTable.addTypeReference(
+        // resolvedSymbolId omitted: UNRESOLVED — triggers name-match fallback
         new EnhancedSymbolReference(
           'total',
           injectedLoc,
           ReferenceContext.VARIABLE_USAGE,
-          undefined, // resolvedSymbolId: UNRESOLVED — triggers name-match fallback
         ),
       );
 

--- a/packages/apex-parser-ast/test/types/symbol.test.ts
+++ b/packages/apex-parser-ast/test/types/symbol.test.ts
@@ -862,6 +862,104 @@ describe('SymbolTable', () => {
     expect(table.lookup('nonExistentVar', childScope ?? null)).toBeUndefined();
   });
 
+  it('lookupInScopeChain resolves through parents and roots but NOT into child scopes', () => {
+    table.setFileUri('test://scopeChain.cls');
+    const fileLocation: SymbolLocation = {
+      symbolRange: { startLine: 1, startColumn: 0, endLine: 20, endColumn: 0 },
+      identifierRange: {
+        startLine: 1,
+        startColumn: 0,
+        endLine: 1,
+        endColumn: 0,
+      },
+    };
+    const fileScope = table.enterScope('file', 'file', fileLocation);
+
+    // A file-level (root) symbol, and a method body scope under it.
+    const rootSymbol: ApexSymbol = {
+      name: 'rootVar',
+      kind: SymbolKind.Variable,
+      ...MOCK_SYMBOL_PROPS,
+      id: 'root-var-id',
+      parentId: fileScope?.id ?? null,
+    };
+    table.addSymbol(rootSymbol, fileScope ?? null);
+
+    const methodLocation: SymbolLocation = {
+      symbolRange: { startLine: 2, startColumn: 0, endLine: 18, endColumn: 0 },
+      identifierRange: {
+        startLine: 2,
+        startColumn: 0,
+        endLine: 2,
+        endColumn: 6,
+      },
+    };
+    const methodScope = table.enterScope(
+      'methodScope',
+      'block',
+      methodLocation,
+      undefined,
+      fileScope ?? null,
+    );
+    const methodLocal: ApexSymbol = {
+      name: 'methodVar',
+      kind: SymbolKind.Variable,
+      ...MOCK_SYMBOL_PROPS,
+      id: 'method-var-id',
+      parentId: methodScope?.id ?? null,
+    };
+    table.addSymbol(methodLocal, methodScope ?? null);
+
+    // A nested block inside the method, declaring `nestedVar`. In real Apex
+    // `nestedVar` is NOT visible from the method body — only from inside the
+    // nested block.
+    const nestedLocation: SymbolLocation = {
+      symbolRange: { startLine: 5, startColumn: 0, endLine: 8, endColumn: 0 },
+      identifierRange: {
+        startLine: 5,
+        startColumn: 0,
+        endLine: 5,
+        endColumn: 6,
+      },
+    };
+    const nestedScope = table.enterScope(
+      'nestedScope',
+      'block',
+      nestedLocation,
+      undefined,
+      methodScope ?? null,
+    );
+    const nestedLocal: ApexSymbol = {
+      name: 'nestedVar',
+      kind: SymbolKind.Variable,
+      ...MOCK_SYMBOL_PROPS,
+      id: 'nested-var-id',
+      parentId: nestedScope?.id ?? null,
+    };
+    table.addSymbol(nestedLocal, nestedScope ?? null);
+
+    // Parents + roots resolve as usual.
+    expect(table.lookupInScopeChain('methodVar', methodScope ?? null)).toBe(
+      methodLocal,
+    );
+    expect(table.lookupInScopeChain('rootVar', methodScope ?? null)).toBe(
+      rootSymbol,
+    );
+
+    // The bug guard: from the method body, `nestedVar` (declared only in a
+    // child block) must NOT resolve. lookup() descends into children and finds
+    // it; lookupInScopeChain() must not.
+    expect(table.lookup('nestedVar', methodScope ?? null)).toBe(nestedLocal);
+    expect(
+      table.lookupInScopeChain('nestedVar', methodScope ?? null),
+    ).toBeUndefined();
+
+    // From inside the nested block, `nestedVar` is in scope and resolves.
+    expect(table.lookupInScopeChain('nestedVar', nestedScope ?? null)).toBe(
+      nestedLocal,
+    );
+  });
+
   it('should look up a symbol by its key', () => {
     const symbol: ApexSymbol = {
       name: 'myVar',

--- a/packages/apex-parser-ast/test/utils/argumentTypeResolution.test.ts
+++ b/packages/apex-parser-ast/test/utils/argumentTypeResolution.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Unit tests for the pure argument-type resolution utility (W-23182862,
+ * Phase B). These cover literal classification, identifier lookup delegation,
+ * and the all-or-nothing contract that keeps same-arity overloads unified when
+ * any argument is unresolvable.
+ */
+
+import {
+  literalTypeOfExpression,
+  isBareIdentifier,
+  resolveArgumentType,
+  resolveArgumentTypes,
+} from '../../src/utils/argumentTypeResolution';
+
+describe('literalTypeOfExpression', () => {
+  it('classifies string literals (single-quoted)', () => {
+    expect(literalTypeOfExpression("'hi'")).toBe('String');
+    expect(literalTypeOfExpression("''")).toBe('String');
+  });
+
+  it('classifies boolean and null literals', () => {
+    expect(literalTypeOfExpression('true')).toBe('Boolean');
+    expect(literalTypeOfExpression('false')).toBe('Boolean');
+    expect(literalTypeOfExpression('null')).toBe('Null');
+  });
+
+  it('classifies numeric literals (Integer / Long / Decimal)', () => {
+    expect(literalTypeOfExpression('42')).toBe('Integer');
+    expect(literalTypeOfExpression('-7')).toBe('Integer');
+    expect(literalTypeOfExpression('42L')).toBe('Long');
+    expect(literalTypeOfExpression('10l')).toBe('Long');
+    expect(literalTypeOfExpression('3.14')).toBe('Decimal');
+    expect(literalTypeOfExpression('.5')).toBe('Decimal');
+    expect(literalTypeOfExpression('5.')).toBe('Decimal');
+  });
+
+  it('returns undefined for identifiers and non-literal expressions', () => {
+    expect(literalTypeOfExpression('x')).toBeUndefined();
+    expect(literalTypeOfExpression('foo()')).toBeUndefined();
+    expect(literalTypeOfExpression('a.b')).toBeUndefined();
+    expect(literalTypeOfExpression('')).toBeUndefined();
+  });
+});
+
+describe('isBareIdentifier', () => {
+  it('accepts simple identifiers', () => {
+    expect(isBareIdentifier('x')).toBe(true);
+    expect(isBareIdentifier('myVar')).toBe(true);
+    expect(isBareIdentifier('_under1')).toBe(true);
+  });
+
+  it('rejects literals, chains, calls, and casts', () => {
+    expect(isBareIdentifier("'hi'")).toBe(false);
+    expect(isBareIdentifier('42')).toBe(false);
+    expect(isBareIdentifier('a.b')).toBe(false);
+    expect(isBareIdentifier('f()')).toBe(false);
+    expect(isBareIdentifier('(String) x')).toBe(false);
+  });
+});
+
+describe('resolveArgumentType', () => {
+  const lookup = (id: string): string | undefined =>
+    ({ name: 'String', count: 'Integer' })[id];
+
+  it('resolves a literal without consulting the lookup', () => {
+    let consulted = false;
+    const spy = (id: string): string | undefined => {
+      consulted = true;
+      return lookup(id);
+    };
+    expect(resolveArgumentType("'x'", spy)).toBe('String');
+    expect(consulted).toBe(false);
+  });
+
+  it('resolves a bare identifier via the lookup', () => {
+    expect(resolveArgumentType('name', lookup)).toBe('String');
+    expect(resolveArgumentType('count', lookup)).toBe('Integer');
+  });
+
+  it('returns undefined for an identifier not in scope', () => {
+    expect(resolveArgumentType('missing', lookup)).toBeUndefined();
+  });
+
+  it('returns undefined for non-identifier, non-literal expressions', () => {
+    expect(resolveArgumentType('f()', lookup)).toBeUndefined();
+    expect(resolveArgumentType('a.b', lookup)).toBeUndefined();
+  });
+});
+
+describe('resolveArgumentTypes (all-or-nothing)', () => {
+  const lookup = (id: string): string | undefined =>
+    ({ s: 'String', n: 'Integer' })[id];
+
+  it('returns the positional types when every argument resolves', () => {
+    expect(resolveArgumentTypes(["'lit'", 's', 'n'], lookup)).toEqual([
+      'String',
+      'String',
+      'Integer',
+    ]);
+  });
+
+  it('returns [] for a no-argument call', () => {
+    expect(resolveArgumentTypes([], lookup)).toEqual([]);
+  });
+
+  it('returns undefined if ANY argument is unresolvable (stays unified)', () => {
+    expect(resolveArgumentTypes(['s', 'mk()'], lookup)).toBeUndefined();
+    expect(resolveArgumentTypes(['unknownVar'], lookup)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Completes overload-aware `findReferences` by separating **same-arity** method/constructor overloads — `use(String)` vs `use(Integer)` — which arity-based separation (F11-2, #501) could not distinguish. A query for one overload now returns only its own call sites.

The work item asks to populate `SymbolReference.argumentTypes` during semantic resolution. Investigation showed the argument-expression AST does **not** survive the parser listener walk, so type derivation cannot happen purely at resolution time. The implementation is therefore two-phase:

1. **Phase A — parse-time capture.** Both reference listeners (`ApexSymbolCollectorListener` and the worker-pass `ApexReferenceCollectorListener`) capture each call argument's raw source text into a new `SymbolReference.argumentExpressions`, alongside the existing `argumentCount`. New helpers `callArgumentExpressions` / `constructorArgumentExpressions` mirror the count helpers. No type derivation here.
2. **Phase B — semantic resolution.** `resolveArgumentTypesEffect` runs at symbol-table ingest (before reverse-index edges are built) and derives positional `argumentTypes` from the captured texts: literals classified directly; bare identifiers (locals/parameters/fields) resolved to their declared type via enclosing-scope lookup. **All-or-nothing:** if any argument cannot be typed at this depth (method-call result, member chain, cast, `new T()`, or an out-of-scope identifier), `argumentTypes` is left undefined and the overload set **stays unified**.

### Scope (deliberate)

Per the no-fallbacks design standard, the conservative degradation is a *correct* answer, not a paper-over: when call-site argument types are genuinely unresolvable at this depth, separating would risk a **wrong** split, so the references stay attributed to every same-arity overload. Literals and simple identifier arguments cover the overwhelming majority of real overload call sites; deeper resolution (chained/method-result arguments) is intentionally out of scope.

### Key changes

- **Matcher:** `separateOverloadReferences` drops a reference from a same-arity sibling set only when its `argumentTypes` match a *different* overload's signature but not the target's (via `doesSignatureMatch`). Unresolved/ambiguous → kept.
- **Reference relationship cache key:** extended from `name@file:arity` to include parameter type strings. Same-arity overloads previously collided on one cache entry and served each other's filtered results; the signature-keyed entry fixes this.
- **Context threading:** `argumentTypes` is threaded through `ReferenceResult.context`, `referenceStore`, and both `addReference` edge-builder paths the same way `argumentCount` is.
- **#497 review note folded in:** the 16-parameter positional `EnhancedSymbolReference` constructor is converted to an options object (separate prep commit), so new optional fields are added by name rather than by widening the positional list.

### Testing

- Same-arity separation by **literal** argument type and by **local-variable** argument type.
- The **unresolved-argument degradation** (a `mk()`-result argument keeps the call attributed to both overloads).
- Pure-unit coverage of the `argumentTypeResolution` utility (literal classification, identifier delegation, all-or-nothing contract).
- Extended the listener-drift guard to assert the worker pass also stamps `argumentExpressions`.
- Full monorepo suite green via pre-commit hook (4629 passed, 0 failed).

### What issues does this PR fix or reference?
@W-23182862@
