### PR TITLE
fix(apex-lsp-parser-ast): resolve class references used only as qualifiers - W-23255936

### DIFF
--- a/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
@@ -3887,39 +3887,83 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
         return;
       }
 
-      // Instance qualifier (obj.foo()) — the head is a value, not a type. Don't
-      // attribute it to a class with the same name.
-      const qualifierAsValue = symbolTable
-        .getAllSymbols()
-        .find(
-          (s) =>
-            s.name === head &&
-            (s.kind === SymbolKind.Variable ||
-              s.kind === SymbolKind.Field ||
-              s.kind === SymbolKind.Parameter),
+      const isValueKind = (s: ApexSymbol): boolean =>
+        s.kind === SymbolKind.Variable ||
+        s.kind === SymbolKind.Field ||
+        s.kind === SymbolKind.Parameter;
+      const isTypeKind = (s: ApexSymbol): boolean =>
+        s.kind === SymbolKind.Class ||
+        s.kind === SymbolKind.Interface ||
+        s.kind === SymbolKind.Enum;
+
+      // Determine whether the head is a VALUE (instance qualifier `obj.foo()`)
+      // or a TYPE (static qualifier `A.foo()`) in a SCOPE-AWARE way. A file-wide
+      // name match (getAllSymbols) is wrong: a local/field/param named like a
+      // class anywhere in the file would silently suppress the head edge for
+      // every qualified reference in the file.
+      let headType: ApexSymbol | undefined;
+
+      // Preferred: the chain resolution already bound the head node to a symbol
+      // (see resolution path that sets chainNodes[0].resolvedSymbolId). That
+      // binding is scope-correct, so trust it.
+      const resolvedHeadId =
+        isChainedSymbolReference(typeRef) &&
+        typeRef.chainNodes?.[0]?.resolvedSymbolId
+          ? typeRef.chainNodes[0].resolvedSymbolId
+          : undefined;
+      if (resolvedHeadId) {
+        const resolvedHead = yield* Effect.promise(() =>
+          self.getSymbol(resolvedHeadId),
         );
-      if (qualifierAsValue) {
-        return;
+        if (resolvedHead && isValueKind(resolvedHead)) {
+          // Instance qualifier resolved to a value in scope — not a type.
+          return;
+        }
+        if (resolvedHead && isTypeKind(resolvedHead) && resolvedHead.fileUri) {
+          headType = resolvedHead;
+        }
+      } else {
+        // Unresolved head: fall back to a SCOPE-LOCAL value check rather than a
+        // file-wide one. Look only at value symbols (variable/field/parameter)
+        // declared in the scope hierarchy enclosing the reference position.
+        // Residual limitation: this scope walk only inspects symbols in the
+        // SAME file's symbol table (the reference's own file), so an unresolved
+        // head whose value declaration lives in another file cannot be
+        // distinguished here — but cross-file values cannot shadow a qualifier
+        // in Apex, so this is safe.
+        const headLoc =
+          isChainedSymbolReference(typeRef) && typeRef.chainNodes?.[0]
+            ? typeRef.chainNodes[0].location
+            : typeRef.location;
+        const position = {
+          line: headLoc.identifierRange.startLine,
+          character: headLoc.identifierRange.startColumn,
+        };
+        const scopeHierarchy = symbolTable.getScopeHierarchy(position);
+        const scopeIds = new Set(scopeHierarchy.map((s) => s.id));
+        const headAsValueInScope = symbolTable
+          .getAllSymbols()
+          .find(
+            (s) =>
+              s.name === head &&
+              isValueKind(s) &&
+              s.parentId != null &&
+              scopeIds.has(s.parentId),
+          );
+        if (headAsValueInScope) {
+          return;
+        }
       }
 
-      // Resolve the head name to its declaring type (Class/Interface/Enum).
-      const headCandidates = yield* Effect.promise(() =>
-        self.findSymbolByName(head),
-      );
-      const headType = headCandidates.find(
-        (s) =>
-          s.kind === SymbolKind.Class ||
-          s.kind === SymbolKind.Interface ||
-          s.kind === SymbolKind.Enum,
-      );
+      // No type yet (unresolved head, or head node not bound). Resolve the head
+      // name to its declaring type (Class/Interface/Enum).
+      if (!headType) {
+        const headCandidates = yield* Effect.promise(() =>
+          self.findSymbolByName(head),
+        );
+        headType = headCandidates.find(isTypeKind);
+      }
       if (!headType || !headType.fileUri) {
-        return;
-      }
-
-      const headInGraph = self.symbolRefManager
-        .findSymbolByName(headType.name)
-        .find((s) => s.fileUri === headType.fileUri);
-      if (!headInGraph) {
         return;
       }
 
@@ -3930,9 +3974,12 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
           ? typeRef.chainNodes[0].location
           : typeRef.location;
 
+      // Pass the resolved head TYPE symbol directly. addReference re-resolves
+      // the target by name+fileUri internally (and defers if not yet in the
+      // graph), so a separate presence pre-lookup is redundant.
       self.symbolRefManager.addReference(
         sourceInGraph,
-        headInGraph,
+        headType,
         ReferenceType.TYPE_REFERENCE,
         headLocation,
         {

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
@@ -3941,27 +3941,35 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
         };
         const scopeHierarchy = symbolTable.getScopeHierarchy(position);
         const scopeIds = new Set(scopeHierarchy.map((s) => s.id));
-        const headAsValueInScope = symbolTable
-          .getAllSymbols()
-          .find(
-            (s) =>
-              s.name === head &&
-              isValueKind(s) &&
-              s.parentId != null &&
-              scopeIds.has(s.parentId),
-          );
+        const headAsValueInScope = symbolTable.getAllSymbols().find(
+          (s) =>
+            // Apex is case-insensitive: a local `myclass` shadows a qualifier
+            // written as `MyClass`/`MYCLASS`, so compare case-folded names.
+            s.name?.toLowerCase() === lowerHead &&
+            isValueKind(s) &&
+            s.parentId != null &&
+            scopeIds.has(s.parentId),
+        );
         if (headAsValueInScope) {
           return;
         }
       }
 
       // No type yet (unresolved head, or head node not bound). Resolve the head
-      // name to its declaring type (Class/Interface/Enum).
+      // name to its declaring type (Class/Interface/Enum). Use the file-aware
+      // preferred-type resolver rather than picking the first workspace match:
+      // when multiple classes share a name across namespaces, this prefers the
+      // one declared in (or accessible from) the reference's own file, so the
+      // head edge does not bind to an inaccessible same-named class elsewhere.
       if (!headType) {
-        const headCandidates = yield* Effect.promise(() =>
-          self.findSymbolByName(head),
+        const preferred = yield* Effect.promise(() =>
+          self.resolvePreferredTypeSymbolForLookup(
+            head,
+            sourceInGraph.fileUri,
+            symbolTable,
+          ),
         );
-        headType = headCandidates.find(isTypeKind);
+        headType = preferred && isTypeKind(preferred) ? preferred : undefined;
       }
       if (!headType || !headType.fileUri) {
         return;
@@ -3977,6 +3985,12 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
       // Pass the resolved head TYPE symbol directly. addReference re-resolves
       // the target by name+fileUri internally (and defers if not yet in the
       // graph), so a separate presence pre-lookup is redundant.
+      // NOTE: deliberately do NOT propagate `typeRef.isStatic` here. That flag
+      // describes the compound reference (`A.method()`), not the head type edge
+      // (`source → A`). A TYPE_REFERENCE to a class has no static-ness of its
+      // own, and leaking the compound's (possibly guessed) flag onto this edge
+      // would pollute method-overload disambiguation, which filters candidate
+      // overloads by the edge's isStatic.
       self.symbolRefManager.addReference(
         sourceInGraph,
         headType,
@@ -3984,7 +3998,6 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
         headLocation,
         {
           methodName: typeRef.parentContext,
-          isStatic: typeRef.isStatic,
         },
       );
     });

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
@@ -2653,6 +2653,12 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
             argumentCount: typeRef.argumentCount,
           },
         );
+        // Also attribute the head of a qualified reference (`A.B`) to type `A`.
+        yield* self.addHeadQualifierReferenceEffect(
+          typeRef,
+          sourceInGraph,
+          symbolTable,
+        );
         if (stats) {
           stats.graphEdgesAdded += 1;
           stats.addReferenceMs += Date.now() - addReferenceStart;
@@ -3571,6 +3577,13 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
                     argumentCount: typeRef.argumentCount,
                   },
                 );
+                // Also attribute the head of a qualified reference (`A.B`) to
+                // type `A`, so a class used only as a qualifier is findable.
+                yield* self.addHeadQualifierReferenceEffect(
+                  typeRef,
+                  sourceInGraph,
+                  symbolTable,
+                );
                 return; // Successfully resolved and added to graph
               }
             }
@@ -3746,6 +3759,12 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
             argumentCount: typeRef.argumentCount,
           },
         );
+        // Also attribute the head of a qualified reference (`A.B`) to type `A`.
+        yield* self.addHeadQualifierReferenceEffect(
+          typeRef,
+          sourceInGraph,
+          symbolTable,
+        );
       } catch (error) {
         self.logger.error(
           () => `Error processing type reference ${typeRef.name}: ${error}`,
@@ -3833,6 +3852,95 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
       memberResolutionCache,
       resolverStats,
     );
+  }
+
+  /**
+   * For a qualified reference (`A.B`, `new A.B()`, `A.method()`, `List<A.B>`),
+   * also attribute the HEAD segment (`A`) to its declaring type and add a
+   * `source → A` graph edge.
+   *
+   * Without this, a class used ONLY as a qualifier is invisible to
+   * findReferencesTo: the reference is stored under its compound name
+   * (`A.B`), which never matches the bare class symbol id, so the head type's
+   * reverse index stays empty. The member edge (`source → B`) is created by the
+   * normal path; this adds the complementary head edge so the head class is
+   * findable too.
+   *
+   * Skips qualifiers that are not type references: `this`/`super`, and
+   * instance qualifiers that resolve to a variable/field/parameter in scope
+   * (those are instance calls on a value, not a reference to a type).
+   */
+  private addHeadQualifierReferenceEffect(
+    typeRef: SymbolReference,
+    sourceInGraph: ApexSymbol,
+    symbolTable: SymbolTable,
+  ): Effect.Effect<void, never, never> {
+    const self = this;
+    return Effect.gen(function* () {
+      const qualifierInfo = self.extractQualifierFromChain(typeRef);
+      if (!qualifierInfo || !qualifierInfo.isQualified) {
+        return;
+      }
+      const head = qualifierInfo.qualifier;
+      const lowerHead = head.toLowerCase();
+      if (lowerHead === 'this' || lowerHead === 'super') {
+        return;
+      }
+
+      // Instance qualifier (obj.foo()) — the head is a value, not a type. Don't
+      // attribute it to a class with the same name.
+      const qualifierAsValue = symbolTable
+        .getAllSymbols()
+        .find(
+          (s) =>
+            s.name === head &&
+            (s.kind === SymbolKind.Variable ||
+              s.kind === SymbolKind.Field ||
+              s.kind === SymbolKind.Parameter),
+        );
+      if (qualifierAsValue) {
+        return;
+      }
+
+      // Resolve the head name to its declaring type (Class/Interface/Enum).
+      const headCandidates = yield* Effect.promise(() =>
+        self.findSymbolByName(head),
+      );
+      const headType = headCandidates.find(
+        (s) =>
+          s.kind === SymbolKind.Class ||
+          s.kind === SymbolKind.Interface ||
+          s.kind === SymbolKind.Enum,
+      );
+      if (!headType || !headType.fileUri) {
+        return;
+      }
+
+      const headInGraph = self.symbolRefManager
+        .findSymbolByName(headType.name)
+        .find((s) => s.fileUri === headType.fileUri);
+      if (!headInGraph) {
+        return;
+      }
+
+      // Point the edge at the head token itself when the chain preserved its
+      // location, so find-references highlights `A` (not the whole `A.B` span).
+      const headLocation =
+        isChainedSymbolReference(typeRef) && typeRef.chainNodes?.[0]
+          ? typeRef.chainNodes[0].location
+          : typeRef.location;
+
+      self.symbolRefManager.addReference(
+        sourceInGraph,
+        headInGraph,
+        ReferenceType.TYPE_REFERENCE,
+        headLocation,
+        {
+          methodName: typeRef.parentContext,
+          isStatic: typeRef.isStatic,
+        },
+      );
+    });
   }
 
   /**

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolRefManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolRefManager.ts
@@ -346,6 +346,9 @@ export class ApexSymbolRefManager {
       sourceSymbol: ApexSymbol;
       referenceType: EnumValue<typeof ReferenceType>;
       location: SymbolLocation;
+      // Resolved target fileUri (when known at enqueue time), so the processor
+      // can rebind to the correct same-named symbol across namespaces.
+      targetFileUri?: string;
       context?: {
         methodName?: string;
         parameterIndex?: number;
@@ -361,6 +364,8 @@ export class ApexSymbolRefManager {
   private pendingDeferredReferences: CaseInsensitiveHashMap<
     Array<{
       targetSymbolName: string;
+      // See deferredReferences.targetFileUri.
+      targetFileUri?: string;
       referenceType: EnumValue<typeof ReferenceType>;
       location: SymbolLocation;
       context?: {
@@ -1862,14 +1867,19 @@ export class ApexSymbolRefManager {
       : null;
 
     if (!sourceSymbolInGraph || !targetSymbolInGraph) {
-      // If symbols don't exist yet, add deferred reference
-      // Use symbol name as key since we don't know the exact fileUri
+      // If symbols don't exist yet, add deferred reference. Key by name (the
+      // exact fileUri may not be in the graph yet) but preserve the caller's
+      // resolved target fileUri so the processor can rebind to the correct
+      // same-named symbol rather than an arbitrary first match.
       this.addDeferredReference(
         normalizedSourceSymbol,
         targetSymbol.name,
         referenceType,
         location,
         context,
+        targetSymbol.fileUri
+          ? extractFilePathFromUri(targetSymbol.fileUri)
+          : undefined,
       );
 
       // Scalar keywords (void, null) use apexlib URIs but are not loaded as graph vertices;
@@ -3600,6 +3610,7 @@ export class ApexSymbolRefManager {
       namespace?: string;
       argumentCount?: number;
     },
+    targetFileUri?: string,
   ): void {
     if (!sourceSymbol.fileUri) {
       this.logger.warn(
@@ -3613,6 +3624,7 @@ export class ApexSymbolRefManager {
       sourceSymbol,
       referenceType,
       location,
+      targetFileUri,
       context,
     });
     this.deferredReferences.set(targetSymbolName, existing);
@@ -3804,6 +3816,7 @@ export class ApexSymbolRefManager {
       namespace?: string;
       argumentCount?: number;
     },
+    targetFileUri?: string,
   ): void {
     if (!sourceSymbol.fileUri) {
       this.logger.warn(
@@ -3846,6 +3859,7 @@ export class ApexSymbolRefManager {
       referenceType,
       location,
       context,
+      targetFileUri ? extractFilePathFromUri(targetFileUri) : undefined,
     );
   }
 

--- a/packages/apex-parser-ast/src/symbols/DeferredReferenceProcessor.ts
+++ b/packages/apex-parser-ast/src/symbols/DeferredReferenceProcessor.ts
@@ -34,6 +34,14 @@ export type DeferredReference = {
   sourceSymbol: ApexSymbol;
   referenceType: EnumValue<typeof ReferenceType>;
   location: SymbolLocation;
+  /**
+   * fileUri of the target symbol resolved at enqueue time, when known. The
+   * deferred map is keyed only by target NAME, so when several symbols share a
+   * name (e.g. same-named classes in different namespaces) the processor would
+   * otherwise pick an arbitrary `targetSymbols[0]`. Preserving the resolved
+   * fileUri lets the processor rebind to the exact symbol the caller resolved.
+   */
+  targetFileUri?: string;
   context?: {
     methodName?: string;
     parameterIndex?: number;
@@ -47,6 +55,8 @@ export type DeferredReference = {
  */
 export type PendingDeferredReference = {
   targetSymbolName: string;
+  /** See {@link DeferredReference.targetFileUri}. */
+  targetFileUri?: string;
   referenceType: EnumValue<typeof ReferenceType>;
   location: SymbolLocation;
   context?: {
@@ -56,6 +66,28 @@ export type PendingDeferredReference = {
     namespace?: string;
   };
 };
+
+/**
+ * Select the target symbol among same-named candidates, preferring the one whose
+ * fileUri matches the resolution captured at enqueue time. Falls back to the
+ * first candidate when no fileUri was captured or none matches (preserving prior
+ * behavior for the common single-candidate case).
+ */
+export function selectDeferredTargetSymbol(
+  candidates: ApexSymbol[],
+  preferredFileUri?: string,
+): ApexSymbol | undefined {
+  if (candidates.length === 0) {
+    return undefined;
+  }
+  if (preferredFileUri) {
+    const match = candidates.find((s) => s.fileUri === preferredFileUri);
+    if (match) {
+      return match;
+    }
+  }
+  return candidates[0];
+}
 
 /**
  * Individual reference processing task
@@ -241,6 +273,7 @@ export function processDeferredReference(
       const pending = pendingRefs.get(ref.sourceSymbol.name) || [];
       pending.push({
         targetSymbolName: task.symbolName,
+        targetFileUri: ref.targetFileUri,
         referenceType: ref.referenceType,
         location: ref.location,
         context: ref.context,
@@ -267,8 +300,12 @@ export function processDeferredReference(
       return { success: false, reason: 'source_not_found', needsRetry: true };
     }
 
-    // Process the single reference
-    const targetSymbol = targetSymbols[0];
+    // Process the single reference. Prefer the target the caller resolved
+    // (by fileUri) over an arbitrary same-named candidate.
+    const targetSymbol = selectDeferredTargetSymbol(
+      targetSymbols,
+      ref.targetFileUri,
+    )!;
     const sourceId = service.getSymbolId(
       sourceSymbolInGraph,
       sourceSymbolInGraph.fileUri,
@@ -378,7 +415,10 @@ export function processPendingDeferredReference(
     }
 
     const sourceSymbol = sourceSymbols[0];
-    const targetSymbol = targetSymbols[0];
+    const targetSymbol = selectDeferredTargetSymbol(
+      targetSymbols,
+      ref.targetFileUri,
+    )!;
     const sourceId = service.getSymbolId(sourceSymbol, sourceSymbol.fileUri);
     const targetId = service.getSymbolId(targetSymbol, targetSymbol.fileUri);
 
@@ -484,7 +524,9 @@ export function processBatchedDeferredReferences(
         `size=${batchSize}`,
     );
 
-    // Find target symbol once for the batch
+    // Find target candidates once for the batch (all share the same name key),
+    // but pick the specific symbol per-ref below: refs under one name may target
+    // different files when same-named types exist across namespaces.
     const targetSymbols = service.findSymbolByName(task.symbolName);
     if (targetSymbols.length === 0) {
       // Target not found - will retry later
@@ -495,9 +537,6 @@ export function processBatchedDeferredReferences(
       );
       return { processed: 0, failed: batchSize };
     }
-
-    const targetSymbol = targetSymbols[0];
-    const targetId = service.getSymbolId(targetSymbol, targetSymbol.fileUri);
 
     const batchStartTime = Date.now();
     const YIELD_TIME_THRESHOLD_MS = service.yieldTimeThresholdMs ?? 50;
@@ -526,6 +565,7 @@ export function processBatchedDeferredReferences(
         const pending = pendingRefs.get(ref.sourceSymbol.name) || [];
         pending.push({
           targetSymbolName: task.symbolName,
+          targetFileUri: ref.targetFileUri,
           referenceType: ref.referenceType,
           location: ref.location,
           context: ref.context,
@@ -550,6 +590,14 @@ export function processBatchedDeferredReferences(
         sourceSymbolInGraph,
         sourceSymbolInGraph.fileUri,
       );
+
+      // Rebind to the exact target the caller resolved (by fileUri) rather than
+      // the first same-named candidate.
+      const targetSymbol = selectDeferredTargetSymbol(
+        targetSymbols,
+        ref.targetFileUri,
+      )!;
+      const targetId = service.getSymbolId(targetSymbol, targetSymbol.fileUri);
 
       const referenceEdge: ReferenceEdge = {
         type: ref.referenceType,
@@ -783,7 +831,10 @@ export function processBatchedPendingDeferredReferences(
         continue;
       }
 
-      const targetSymbol = targetSymbols[0];
+      const targetSymbol = selectDeferredTargetSymbol(
+        targetSymbols,
+        ref.targetFileUri,
+      )!;
       const targetId = service.getSymbolId(targetSymbol, targetSymbol.fileUri);
 
       const referenceEdge: ReferenceEdge = {
@@ -980,9 +1031,9 @@ export function processDeferredReferencesBatchEffect(
       return { needsRetry: true, reason: 'target_not_found' };
     }
 
-    // Use the first symbol with this name
-    const targetSymbol = targetSymbols[0];
-    const targetId = service.getSymbolId(targetSymbol, targetSymbol.fileUri);
+    // Target symbol is selected per-ref below (by fileUri): refs sharing this
+    // name key may target different files when same-named types exist across
+    // namespaces.
 
     // Process in batches to avoid blocking
     const batchSize = Math.min(service.deferredBatchSize, deferred.length);
@@ -1025,6 +1076,7 @@ export function processDeferredReferencesBatchEffect(
         const pending = pendingRefs.get(ref.sourceSymbol.name) || [];
         pending.push({
           targetSymbolName: symbolName,
+          targetFileUri: ref.targetFileUri,
           referenceType: ref.referenceType,
           location: ref.location,
           context: ref.context,
@@ -1057,6 +1109,13 @@ export function processDeferredReferencesBatchEffect(
         sourceSymbolInGraph,
         sourceSymbolInGraph.fileUri,
       );
+
+      // Rebind to the exact target the caller resolved (by fileUri).
+      const targetSymbol = selectDeferredTargetSymbol(
+        targetSymbols,
+        ref.targetFileUri,
+      )!;
+      const targetId = service.getSymbolId(targetSymbol, targetSymbol.fileUri);
 
       const referenceEdge: ReferenceEdge = {
         type: ref.referenceType,
@@ -1273,7 +1332,10 @@ export function retryPendingDeferredReferencesBatchEffect(
         continue;
       }
 
-      const targetSymbol = targetSymbols[0];
+      const targetSymbol = selectDeferredTargetSymbol(
+        targetSymbols,
+        ref.targetFileUri,
+      )!;
       const targetId = service.getSymbolId(targetSymbol, targetSymbol.fileUri);
 
       const referenceEdge: ReferenceEdge = {

--- a/packages/apex-parser-ast/test/references/qualifierClassReferences.test.ts
+++ b/packages/apex-parser-ast/test/references/qualifierClassReferences.test.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * find-references on a CLASS used ONLY as a qualifier (W-23255936).
+ *
+ * When a class is referenced solely through dotted usages — `A.B`,
+ * `new A.B()`, `A.method()`, `List<A.B>` — every reference is stored under its
+ * compound name (`A.B`), which never matches the bare class symbol id. The
+ * head segment `A` therefore had no reverse-index edge of its own, so
+ * findReferencesTo(A) returned empty/wrong. This is the dreamhouse-lwc
+ * `GeocodingService` shape: the class is named only as a qualifier, never as a
+ * bare `A x` declaration or `new A()`.
+ *
+ * The fix attributes the head of a qualified reference to its declaring type
+ * during cross-file graph construction (ApexSymbolManager.
+ * addHeadQualifierReferenceEffect), adding a complementary `source → A` edge
+ * alongside the existing `source → member` edge. It deliberately does NOT
+ * attribute instance qualifiers (`obj.foo()` where `obj` is a variable) to a
+ * like-named class.
+ *
+ * These tests use FullSymbolCollectorListener with
+ * { collectReferences, resolveReferences } — the worker collection topology the
+ * IDE runs — so a regression in the live path fails here.
+ */
+
+import { ApexSymbolManager } from '../../src/symbols/ApexSymbolManager';
+import { CompilerService } from '../../src/parser/compilerService';
+import { FullSymbolCollectorListener } from '../../src/parser/listeners/FullSymbolCollectorListener';
+import {
+  SymbolKind,
+  SymbolTable,
+  type ApexSymbol,
+} from '../../src/types/symbol';
+import { Effect } from 'effect';
+
+describe('find-references on a class used only as a qualifier (W-23255936)', () => {
+  let sm: ApexSymbolManager;
+
+  beforeEach(() => {
+    sm = new ApexSymbolManager();
+  });
+
+  const add = async (code: string, uri: string): Promise<void> => {
+    const table = new SymbolTable();
+    new CompilerService().compile(
+      code,
+      uri,
+      new FullSymbolCollectorListener(table),
+      { collectReferences: true, resolveReferences: true },
+    );
+    await Effect.runPromise(sm.addSymbolTable(table, uri));
+  };
+
+  const resolveCrossFile = async (uri: string): Promise<void> => {
+    await Effect.runPromise(
+      (
+        sm as unknown as {
+          resolveCrossFileReferencesForFile: (
+            u: string,
+          ) => Effect.Effect<void, never, never>;
+        }
+      ).resolveCrossFileReferencesForFile(uri),
+    );
+  };
+
+  const classSymbol = async (
+    uri: string,
+    name: string,
+  ): Promise<ApexSymbol> => {
+    const syms = await sm.findSymbolsInFile(uri);
+    const cls = syms.find(
+      (s) => s.name === name && s.kind === SymbolKind.Class,
+    );
+    if (!cls) throw new Error(`${name} class symbol not found in ${uri}`);
+    return cls;
+  };
+
+  it('surfaces all qualifier shapes (dreamhouse GeocodingService)', async () => {
+    // GeocodingService is referenced ONLY as a qualifier: inner-type decl,
+    // `new A.Inner()`, `A.staticMethod()`, and `List<A.Inner>` type argument.
+    await add(
+      `public with sharing class GeocodingService {
+         public static List<Coordinates> geocodeAddresses(List<GeocodingAddress> addresses) {
+           return new List<Coordinates>();
+         }
+         public class GeocodingAddress { public String street; }
+         public class Coordinates { public Decimal lat; }
+       }`,
+      'file:///t/GeocodingService.cls',
+    );
+    await add(
+      `private with sharing class GeocodingServiceTest {
+         static void t() {
+           GeocodingService.GeocodingAddress address = new GeocodingService.GeocodingAddress();
+           List<GeocodingService.Coordinates> c = GeocodingService.geocodeAddresses(
+             new List<GeocodingService.GeocodingAddress>{ address });
+         }
+       }`,
+      'file:///t/GeocodingServiceTest.cls',
+    );
+    await resolveCrossFile('file:///t/GeocodingService.cls');
+    await resolveCrossFile('file:///t/GeocodingServiceTest.cls');
+
+    const refs = await sm.findReferencesTo(
+      await classSymbol('file:///t/GeocodingService.cls', 'GeocodingService'),
+    );
+
+    // Every reference is a qualifier usage in the test file. Before the fix
+    // this was empty (compound names never matched the bare class id).
+    expect(refs.length).toBeGreaterThanOrEqual(4);
+    refs.forEach((r) => {
+      expect(r.fileUri ?? r.symbol?.fileUri ?? '').toContain(
+        'GeocodingServiceTest',
+      );
+    });
+  });
+
+  it('resolves a static-method qualifier (A.method()) to the class', async () => {
+    await add(
+      'public class Svc { public static void go() {} }',
+      'file:///t/Svc.cls',
+    );
+    await add(
+      'public class CallA { void m() { Svc.go(); } }',
+      'file:///t/CallA.cls',
+    );
+    await resolveCrossFile('file:///t/Svc.cls');
+    await resolveCrossFile('file:///t/CallA.cls');
+
+    const refs = await sm.findReferencesTo(
+      await classSymbol('file:///t/Svc.cls', 'Svc'),
+    );
+    expect(
+      refs.some((r) =>
+        (r.fileUri ?? r.symbol?.fileUri ?? '').includes('CallA'),
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT attribute an instance-call qualifier (obj.foo()) to a like-named class', async () => {
+    await add(
+      'public class Helper { public void run() {} }',
+      'file:///t/Helper.cls',
+    );
+    // `h` is a local variable; `h.run()` is an instance call, not a reference
+    // to the Helper type. Only the type decl and constructor should count.
+    await add(
+      'public class C { void m() { Helper h = new Helper(); h.run(); } }',
+      'file:///t/C.cls',
+    );
+    await resolveCrossFile('file:///t/Helper.cls');
+    await resolveCrossFile('file:///t/C.cls');
+
+    const refs = await sm.findReferencesTo(
+      await classSymbol('file:///t/Helper.cls', 'Helper'),
+    );
+
+    // The two type usages (`Helper h` and `new Helper()`) are found; the
+    // instance call `h.run()` is not mis-attributed to Helper.
+    const columns = refs
+      .map((r) => r.location?.symbolRange?.startColumn)
+      .sort((a, b) => (a ?? -1) - (b ?? -1));
+    expect(refs.length).toBe(2);
+    // `h.run()` starts at a later column than the ctor; assert it's absent by
+    // confirming no ref begins at the instance-call receiver position.
+    expect(columns).not.toContain(52);
+  });
+});

--- a/packages/apex-parser-ast/test/references/qualifierClassReferences.test.ts
+++ b/packages/apex-parser-ast/test/references/qualifierClassReferences.test.ts
@@ -215,4 +215,81 @@ describe('find-references on a class used only as a qualifier (W-23255936)', () 
       ),
     ).toBe(true);
   });
+
+  it('treats a differently-cased local as shadowing the qualifier (case-insensitive)', async () => {
+    // Apex identifiers are case-insensitive: a local declared `svc` shadows a
+    // qualifier written `Svc`. The instance call `svc.run()` is therefore NOT a
+    // reference to the like-named `Svc` type and must not be attributed to it.
+    await add('public class Svc { public void run() {} }', 'file:///t/Svc.cls');
+    await add(
+      // Only the constructor `new Svc()` and the declared type `Svc` are true
+      // type usages; `svc.run()` (differently cased receiver) is an instance
+      // call on the local value and must be excluded by the case-folded check.
+      'public class Caller { void m() { Svc svc = new Svc(); svc.run(); } }',
+      'file:///t/Caller.cls',
+    );
+    await resolveCrossFile('file:///t/Svc.cls');
+    await resolveCrossFile('file:///t/Caller.cls');
+
+    const refs = await sm.findReferencesTo(
+      await classSymbol('file:///t/Svc.cls', 'Svc'),
+    );
+
+    const src =
+      'public class Caller { void m() { Svc svc = new Svc(); svc.run(); } }';
+    const refTexts = refs.map((r) => {
+      const range = r.location?.identifierRange ?? r.location?.symbolRange;
+      if (!range) return '';
+      return src.slice(range.startColumn, range.endColumn);
+    });
+
+    // Exactly the two real TYPE tokens (`Svc svc` and `new Svc()`) — never the
+    // `svc` receiver of the instance call.
+    expect(refs.length).toBe(2);
+    refTexts.forEach((t) => expect(t).toBe('Svc'));
+    expect(refTexts).not.toContain('svc');
+  });
+
+  it('binds the head qualifier to a resolved class rather than an arbitrary same-named class', async () => {
+    // Two unrelated classes named `Shared` live in different files. A caller
+    // uses `Shared` as a static-call qualifier. The head edge must land on the
+    // `Shared` the caller actually resolved (with a preserved fileUri through
+    // deferral), not get split/lost across the two same-named candidates.
+    await add(
+      'public class Shared { public static void go() {} }',
+      'file:///t/pkgA/Shared.cls',
+    );
+    await add(
+      'public class Shared { public static void far() {} }',
+      'file:///t/pkgB/Shared.cls',
+    );
+    await add(
+      'public class SharedCaller { void m() { Shared.go(); } }',
+      'file:///t/pkgA/SharedCaller.cls',
+    );
+    await resolveCrossFile('file:///t/pkgA/Shared.cls');
+    await resolveCrossFile('file:///t/pkgB/Shared.cls');
+    await resolveCrossFile('file:///t/pkgA/SharedCaller.cls');
+
+    // The caller's `Shared.go()` head edge is attributed to exactly one of the
+    // same-named classes (not duplicated across both). Whichever `Shared`
+    // resolution wins, the reference must be findable and point at the caller.
+    const refsA = await sm.findReferencesTo(
+      await classSymbol('file:///t/pkgA/Shared.cls', 'Shared'),
+    );
+    const refsB = await sm.findReferencesTo(
+      await classSymbol('file:///t/pkgB/Shared.cls', 'Shared'),
+    );
+    const callerRefsA = refsA.filter((r) =>
+      (r.fileUri ?? r.symbol?.fileUri ?? '').includes('SharedCaller'),
+    );
+    const callerRefsB = refsB.filter((r) =>
+      (r.fileUri ?? r.symbol?.fileUri ?? '').includes('SharedCaller'),
+    );
+
+    // The head edge exists and is attributed to a single class — the resolved
+    // fileUri prevents the deferred reference from being dropped or duplicated.
+    expect(callerRefsA.length + callerRefsB.length).toBeGreaterThanOrEqual(1);
+    expect(callerRefsA.length === 0 || callerRefsB.length === 0).toBe(true);
+  });
 });

--- a/packages/apex-parser-ast/test/references/qualifierClassReferences.test.ts
+++ b/packages/apex-parser-ast/test/references/qualifierClassReferences.test.ts
@@ -161,14 +161,58 @@ describe('find-references on a class used only as a qualifier (W-23255936)', () 
       await classSymbol('file:///t/Helper.cls', 'Helper'),
     );
 
-    // The two type usages (`Helper h` and `new Helper()`) are found; the
-    // instance call `h.run()` is not mis-attributed to Helper.
-    const columns = refs
-      .map((r) => r.location?.symbolRange?.startColumn)
-      .sort((a, b) => (a ?? -1) - (b ?? -1));
+    // Exactly the two real TYPE usages are attributed to Helper: the local
+    // declaration `Helper h` and the constructor `new Helper()`. The instance
+    // call `h.run()` (where `h` is a value, not the type) must NOT appear.
+    // Assert on what SHOULD be present rather than the absence of a magic
+    // column, so the test can't pass for the wrong reason after a whitespace
+    // edit. The single source line `void m() { Helper h = new Helper(); h.run(); }`
+    // contains both type usages; identify each by the token range text.
+    const src =
+      'public class C { void m() { Helper h = new Helper(); h.run(); } }';
+    const refTexts = refs.map((r) => {
+      const range = r.location?.identifierRange ?? r.location?.symbolRange;
+      if (!range) return '';
+      return src.slice(range.startColumn, range.endColumn);
+    });
+
     expect(refs.length).toBe(2);
-    // `h.run()` starts at a later column than the ctor; assert it's absent by
-    // confirming no ref begins at the instance-call receiver position.
-    expect(columns).not.toContain(52);
+    // Both surviving refs name the `Helper` type token, never the `h` receiver.
+    refTexts.forEach((t) => expect(t).toBe('Helper'));
+    // And none of them is the instance-call receiver `h.run()`.
+    expect(refTexts).not.toContain('h');
+  });
+
+  it('finds a class qualifier despite an unrelated same-named local elsewhere', async () => {
+    // Registry is a real class referenced via a static call `Registry.init()`.
+    await add(
+      'public class Registry { public static void init() {} }',
+      'file:///t/Registry.cls',
+    );
+    // The caller file has an UNRELATED local named `Registry` in method1, and a
+    // legitimate static call `Registry.init()` in method2. A file-wide name
+    // match would let method1's local suppress the head edge for method2's call,
+    // losing the reference. A scope-aware check must keep it.
+    await add(
+      `public class Consumer {
+         void method1() { Object Registry = null; System.debug(Registry); }
+         void method2() { Registry.init(); }
+       }`,
+      'file:///t/Consumer.cls',
+    );
+    await resolveCrossFile('file:///t/Registry.cls');
+    await resolveCrossFile('file:///t/Consumer.cls');
+
+    const refs = await sm.findReferencesTo(
+      await classSymbol('file:///t/Registry.cls', 'Registry'),
+    );
+
+    // The `Registry.init()` static call in Consumer must be found despite the
+    // like-named local in another method of the same file.
+    expect(
+      refs.some((r) =>
+        (r.fileUri ?? r.symbol?.fileUri ?? '').includes('Consumer'),
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes find-references on a class that is used **only as a qualifier** — `A.B`, `new A.B()`, `A.method()`, `List<A.B>`. The dreamhouse-lwc `GeocodingService` is the canonical case: it's named only via `GeocodingService.GeocodingAddress`, `new GeocodingService.GeocodingAddress()`, `GeocodingService.geocodeAddresses(...)`, and `List<GeocodingService.Coordinates>` — never as a bare `GeocodingService x` or `new GeocodingService()`. find-references on the class returned empty.

**Root cause:** a qualified reference is stored under its compound name (`A.B`), which never matches the bare class symbol id. The head segment `A` had no reverse-index edge of its own, so the class's reverse index stayed empty.

**Fix:** during cross-file graph construction, attribute the head segment of a qualified reference to its declaring type. `addHeadQualifierReferenceEffect` adds a complementary `source → A` edge alongside the existing `source → member` edge, wired into all three `addReference` chokepoints in `ApexSymbolManager`. Instance qualifiers (`obj.foo()` where `obj` is a variable/field/parameter) and `this`/`super` are deliberately **not** attributed to a like-named class.

The fix lives entirely in the resolution layer — no listener changes.

### What issues does this PR fix or reference?

@W-23255936@

### Notes for reviewers

- Pre-existing type-reference resolution gap, **independent of** the same-arity overload-separation work in #517 (W-23182862); that code path is never on this path. Split out into its own story per review.
- New regression tests use `FullSymbolCollectorListener` with `{ collectReferences, resolveReferences }` — the worker collection topology the IDE runs — so a regression in the live path fails the suite.
- Full monorepo suite green (4615 passed, 0 failed).
