### PR TITLE
fix(apex-lsp-compliant-services): find-references idempotency + hover timeout - W-23320108

### DIFF
--- a/packages/apex-ls/src/server/WorkerCoordinator.ts
+++ b/packages/apex-ls/src/server/WorkerCoordinator.ts
@@ -1016,14 +1016,6 @@ interface DocumentEventParams {
   };
   readonly textDocument?: { readonly uri: string };
   readonly text?: string;
-  readonly contentChanges?: ReadonlyArray<{
-    readonly range?: {
-      readonly start: { readonly line: number; readonly character: number };
-      readonly end: { readonly line: number; readonly character: number };
-    };
-    readonly rangeLength?: number;
-    readonly text: string;
-  }>;
 }
 
 /** Params shape for position-based enrichment dispatches. */
@@ -1061,18 +1053,18 @@ function buildDataOwnerMessage(
       return new DispatchDocumentChange({
         uri: p.document?.uri ?? p.textDocument?.uri ?? '',
         version: p.document?.version ?? 0,
-        contentChanges: (p.contentChanges ?? []).map((c) => ({
-          text: c.text,
-          ...(c.range ? { range: c.range } : {}),
-          ...(c.rangeLength !== undefined
-            ? { rangeLength: c.rangeLength }
-            : {}),
-        })),
+        // Full-text sync: the change event carries the entire updated document,
+        // so document.getText() is the authoritative post-change content. The
+        // data-owner stores this as the file's text (used by text-based scans
+        // like find-references' lexical prefilter) rather than a blank
+        // placeholder (W-23272674).
+        content: p.document?.getText?.() ?? p.text ?? '',
       });
     case 'documentSave':
       return new DispatchDocumentSave({
         uri: p.document?.uri ?? p.textDocument?.uri ?? '',
         version: p.document?.version ?? 0,
+        content: p.document?.getText?.() ?? p.text ?? '',
       });
     case 'documentClose':
       return new DispatchDocumentClose({

--- a/packages/apex-ls/src/worker.platform.ts
+++ b/packages/apex-ls/src/worker.platform.ts
@@ -2503,9 +2503,15 @@ const handlers: WorkerRunner.SerializedRunner.Handlers<
     'DispatchDocumentChange',
     (svc, req) =>
       Effect.gen(function* () {
+        // Store the full post-change text (full-text sync). The compile this
+        // change triggers writes symbols back via UpdateSymbolSubset, which
+        // merges the symbol table but does NOT touch the stored document text —
+        // so a blank placeholder here would leave the file's text empty until
+        // the next full workspace ingest, silently dropping it from text-based
+        // scans like the find-references lexical prefilter (W-23272674).
         const doc: WorkerDocument = {
           uri: req.uri,
-          getText: () => '',
+          getText: () => req.content,
           languageId: 'apex',
           version: req.version,
         };
@@ -2523,15 +2529,17 @@ const handlers: WorkerRunner.SerializedRunner.Handlers<
     'DispatchDocumentSave',
     (svc, req) =>
       Effect.gen(function* () {
-        // Mirror DispatchDocumentChange: store a version placeholder and arm the
+        // Mirror DispatchDocumentChange: store the full saved text and arm the
         // readiness latch so the CompileDocument this save triggers can write
         // its symbols back (UpdateSymbolSubset requires the document present at
         // this version) and a request racing the save re-evaluates against the
-        // saved version. The compile message carries the real saved content; the
-        // placeholder text is replaced when the write-back merges.
+        // saved version. UpdateSymbolSubset merges symbols but never restores
+        // document text, so we must store the real content here — a blank
+        // placeholder would drop the file from text-based scans like the
+        // find-references lexical prefilter (W-23272674).
         const doc: WorkerDocument = {
           uri: req.uri,
-          getText: () => '',
+          getText: () => req.content,
           languageId: 'apex',
           version: req.version,
         };

--- a/packages/apex-ls/src/worker.platform.web.ts
+++ b/packages/apex-ls/src/worker.platform.web.ts
@@ -2246,9 +2246,14 @@ const handlers: WorkerRunner.SerializedRunner.Handlers<
     'DispatchDocumentChange',
     (svc, req) =>
       Effect.gen(function* () {
+        // Store the full post-change text (full-text sync). UpdateSymbolSubset
+        // merges the recompiled symbols but never restores document text, so a
+        // blank placeholder here would leave the file's text empty until the
+        // next full workspace ingest, dropping it from text-based scans like
+        // the find-references lexical prefilter (W-23272674).
         const doc: WorkerDocument = {
           uri: req.uri,
-          getText: () => '',
+          getText: () => req.content,
           languageId: 'apex',
           version: req.version,
         };
@@ -2264,13 +2269,15 @@ const handlers: WorkerRunner.SerializedRunner.Handlers<
     'DispatchDocumentSave',
     (svc, req) =>
       Effect.gen(function* () {
-        // Mirror DispatchDocumentChange: store a version placeholder and arm the
+        // Mirror DispatchDocumentChange: store the full saved text and arm the
         // readiness latch so the CompileDocument this save triggers can write
         // its symbols back and a racing request re-evaluates against the saved
-        // version. The compile message carries the real saved content.
+        // version. UpdateSymbolSubset merges symbols but never restores document
+        // text, so we store the real content here rather than a blank
+        // placeholder (W-23272674).
         const doc: WorkerDocument = {
           uri: req.uri,
-          getText: () => '',
+          getText: () => req.content,
           languageId: 'apex',
           version: req.version,
         };

--- a/packages/apex-ls/test/integration/EnrichmentRoundTrip.node.test.ts
+++ b/packages/apex-ls/test/integration/EnrichmentRoundTrip.node.test.ts
@@ -677,7 +677,6 @@ describe('Enrichment round-trip through the worker topology (live assistance bus
             getText: () => IMPL3_FINAL_SRC,
           },
           textDocument: { uri: IMPL3_URI },
-          contentChanges: [{ text: IMPL3_FINAL_SRC }],
         }),
       );
       yield* Effect.promise(() =>

--- a/packages/apex-ls/test/integration/ReferencesThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/ReferencesThroughWorkerTopology.node.test.ts
@@ -216,6 +216,97 @@ describe('find-references through the worker topology (location count)', () => {
     expect(uris.some((u) => u.includes('RefCallerB'))).toBe(true);
   }, 120_000);
 
+  it('returns the same count on a repeat request after an intervening documentChange (W-23272674)', async () => {
+    // Regression: find-references was not idempotent. The phase-1 lexical
+    // prefilter scans the data-owner's stored document text; a documentChange
+    // used to overwrite that text with a blank placeholder (the write-back
+    // merges symbols but never restores text), so any file edited since the
+    // last full workspace ingest silently dropped out of the candidate set and
+    // its call sites vanished from the second request's result.
+    const program = Effect.gen(function* () {
+      const topology = yield* initializeTopology({
+        poolSize: 1,
+        enableResourceLoader: true,
+        logger,
+        logLevel: 'error',
+      });
+      const dispatcher = makeWorkerDispatcher(
+        topology,
+        logger,
+        (uri) => SOURCES[uri],
+      );
+      wireProductionMediator(topology, dispatcher, logger);
+      yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentOpen', {
+          document: {
+            uri: UTIL_URI,
+            languageId: 'apex',
+            version: 1,
+            getText: () => UTIL_SRC,
+          },
+          textDocument: { uri: UTIL_URI },
+          text: UTIL_SRC,
+        }),
+      );
+
+      const ingest = dispatcher.createBatchIngestionDispatcher();
+      const compile = dispatcher.createBatchCompileDispatcher();
+      yield* Effect.promise(() => ingest('wf-refs-idem', ALL_ENTRIES));
+      yield* Effect.promise(() => compile('wf-refs-idem', ALL_ENTRIES));
+
+      const dispatchRefs = () =>
+        Effect.promise(() =>
+          dispatcher.dispatch('references', {
+            textDocument: { uri: CALLER_A_URI },
+            position: { line: 2, character: 8 }, // on `RefUtil` usage in caller A
+            context: { includeDeclaration: true },
+          }),
+        );
+
+      const first = yield* dispatchRefs();
+
+      // A caller file is edited (content unchanged, new version) — the exact
+      // event that used to blank RefCallerB's stored text on the data-owner.
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentChange', {
+          document: {
+            uri: CALLER_B_URI,
+            languageId: 'apex',
+            version: 2,
+            getText: () => CALLER_B_SRC,
+          },
+          textDocument: { uri: CALLER_B_URI },
+          text: CALLER_B_SRC,
+        }),
+      );
+
+      const second = yield* dispatchRefs();
+
+      return { first, second };
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(makeNodeWorkerLayer(WORKER_TS_ENTRY, TSX_OPTIONS)),
+    );
+
+    const { first, second } = await Effect.runPromise(program);
+
+    const firstUris = toLocations(first).map((l) => l.uri ?? l.targetUri ?? '');
+    const secondUris = toLocations(second).map(
+      (l) => l.uri ?? l.targetUri ?? '',
+    );
+    console.log(
+      `[refs-topology:idempotent] first=${firstUris.length} second=${secondUris.length}`,
+    );
+
+    // The second request must return the same locations as the first — in
+    // particular RefCallerB (the edited file) must still contribute its usages.
+    expect(secondUris.length).toBe(firstUris.length);
+    expect(secondUris.some((u) => u.includes('RefCallerB'))).toBe(true);
+    expect(secondUris.some((u) => u.includes('RefCallerA'))).toBe(true);
+  }, 120_000);
+
   it('omits the declaration when includeDeclaration is false', async () => {
     const program = Effect.gen(function* () {
       const topology = yield* initializeTopology({

--- a/packages/apex-ls/test/integration/WorkerConcurrencyInterop.node.test.ts
+++ b/packages/apex-ls/test/integration/WorkerConcurrencyInterop.node.test.ts
@@ -79,7 +79,6 @@ const changeParams = (uri: string, text: string, version: number) => ({
     getText: () => text,
   },
   textDocument: { uri, version },
-  contentChanges: [{ text }],
   text,
 });
 

--- a/packages/apex-lsp-shared/src/workerWireSchemas.ts
+++ b/packages/apex-lsp-shared/src/workerWireSchemas.ts
@@ -521,7 +521,13 @@ export class DispatchDocumentChange extends Schema.TaggedRequest<DispatchDocumen
     payload: {
       uri: Schema.String,
       version: Schema.Number,
-      contentChanges: Schema.Array(WireContentChangeEvent),
+      // Full document text after the change. The LS negotiates full-text sync
+      // (TextDocumentSyncKind.Full), so each change carries the entire updated
+      // document. The data-owner stores this as the file's authoritative text
+      // (used by e.g. the find-references lexical prefilter); storing a blank
+      // placeholder here silently drops the file out of any text-based scan
+      // until the next full workspace ingest (W-23272674).
+      content: Schema.String,
     },
   },
 ) {}
@@ -534,6 +540,8 @@ export class DispatchDocumentSave extends Schema.TaggedRequest<DispatchDocumentS
     payload: {
       uri: Schema.String,
       version: Schema.Number,
+      // Full saved document text — see DispatchDocumentChange.content.
+      content: Schema.String,
     },
   },
 ) {}

--- a/packages/apex-lsp-shared/test/workerWireSchemas.test.ts
+++ b/packages/apex-lsp-shared/test/workerWireSchemas.test.ts
@@ -223,13 +223,14 @@ describe('workerWireSchemas', () => {
       const req = new DispatchDocumentChange({
         uri: 'file:///MyClass.cls',
         version: 2,
-        contentChanges: [{ text: 'updated' }],
+        content: 'updated',
       });
       expect(req._tag).toBe('DispatchDocumentChange');
 
       const encoded = Schema.encodeSync(DispatchDocumentChange)(req);
       const decoded = Schema.decodeSync(DispatchDocumentChange)(encoded);
       expect(decoded.version).toBe(2);
+      expect(decoded.content).toBe('updated');
     });
   });
 
@@ -238,10 +239,12 @@ describe('workerWireSchemas', () => {
       const req = new DispatchDocumentSave({
         uri: 'file:///MyClass.cls',
         version: 3,
+        content: 'saved',
       });
       const encoded = Schema.encodeSync(DispatchDocumentSave)(req);
       const decoded = Schema.decodeSync(DispatchDocumentSave)(encoded);
       expect(decoded.uri).toBe('file:///MyClass.cls');
+      expect(decoded.content).toBe('saved');
     });
   });
 

--- a/packages/lsp-compliant-services/src/config/ServiceConfiguration.ts
+++ b/packages/lsp-compliant-services/src/config/ServiceConfiguration.ts
@@ -27,7 +27,7 @@ export const DEFAULT_SERVICE_CONFIG: ServiceConfig[] = [
   {
     requestType: 'hover',
     priority: Priority.Immediate,
-    timeout: 1000,
+    timeout: 5000,
     maxRetries: 0,
     serviceFactory: (deps) => deps.serviceFactory.createHoverService(),
   },


### PR DESCRIPTION
### What does this PR do?

Fixes two issues surfaced while testing Find All References, stacked on top of the W-23272674 find-references work (this PR targets that branch).

**1. Find All References was not idempotent.** A repeat request returned fewer results than the first call for the same symbol. Root cause: the data-owner `DispatchDocumentChange`/`DispatchDocumentSave` handlers stored an empty-string placeholder for a file's text. The compile write-back (`UpdateSymbolSubset`) merges symbols but never restores document text — so any file edited or saved since the last full workspace ingest had empty stored text, silently failed the find-references phase-1 lexical prefilter (which scans `getAllDocumentContents`), and dropped its call sites from every subsequent request.

The fix carries the full post-change/save document text on the `DispatchDocumentChange`/`DispatchDocumentSave` wire messages (full-text sync already provides it) and stores it instead of the blank placeholder. The now-dead `contentChanges` payload field is removed.

**2. Hover timed out at 1s.** On a cold or busy workspace, hover routinely exceeded the 1s budget and returned a `TimeoutException` instead of content. Raised the hover timeout to 5s (matching `documentSymbol`).

### What issues does this PR fix or reference?

@W-23320108@

### Functionality Before

- Find All References returned the full set on the first call, then a reduced set on every subsequent call once any involved file had been edited/saved.
- Hover frequently failed with `Operation timed out after '1s'` under load.

### Functionality After

- Find All References returns a stable, complete set across repeated calls regardless of intervening edits/saves.
- Hover has a 5s budget, resolving under normal cold-start/load conditions.

### Testing

- Added a regression test in `ReferencesThroughWorkerTopology.node.test.ts`: dispatch references → `documentChange` on a caller → re-dispatch, asserting a stable count. Confirmed it fails without the fix (`first=4 second=2`) and passes with it (`4/4`).
- Updated wire-schema round-trip tests and two topology integration tests for the new payload shape.
- Full suite green via commit hooks: 4642 passed, 0 failed.
