### PR TITLE
fix(apex-lsp-extension): restore web outline/diagnostics by pinning to desktop settings defaults

### DIFF
--- a/packages/apex-lsp-vscode-extension/src/configuration.ts
+++ b/packages/apex-lsp-vscode-extension/src/configuration.ts
@@ -20,7 +20,6 @@ import {
   generateStartupSummary,
   mergeWithDefaults,
 } from '@salesforce/apex-lsp-shared';
-import { detectEnvironment } from './utils/serverUtils';
 
 /**
  * Creates a clean, serializable notification object for workspace/didChangeConfiguration
@@ -59,9 +58,17 @@ export const getWorkspaceSettings = (): ApexLanguageServerSettings => {
     settings = {};
   }
 
-  // Merge user settings with defaults, ensuring all required properties exist
+  // Merge user settings with defaults, ensuring all required properties exist.
+  //
+  // NOTE: intentionally always merges against the 'desktop' defaults, even in a
+  // web extension host. Routing web through BROWSER_DEFAULT_APEX_SETTINGS (via
+  // detectEnvironment()) regressed document-symbol/outline population in web —
+  // the browser scheduler/queue tuning starves symbol requests so the outline
+  // never populates and the diagnostics progress never resolves. Until those
+  // browser defaults are corrected, use the desktop defaults that web shipped
+  // with historically. See W-<TBD>.
   const userSettings = { apex: settings };
-  return mergeWithDefaults(userSettings, detectEnvironment());
+  return mergeWithDefaults(userSettings, 'desktop');
 };
 
 /**


### PR DESCRIPTION
## Summary

Fixes a web-only regression introduced by this feature branch (#533): the Apex **outline/document symbols never populate** and the **"Computing Apex Diagnostics" progress spins forever** in the web (browser) extension host.

Target: this PR is opened against the feature branch `worktree-worker-platform-shared-extraction` (the head of #533) so the fix lands before #533 merges to `main`.

## Root cause

On `main`, `getWorkspaceSettings()` in `packages/apex-lsp-vscode-extension/src/configuration.ts` **hardcoded** the desktop defaults:

```ts
return mergeWithDefaults(userSettings, 'desktop');
```

So even in the web extension host, settings were always merged against `DEFAULT_APEX_SETTINGS` (desktop tuning), and web worked.

This feature branch changed that line to resolve the environment dynamically:

```ts
return mergeWithDefaults(userSettings, detectEnvironment());
```

In the web host, `detectEnvironment()` returns `'web'`, so for the first time settings were merged against `BROWSER_DEFAULT_APEX_SETTINGS`. Those browser defaults carry much tighter scheduler/queue tuning than desktop, which **starves symbol processing**: the priority scheduler never drains symbol requests, so the outline never populates and the pull-diagnostics request never resolves (hence the perpetual progress spinner).

The switch to `detectEnvironment()` is correct in principle — the problem is that `BROWSER_DEFAULT_APEX_SETTINGS` itself is mis-tuned and starves symbols. That's tracked as follow-up work (see below).

## Fix

Revert `getWorkspaceSettings()` to always merge against the `'desktop'` defaults — the exact behavior web shipped with historically and which is proven-good — and drop the now-unused `detectEnvironment` import. A code comment documents *why* the merge is intentionally pinned to `'desktop'` and points at the follow-up to correct the browser defaults.

This is a deliberately narrow, low-risk fix: it restores the previous, working behavior rather than changing the (broken) browser defaults under time pressure.

## Verification

Verified empirically against the web e2e outline test (`e2e-tests/tests/apex-outline.spec.ts`, run via `playwright.config.web.ts`), clean workspace each run:

| Config | Result |
| --- | --- |
| `main` | 11/11 pass (baseline) |
| Feature branch, unmodified | **3/3 fail** (deterministic) |
| Feature branch + this fix | outline **0 failures ×3**; `apex-lsp-integration` web spec **16/16** |

Typecheck and prettier clean. Pre-commit test suite: 4645 passed, 0 failed.

## Follow-up

The deeper fix is to correct the specific offending field(s) in `BROWSER_DEFAULT_APEX_SETTINGS` so the web host can eventually use its intended browser-tuned defaults without starving symbols. Prime suspect: `scheduler.queueStateNotificationIntervalMs: 0` (desktop uses `500`), which makes `startQueueStateNotificationTask` busy-loop on `Effect.sleep(0)`. Investigation starting now.
