### PR TITLE
fix(ci): use quality:stable for web e2e test-web version pin - W-23333500

### DIFF
--- a/e2e-tests/test-server.js
+++ b/e2e-tests/test-server.js
@@ -11,6 +11,7 @@ const path = require('path');
 const fs = require('fs');
 const {
   readLocalVSCodeVersion,
+  resolveVscodeWebBuildOptions,
 } = require('../scripts/sync-vscode-version');
 
 async function startTestServer() {
@@ -128,6 +129,7 @@ async function startTestServer() {
     console.log(`🔍 CI environment: ${process.env.CI ? 'Yes' : 'No'}`);
 
     const vsCodeVersion = readLocalVSCodeVersion();
+    const vscodeWebBuildOptions = resolveVscodeWebBuildOptions(vsCodeVersion);
 
     // Log extension files for debugging
     console.log('📋 Extension files:');
@@ -157,8 +159,7 @@ async function startTestServer() {
       folderPath: workspacePath,
       headless: true, // Always headless - Playwright will open its own browser window
       browserType: 'chromium',
-      quality: 'stable',
-      commit: vsCodeVersion,
+      ...vscodeWebBuildOptions,
       printServerLog: true,
       verbose: true,
       coi: true, // Cross-origin isolation for SharedArrayBuffer support

--- a/scripts/sync-vscode-version.js
+++ b/scripts/sync-vscode-version.js
@@ -72,6 +72,27 @@ function readLocalVSCodeVersion() {
 }
 
 /**
+ * Maps `.vscode-version` content to @vscode/test-web download options.
+ *
+ * @vscode/test-web's getBuild() computes `quality = options.quality || options.version`
+ * and only downloads the **stable** channel when that value is the literal string
+ * `'stable'`. A semver like `1.121.0` is not `'stable'`, so passing it as `version`
+ * would fetch the **latest Insiders** build instead of that release. The `commit`
+ * option is not an escape hatch either: it must be a 40-char SHA, so passing a
+ * semver there makes the CDN lookup 404 ("Failed to find a download for stable and
+ * 1.121.0"). Without a real commit SHA, the closest we can pin is the stable channel.
+ *
+ * @param {string} vsCodeVersion from readLocalVSCodeVersion()
+ * @returns {{ quality: 'stable' } | { version: string }}
+ */
+function resolveVscodeWebBuildOptions(vsCodeVersion) {
+  if (vsCodeVersion === 'stable' || /^\d+\.\d+\.\d+$/.test(vsCodeVersion)) {
+    return { quality: 'stable' };
+  }
+  return { version: vsCodeVersion };
+}
+
+/**
  * Fetches the VS Code version from the Code Builder Web repo and writes
  * it to the local `.vscode-version` file.
  *
@@ -183,4 +204,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { readLocalVSCodeVersion };
+module.exports = { readLocalVSCodeVersion, resolveVscodeWebBuildOptions };

--- a/scripts/test-web-ext.js
+++ b/scripts/test-web-ext.js
@@ -33,26 +33,10 @@ const { exec } = require('child_process');
 const { promisify } = require('util');
 const {
   readLocalVSCodeVersion,
+  resolveVscodeWebBuildOptions,
 } = require('./sync-vscode-version');
 
 const execAsync = promisify(exec);
-
-/**
- * Maps `.vscode-version` content to @vscode/test-web download options.
- * getBuild() uses `quality = options.quality || options.version` and only
- * downloads **stable** when that value is the literal string `'stable'`.
- * A semver like `1.108.0` is not `'stable'`, so the harness would otherwise
- * fetch **latest Insider** (not that release). Semver pins here mean "match
- * stable channel" unless you also pass a 40-char `commit`.
- * @param {string} vsCodeVersion from readLocalVSCodeVersion()
- * @returns {{ quality: 'stable' } | { version: string }}
- */
-function resolveVscodeWebBuildOptions(vsCodeVersion) {
-  if (vsCodeVersion === 'stable' || /^\d+\.\d+\.\d+$/.test(vsCodeVersion)) {
-    return { quality: 'stable' };
-  }
-  return { version: vsCodeVersion };
-}
 
 /**
  * Creates a test Apex class with @isTest annotations for testing CodeLens functionality


### PR DESCRIPTION
## Summary

Fixes the Web E2E failures on #533. Commit `b9b77f4f5` changed `e2e-tests/test-server.js` to pass the pinned `.vscode-version` as `@vscode/test-web`'s `commit` option, but `commit` must be a 40-char SHA. A version string like `1.121.0` makes the CDN lookup 404:

```
[WebServer] ❌ Failed to start test server: Failed to find a download for stable and 1.121.0
```

so the web server never starts and all 5 Web E2E suites fail before any test runs.

## Fix

- Reuse the existing `resolveVscodeWebBuildOptions` helper (semver pin → `{ quality: 'stable' }`), which was already the correct pattern in `scripts/test-web-ext.js`.
- Promote it into the shared `scripts/sync-vscode-version.js` module (both callers already import from it) and export it.
- Consume it in `test-server.js` (fixing the bug) and `test-web-ext.js` (dropping the duplicate copy).

Note: with a semver pin, `@vscode/test-web` downloads the latest **stable** build (not that exact version) — the documented harness limitation without a real commit SHA, and the behavior `test-web-ext.js` already relied on.

## Test plan

- [x] Ran `test-server.js` under `CI=true` with the insider cache cleared → downloads **VS Code Stable**, extracts, and serves (`Listening on http://localhost:3000` → `Opening browser`). Before the fix this hard-failed with the CDN 404.
- [x] Full monorepo test suite green on commit (pre-commit hook): 4645 passed, 0 failed.

### What issues does this PR fix or reference?
@W-23333500@
