### PR TITLE
fix(apex-lsp-web): resolve web worker script relative to parent origin - W-23333500

### DIFF
--- a/packages/apex-ls/src/server/LCSAdapter.ts
+++ b/packages/apex-ls/src/server/LCSAdapter.ts
@@ -2333,13 +2333,18 @@ export class LCSAdapter {
           scope,
         );
       } else {
-        const injectedUrl = this.workerPlatformWebUrl;
+        // Resolve the worker script relative to the parent server bundle's own
+        // origin. Using the client-injected extension URL directly (a different
+        // origin — the extension's dist/) breaks sub-worker spawning for
+        // resolution-heavy roles: makeBrowserWorkerLayer's cross-origin
+        // fetch→blob misbehaves, silently degrading hover/definition symbol
+        // resolution while basic requests still work. workerPlatformWebUrl is
+        // kept only as a last-resort base when location.href is unavailable.
         const selfHref =
-          injectedUrl ??
           (globalThis as any).location?.href ??
+          this.workerPlatformWebUrl ??
           'file:///server.web.js';
-        const workerUrl =
-          injectedUrl ?? new URL('./worker.platform.web.js', selfHref).href;
+        const workerUrl = new URL('./worker.platform.web.js', selfHref).href;
         this.logger.alwaysLog(
           () => `[WorkerCoordinator] Worker script (browser): ${workerUrl}`,
         );


### PR DESCRIPTION
## Summary

Fixes the 8 web E2E failures on #533 in `apex-hover.spec.ts` and `apex-goto-definition.spec.ts`. These were a genuine functional regression — hover returned the `🔍 Searching for symbol…` placeholder and go-to-definition landed on the wrong location (or didn't move).

## Root cause

Bisected to commit `fee53a6e4`. Its `LCSAdapter` change started passing the client-injected `workerPlatformWebUrl` (the extension's `dist/worker.platform.web.js`) **directly** as the browser worker script URL. That URL is a **different origin** from the running server bundle, and `makeBrowserWorkerLayer`'s cross-origin `fetch → blob` misbehaves for the resolution-heavy worker roles — silently degrading hover/definition symbol resolution while basic requests still worked.

Before that commit, `workerPlatformWebUrl` was never assigned, so the worker resolved **relative to the parent server bundle's own origin** (`location.href`) — which worked.

## Fix

Restore the parent-origin resolution for the web worker script; keep `workerPlatformWebUrl` only as a last-resort base when `location.href` is unavailable. One-line-ish change in `LCSAdapter.ts`.

## Validation (local, web e2e, identical hardware)

Bisect + controlled reverts pinned the cause to a single line:

| Build | hover+goto failures |
|---|---|
| `713368a75` (pre-`fee53a6e4`) / main | 1 (pre-existing List-variable flake) |
| `fee53a6e4` | 23 |
| branch tip (as-is) | 8 |
| **branch tip + this fix** | **0 (50/50 pass)** |

- [x] `apex-hover.spec.ts` + `apex-goto-definition.spec.ts`: **50 passed, 0 failed**
- [x] Full web e2e suite: only the **pre-existing** `apex-completions` / `apex-find-references` failures remain (confirmed identical with and without this fix — separate issue, and neither spec is in the CI E2E matrix)
- [x] All 5 CI-gated web specs (extension-core, goto-definition, hover, lsp-integration, outline) pass
- [x] Full monorepo suite green on commit (pre-commit hook): 4645 passed, 0 failed

## Notes

The `workerPlatformWebUrl` injection was presumably added because real vscode.dev may need an explicit extension URI where `location.href` won't resolve. If that's the case, a follow-up should make `makeBrowserWorkerLayer` handle the cross-origin URL correctly (fetch→blob for **all** worker roles) rather than relying on parent-origin resolution. This PR restores the known-good behavior to unblock #533's E2E.

### What issues does this PR fix or reference?
@W-23333500@
