### PR TITLE
fix(ci): repair web find-references peek assertions - W-23405972

### DIFF
--- a/e2e-tests/pages/ApexEditorPage.ts
+++ b/e2e-tests/pages/ApexEditorPage.ts
@@ -178,10 +178,27 @@ export class ApexEditorPage extends BasePage {
   }
 
   /**
+   * The references peek widget, across VS Code variants.
+   *
+   * Find-all-references surfaces results in the dedicated references peek, whose
+   * container is `.zone-widget-container.peekview-widget.reference-zone-widget`.
+   * NOTE: this is NOT the `.editor-widget.peekview-widget` used by the go-to
+   * peek — the references peek is a `zone-widget-container`, so an
+   * `.editor-widget.peekview-widget` selector never matches it and the wait
+   * times out. Match the references-specific class instead, and keep the
+   * generic `.peekview-widget` as a fallback for other VS Code builds.
+   */
+  private get referencesPeek() {
+    return this.page.locator(
+      '.reference-zone-widget, .editor-widget.peekview-widget',
+    );
+  }
+
+  /**
    * Trigger find-all-references at the current cursor position (Shift+F12).
    *
-   * VS Code surfaces references in a peek widget (the `references-view` /
-   * `.peekview-widget`). Returns the number of reference entries the peek
+   * VS Code surfaces references in a peek widget (the references peek /
+   * `.reference-zone-widget`). Returns the number of reference entries the peek
    * lists, or 0 when none appear. The peek is left OPEN so callers can assert
    * on its contents; close it with {@link closePeek} when done.
    */
@@ -200,7 +217,7 @@ export class ApexEditorPage extends BasePage {
 
     // The references peek widget appears for any non-empty result set. Give the
     // LSP time to answer (references can fan out cross-file).
-    const peekWidget = this.page.locator('.editor-widget.peekview-widget');
+    const peekWidget = this.referencesPeek.first();
     await peekWidget
       .waitFor({ state: 'visible', timeout: this.defaultTimeout })
       .catch(() => {});
@@ -209,20 +226,52 @@ export class ApexEditorPage extends BasePage {
       return 0;
     }
 
-    // Each reference is a row in the peek's tree. Count the result entries
-    // (file/line rows), excluding the file-group headers.
+    // The peek title reports the total as `References (N)` (a `.meta` span);
+    // this is stable regardless of which file groups happen to be expanded in
+    // the tree, so it's the most reliable count.
+    const metaText = await peekWidget
+      .locator('.peekview-title .meta')
+      .first()
+      .innerText()
+      .catch(() => '');
+    const metaMatch = metaText.match(/\((\d+)\)/);
+    if (metaMatch) {
+      return Number(metaMatch[1]);
+    }
+
+    // Fallback for builds without the meta count: sum the per-file badge counts
+    // in the results tree (each file group shows its match count as a badge).
+    const badges = peekWidget.locator(
+      '.monaco-list-row .count, .monaco-list-row .monaco-count-badge',
+    );
+    const badgeCount = await badges.count().catch(() => 0);
+    if (badgeCount > 0) {
+      let total = 0;
+      for (let i = 0; i < badgeCount; i++) {
+        const n = Number(
+          (await badges
+            .nth(i)
+            .innerText()
+            .catch(() => '')) || 0,
+        );
+        if (!Number.isNaN(n)) total += n;
+      }
+      if (total > 0) return total;
+    }
+
+    // Last resort: count reference rows directly (file-group headers included,
+    // so this over-counts slightly, but still distinguishes "some" from "none").
     const entries = peekWidget.locator(
       '.monaco-list-row .referenceMatch, .monaco-list-row[role="treeitem"]',
     );
-    const count = await entries.count().catch(() => 0);
-    return count;
+    return await entries.count().catch(() => 0);
   }
 
   /**
    * Close any open peek widget (references / definition peek).
    */
   async closePeek(): Promise<void> {
-    const peekWidget = this.page.locator('.editor-widget.peekview-widget');
+    const peekWidget = this.referencesPeek.first();
     for (let i = 0; i < 3; i++) {
       if (!(await peekWidget.isVisible())) {
         return;

--- a/e2e-tests/tests/apex-find-references.spec.ts
+++ b/e2e-tests/tests/apex-find-references.spec.ts
@@ -29,13 +29,19 @@ test.describe('Apex Find All References', () => {
     });
 
     await test.step('Position on a symbol that is used more than once', async () => {
-      // `sayHello` is declared and called within ApexClassExample.
-      await apexEditor.positionCursorOnWord('sayHello');
+      // `String` is used many times throughout ApexClassExample (parameter
+      // types, locals, return types), so find-references surfaces a clear,
+      // multi-entry result set that all lives WITHIN this one file. We
+      // deliberately avoid a user-declared method here: the fixture's methods
+      // are each referenced at most once, and VS Code does not open the
+      // references peek for a single-entry result (it navigates instead) — so
+      // a once-used symbol can't reliably assert on peek contents.
+      await apexEditor.positionCursorOnWord('String');
     });
 
     await test.step('Trigger find-references and assert results appear', async () => {
       const count = await apexEditor.findReferences();
-      // At least the declaration + one call site.
+      // Many intra-file usages of `String`.
       expect(count).toBeGreaterThan(0);
       console.log(`✅ Find-references returned ${count} entries`);
       await apexEditor.closePeek();
@@ -95,7 +101,10 @@ test.describe('Apex Find All References', () => {
   test('find-references is responsive', async ({ apexEditor }) => {
     await apexEditor.openFile('ApexClassExample.cls');
     await apexEditor.waitForLanguageServerReady();
-    await apexEditor.positionCursorOnWord('sayHello');
+    // Use a symbol with many intra-file usages so the references peek reliably
+    // opens (see the intra-file test above for why a once-used symbol does not
+    // surface a peek).
+    await apexEditor.positionCursorOnWord('String');
 
     const startTime = Date.now();
     await apexEditor.findReferences();


### PR DESCRIPTION
### What does this PR do?

Repairs the web-mode `apex-find-references` e2e tests, which were failing on the worker-platform-shared branch (now merged to `main` via #533). Investigation confirmed the **language server returns correct results end-to-end** — the failures were entirely in the test harness.

**Test-only change. No production/source code is modified.**

### Root cause

1. **Wrong peek selector.** `ApexEditorPage` waited on `.editor-widget.peekview-widget`, but VS Code renders the references peek as a *zone-widget* (`.zone-widget-container.peekview-widget.reference-zone-widget`), not an editor-widget. The wait always timed out, the helper returned `0`, and the responsive test blew its ~18s budget — even though the LSP was answering correctly (verified: cross-file `CrossFileUtility` returns 5 correct locations: the declaration + 4 usages).

2. **Degenerate fixture symbol.** The intra-file and responsive tests positioned on `sayHello`, which is only *declared* (never called) in `ApexClassExample.cls`. A single-reference result makes VS Code *navigate* rather than open a peek, so there was nothing to assert on.

### Changes

- `e2e-tests/pages/ApexEditorPage.ts` — added a `referencesPeek` locator matching `.reference-zone-widget` (old selector retained as a fallback for other builds); `findReferences()` now reads the stable `References (N)` title-meta count, with badge- and row-count fallbacks; `closePeek()` uses the same locator.
- `e2e-tests/tests/apex-find-references.spec.ts` — intra-file and responsive tests now target `String` (many intra-file usages → reliable multi-entry peek) instead of the once-declared `sayHello`, with comments explaining why.

### Validation

- **Find-references web specs: 4/4 pass**, stable across 3 consecutive runs (intra-file → 21, cross-file → 5, responsive ~3.3s, no-references → 0). Was 1/4.
- Full unit suite: 4645 passed.
- CI-gated web specs `apex-extension-core`, `apex-lsp-integration`, `apex-outline` + find-references: 39/39.

### Follow-up items (tracked separately, not in this PR)

- **`apex-completions` web specs (W-23405970)** — under investigation. Two real provider bugs were found (`document.offsetAt` missing on the worker doc object; a cold-read gate returning empty), plus an open question of whether member/dot-completion is fully implemented in the LSP. Kept out of this PR since it's a distinct feature area still being scoped.
- **Enrichment-pool double-dispatch (latent).** While instrumenting, find-references was observed being dispatched twice per invocation with occasionally inconsistent declaration inclusion (2 then 1 locations). It didn't affect these tests once a reliably multi-referenced symbol is used, but may warrant a follow-up ticket.
- **Adding these specs to the CI e2e matrix (W-23405814)** — `apex-find-references` is now green and ready to be added; `apex-completions` gates that work.

### What issues does this PR fix or reference?

@W-23405972@
