### PR TITLE
ci: add capability-gating and hover-stdlib to web e2e matrix - W-23405814

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,9 +33,11 @@ jobs:
       fail-fast: false
       matrix:
         test_file:
+          - apex-capability-gating.spec.ts
           - apex-extension-core.spec.ts
           - apex-goto-definition.spec.ts
           - apex-hover.spec.ts
+          - apex-hover-stdlib.spec.ts
           - apex-lsp-integration.spec.ts
           - apex-outline.spec.ts
 
@@ -271,9 +273,11 @@ jobs:
 
           # Expected spec files from the matrix — keep in sync with the matrix above
           EXPECTED_SPECS=(
+            "apex-capability-gating.spec.ts"
             "apex-extension-core.spec.ts"
             "apex-goto-definition.spec.ts"
             "apex-hover.spec.ts"
+            "apex-hover-stdlib.spec.ts"
             "apex-lsp-integration.spec.ts"
             "apex-outline.spec.ts"
           )


### PR DESCRIPTION
### What does this PR do?

Adds two already-passing web e2e specs to the CI matrix:

- `apex-capability-gating.spec.ts`
- `apex-hover-stdlib.spec.ts`

Both are updated in the web `strategy.matrix.test_file` list **and** the `EXPECTED_SPECS` array in the summary job (the two are kept in sync per the in-file comment).

### Validation

Verified green on a clean build (`npm run compile && npm run bundle`), web mode, retries=0:
- `apex-capability-gating`: 3/3 pass
- `apex-hover-stdlib`: 3/3 pass

### Why not the other two missing specs?

The original enablement scope (W-23405814) also considered `apex-find-references` and `apex-completions`. Both are intentionally **excluded** here:

- **`apex-find-references`** — returns 0 references in web mode. Root cause (verified): the request-pool worker topology fails to initialize in VS Code Web (the server bundle's `blob:` URL is an invalid base for `new URL`), so the dispatcher is never wired and references falls through to an empty coordinator-local stub. Reviving the pool regresses hover/go-to-definition (proven via A/B: 50/50 → 41/50), because pool-based resolution is itself broken in web. This is a substantive LSP regression tracked in **@W-23408848@** (find-references e2e fix blocked on it: W-23405972).
- **`apex-completions`** — completion is a scaffolded-but-incomplete feature (prefix→type and stdlib instance member completion were never built; `completionProvider` is `undefined // Not ready for production`). Tracked in W-23405970.

Neither will be added to CI until its underlying work lands.

### What issues does this PR fix or reference?

@W-23405814@
