### PR TITLE
fix(apex-lsp-web): revive web worker topology + pool member/cross-file resolution - W-23408848

### DIFF
--- a/e2e-tests/pages/ApexEditorPage.ts
+++ b/e2e-tests/pages/ApexEditorPage.ts
@@ -199,7 +199,7 @@ export class ApexEditorPage extends BasePage {
     await this.page.keyboard.press('Shift+F12');
 
     // Find-all-references renders in the `reference-zone-widget` peek — a
-    // DIFFERENT DOM node than the go-to-definition peek
+    // different DOM node than the go-to-definition peek
     // (`.editor-widget.peekview-widget`). Match the references widget
     // specifically so we don't miss it and report 0.
     const peekWidget = this.page.locator(
@@ -213,10 +213,10 @@ export class ApexEditorPage extends BasePage {
       return 0;
     }
 
-    // The peek's result tree is VIRTUALIZED: only the on-screen rows exist in
-    // the DOM (a 5-result peek may render just 2-3 `.monaco-list-row`s), so
-    // counting rows undercounts. The peek title carries the authoritative
-    // total — "References (5)" — so parse that first.
+    // The peek's result tree is virtualized: only on-screen rows exist in the
+    // DOM (a 5-result peek may render just 2-3 `.monaco-list-row`s), so counting
+    // rows undercounts. The peek title carries the authoritative total —
+    // "References (5)" — so parse that first.
     const titleText = await peekWidget
       .locator('.head .peekview-title .meta')
       .first()

--- a/e2e-tests/pages/ApexEditorPage.ts
+++ b/e2e-tests/pages/ApexEditorPage.ts
@@ -227,6 +227,15 @@ export class ApexEditorPage extends BasePage {
       return Number(match[1]);
     }
 
+    // Locale fallback: on non-English VS Code the word "References" is
+    // translated, so the word-anchored regex above misses. The count is still
+    // rendered in parentheses regardless of locale, so extract the last
+    // parenthesized integer from the title before resorting to row counting.
+    const localeMatch = titleText?.match(/\((\d+)\)\s*$/);
+    if (localeMatch) {
+      return Number(localeMatch[1]);
+    }
+
     // Fallback: no parseable title (older VS Code, or a single-result peek that
     // navigates instead of showing a count) — count the rendered result rows.
     const entries = peekWidget.locator(

--- a/e2e-tests/pages/ApexEditorPage.ts
+++ b/e2e-tests/pages/ApexEditorPage.ts
@@ -198,9 +198,13 @@ export class ApexEditorPage extends BasePage {
 
     await this.page.keyboard.press('Shift+F12');
 
-    // The references peek widget appears for any non-empty result set. Give the
-    // LSP time to answer (references can fan out cross-file).
-    const peekWidget = this.page.locator('.editor-widget.peekview-widget');
+    // Find-all-references renders in the `reference-zone-widget` peek — a
+    // DIFFERENT DOM node than the go-to-definition peek
+    // (`.editor-widget.peekview-widget`). Match the references widget
+    // specifically so we don't miss it and report 0.
+    const peekWidget = this.page.locator(
+      '.peekview-widget.reference-zone-widget',
+    );
     await peekWidget
       .waitFor({ state: 'visible', timeout: this.defaultTimeout })
       .catch(() => {});
@@ -209,8 +213,22 @@ export class ApexEditorPage extends BasePage {
       return 0;
     }
 
-    // Each reference is a row in the peek's tree. Count the result entries
-    // (file/line rows), excluding the file-group headers.
+    // The peek's result tree is VIRTUALIZED: only the on-screen rows exist in
+    // the DOM (a 5-result peek may render just 2-3 `.monaco-list-row`s), so
+    // counting rows undercounts. The peek title carries the authoritative
+    // total — "References (5)" — so parse that first.
+    const titleText = await peekWidget
+      .locator('.head .peekview-title .meta')
+      .first()
+      .textContent()
+      .catch(() => null);
+    const match = titleText?.match(/References?\s*\((\d+)\)/i);
+    if (match) {
+      return Number(match[1]);
+    }
+
+    // Fallback: no parseable title (older VS Code, or a single-result peek that
+    // navigates instead of showing a count) — count the rendered result rows.
     const entries = peekWidget.locator(
       '.monaco-list-row .referenceMatch, .monaco-list-row[role="treeitem"]',
     );
@@ -222,7 +240,11 @@ export class ApexEditorPage extends BasePage {
    * Close any open peek widget (references / definition peek).
    */
   async closePeek(): Promise<void> {
-    const peekWidget = this.page.locator('.editor-widget.peekview-widget');
+    // Both peek variants share the `.peekview-widget` base class: the
+    // go-to-definition peek (`.editor-widget.peekview-widget`) and the
+    // find-references peek (`.reference-zone-widget`). Match the base class so
+    // either is dismissed.
+    const peekWidget = this.page.locator('.peekview-widget');
     for (let i = 0; i < 3; i++) {
       if (!(await peekWidget.isVisible())) {
         return;

--- a/e2e-tests/tests/apex-find-references.spec.ts
+++ b/e2e-tests/tests/apex-find-references.spec.ts
@@ -29,8 +29,12 @@ test.describe('Apex Find All References', () => {
     });
 
     await test.step('Position on a symbol that is used more than once', async () => {
-      // `sayHello` is declared and called within ApexClassExample.
-      await apexEditor.positionCursorOnWord('sayHello');
+      // `accounts` is the instance field (declared line 8) with several
+      // intra-file usages (lines 25, 67, 78, 91, …). A field with multiple
+      // same-file references reliably surfaces the references peek in VS Code
+      // Web; a symbol with only a declaration + single usage does not open a
+      // peek there (VS Code collapses a near-empty same-file result set).
+      await apexEditor.positionCursorOnWord('accounts');
     });
 
     await test.step('Trigger find-references and assert results appear', async () => {
@@ -95,7 +99,7 @@ test.describe('Apex Find All References', () => {
   test('find-references is responsive', async ({ apexEditor }) => {
     await apexEditor.openFile('ApexClassExample.cls');
     await apexEditor.waitForLanguageServerReady();
-    await apexEditor.positionCursorOnWord('sayHello');
+    await apexEditor.positionCursorOnWord('accounts');
 
     const startTime = Date.now();
     await apexEditor.findReferences();

--- a/e2e-tests/tests/apex-find-references.spec.ts
+++ b/e2e-tests/tests/apex-find-references.spec.ts
@@ -29,11 +29,10 @@ test.describe('Apex Find All References', () => {
     });
 
     await test.step('Position on a symbol that is used more than once', async () => {
-      // `accounts` is the instance field (declared line 8) with several
-      // intra-file usages (lines 25, 67, 78, 91, …). A field with multiple
-      // same-file references reliably surfaces the references peek in VS Code
-      // Web; a symbol with only a declaration + single usage does not open a
-      // peek there (VS Code collapses a near-empty same-file result set).
+      // `accounts` is the instance field with several intra-file references. A
+      // field with multiple same-file references reliably surfaces the peek in
+      // VS Code Web; a symbol with only a declaration + single usage does not
+      // (VS Code collapses a near-empty same-file result set).
       await apexEditor.positionCursorOnWord('accounts');
     });
 

--- a/packages/apex-ls/src/server/LCSAdapter.ts
+++ b/packages/apex-ls/src/server/LCSAdapter.ts
@@ -2349,8 +2349,10 @@ export class LCSAdapter {
         const workerUrl =
           typeof rawHref === 'string' && !rawHref.startsWith('blob:')
             ? resolveWorkerUrl(rawHref)
-            : (this.workerPlatformWebUrl ??
-              resolveWorkerUrl('file:///server.web.js'));
+            : // `||` (not `??`): an empty string is as unusable a base as
+              // undefined, so fall through to the placeholder in both cases.
+              this.workerPlatformWebUrl ||
+              resolveWorkerUrl('file:///server.web.js');
         this.logger.alwaysLog(
           () => `[WorkerCoordinator] Worker script (browser): ${workerUrl}`,
         );

--- a/packages/apex-ls/src/server/LCSAdapter.ts
+++ b/packages/apex-ls/src/server/LCSAdapter.ts
@@ -2333,36 +2333,24 @@ export class LCSAdapter {
           scope,
         );
       } else {
-        // Resolve the worker script URL. Preferred: relative to the parent
-        // server bundle's own origin (location.href) — same-origin, no CORS.
-        //
-        // BUT VS Code Web serves the server bundle from a `blob:` URL (subdomain
-        // isolation), and a `blob:` href is NOT a valid base for
-        // `new URL(relative, base)` — it throws "Failed to construct 'URL':
-        // Invalid URL", which aborts topology init entirely and silently drops
-        // the whole worker pool (hover/definition/references then fall back to
-        // the coordinator-local path, and references — whose local handler is an
-        // empty stub — returns nothing). When the href is unusable as a base,
-        // fall back to the client-injected absolute worker URL
-        // (workerPlatformWebUrl), which points straight at the worker file.
-        // makeBrowserWorkerLayer fetches whatever URL we hand it and re-wraps
-        // the script in a SAME-ORIGIN blob before spawning, so the sub-worker
-        // shares the parent's origin regardless of which base produced the URL.
+        // Resolve the worker script URL relative to the parent server bundle's
+        // own origin (location.href) — same-origin, no CORS. But VS Code Web
+        // serves the bundle from a `blob:` URL, which is NOT a valid base for
+        // `new URL(relative, base)` — it throws, aborting topology init and
+        // silently dropping the whole worker pool (hover/definition/references
+        // fall back to the coordinator-local path, and references — an empty
+        // stub there — returns nothing). When href is unusable as a base, use
+        // the client-injected absolute worker URL, then a file:// placeholder.
+        // makeBrowserWorkerLayer re-wraps the fetched script in a SAME-ORIGIN
+        // blob regardless, so the sub-worker always shares the parent's origin.
+        const resolveWorkerUrl = (base: string) =>
+          new URL('./worker.platform.web.js', base).href;
         const rawHref = (globalThis as any).location?.href;
-        const hrefUsableAsBase =
-          typeof rawHref === 'string' && !rawHref.startsWith('blob:');
-        let workerUrl: string;
-        if (hrefUsableAsBase) {
-          workerUrl = new URL('./worker.platform.web.js', rawHref).href;
-        } else if (this.workerPlatformWebUrl) {
-          // Already an absolute URL to the worker file — use as-is.
-          workerUrl = this.workerPlatformWebUrl;
-        } else {
-          workerUrl = new URL(
-            './worker.platform.web.js',
-            'file:///server.web.js',
-          ).href;
-        }
+        const workerUrl =
+          typeof rawHref === 'string' && !rawHref.startsWith('blob:')
+            ? resolveWorkerUrl(rawHref)
+            : (this.workerPlatformWebUrl ??
+              resolveWorkerUrl('file:///server.web.js'));
         this.logger.alwaysLog(
           () => `[WorkerCoordinator] Worker script (browser): ${workerUrl}`,
         );

--- a/packages/apex-ls/src/server/LCSAdapter.ts
+++ b/packages/apex-ls/src/server/LCSAdapter.ts
@@ -2333,18 +2333,36 @@ export class LCSAdapter {
           scope,
         );
       } else {
-        // Resolve the worker script relative to the parent server bundle's own
-        // origin. Using the client-injected extension URL directly (a different
-        // origin — the extension's dist/) breaks sub-worker spawning for
-        // resolution-heavy roles: makeBrowserWorkerLayer's cross-origin
-        // fetch→blob misbehaves, silently degrading hover/definition symbol
-        // resolution while basic requests still work. workerPlatformWebUrl is
-        // kept only as a last-resort base when location.href is unavailable.
-        const selfHref =
-          (globalThis as any).location?.href ??
-          this.workerPlatformWebUrl ??
-          'file:///server.web.js';
-        const workerUrl = new URL('./worker.platform.web.js', selfHref).href;
+        // Resolve the worker script URL. Preferred: relative to the parent
+        // server bundle's own origin (location.href) — same-origin, no CORS.
+        //
+        // BUT VS Code Web serves the server bundle from a `blob:` URL (subdomain
+        // isolation), and a `blob:` href is NOT a valid base for
+        // `new URL(relative, base)` — it throws "Failed to construct 'URL':
+        // Invalid URL", which aborts topology init entirely and silently drops
+        // the whole worker pool (hover/definition/references then fall back to
+        // the coordinator-local path, and references — whose local handler is an
+        // empty stub — returns nothing). When the href is unusable as a base,
+        // fall back to the client-injected absolute worker URL
+        // (workerPlatformWebUrl), which points straight at the worker file.
+        // makeBrowserWorkerLayer fetches whatever URL we hand it and re-wraps
+        // the script in a SAME-ORIGIN blob before spawning, so the sub-worker
+        // shares the parent's origin regardless of which base produced the URL.
+        const rawHref = (globalThis as any).location?.href;
+        const hrefUsableAsBase =
+          typeof rawHref === 'string' && !rawHref.startsWith('blob:');
+        let workerUrl: string;
+        if (hrefUsableAsBase) {
+          workerUrl = new URL('./worker.platform.web.js', rawHref).href;
+        } else if (this.workerPlatformWebUrl) {
+          // Already an absolute URL to the worker file — use as-is.
+          workerUrl = this.workerPlatformWebUrl;
+        } else {
+          workerUrl = new URL(
+            './worker.platform.web.js',
+            'file:///server.web.js',
+          ).href;
+        }
         this.logger.alwaysLog(
           () => `[WorkerCoordinator] Worker script (browser): ${workerUrl}`,
         );

--- a/packages/apex-ls/src/server/WorkerCoordinator.ts
+++ b/packages/apex-ls/src/server/WorkerCoordinator.ts
@@ -1127,6 +1127,7 @@ function buildLspRequestMessage(
       return new DispatchDefinition({
         textDocument: { uri: p.textDocument.uri },
         position: (p as PositionBasedParams).position,
+        content: getDocumentContent?.(p.textDocument.uri),
       });
     case 'signatureHelp': {
       const s = p as PositionBasedParams & { context?: unknown };

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -1690,13 +1690,22 @@ const requestHandlers = {
       // from the live buffer. Runs after loadSymbolDataForEnrichment so the
       // full-detail table wins while the cross-file dep tables it loaded stay
       // present for the re-resolve inside recompileCursorFileAtFullDetail.
+      //
+      // DEFERRED perf (W-23408848): this runs on every hover on ALL platforms,
+      // not just web. It is NOT safe to gate on the data-owner's reported
+      // detailLevel (`shouldEnrich(detailLevel, 'full')`): that level reflects
+      // the DATA-OWNER's stored table, not what THIS pool member holds locally,
+      // so a fresh pool worker with detailLevel='full' still lacks the member
+      // symbols and skipping the recompile regresses field/instance-variable
+      // hover+definition (verified: 3 web e2e failures). A correct gate needs a
+      // LOCAL full-detail marker for the uri; deferred until one exists.
       await recompileCursorFileAtFullDetail(
         svc,
         req.textDocument.uri,
         req.content,
       );
 
-      // Hover requires 'full' detail level per LspRequestPrerequisiteMapping
+      // Hover requires 'full' detail level per LspRequestPrerequisiteMapping.
       const requiredLevel = 'full';
       const needsEnrichment = shouldEnrich(detailLevel, requiredLevel);
 
@@ -1834,14 +1843,16 @@ const requestHandlers = {
 
       // As in DispatchHover: the data-owner holds only public-api detail, so
       // definition on a field/local/private member resolves to nothing.
-      // Recompile locally at full detail from the live buffer.
+      // Recompile locally at full detail from the live buffer. See DispatchHover
+      // for why this can't safely be gated on the reported detailLevel
+      // (DEFERRED perf, W-23408848).
       await recompileCursorFileAtFullDetail(
         svc,
         req.textDocument.uri,
         req.content,
       );
 
-      // Definition requires 'full' detail level per LspRequestPrerequisiteMapping
+      // Definition requires 'full' detail level per LspRequestPrerequisiteMapping.
       const requiredLevel = 'full';
       const needsEnrichment = shouldEnrich(detailLevel, requiredLevel);
 

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -1167,11 +1167,21 @@ export const ensureRequestServices: Effect.Effect<RequestServices> =
         // Wire coordinator assistance so the enrichment worker can forward
         // apex/findMissingArtifact to the coordinator (which holds the LSP
         // client connection) rather than silently dropping the request.
+        //
+        // blocking=true: the coordinator mediator must AWAIT its handler (drive
+        // the client to open the artifact, which flows to the data-owner via
+        // didOpen) and return the real FindMissingArtifactResult. With
+        // blocking=false the mediator returns {accepted:true} immediately, which
+        // the blocking-resolution caller would mis-read as "resolved" before the
+        // artifact actually loaded — so goto-definition's re-query saw nothing.
+        // The background caller doesn't await this promise, so blocking=true is
+        // harmless there (the coordinator queues background work Low-priority and
+        // returns promptly).
         EnhancedMissingArtifactResolutionService.setAssistanceProxy((params) =>
           requestCoordinatorAssistancePromiseShared(
             'apex/findMissingArtifact',
             params,
-            false,
+            true,
           ),
         );
 

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -628,12 +628,25 @@ export async function loadSymbolDataForEnrichment(
         }>;
         const classNames = new Set<string>();
         for (const ref of refs) {
-          if (
+          // Unresolved outbound type refs: fetch the owning file so the name
+          // resolves. Skipped once resolved (the resolvedSymbolId already points
+          // at the target for on-demand hover/definition).
+          const isUnresolvedTypeRef =
             !ref.resolvedSymbolId &&
             (ref.context === ReferenceContext.CLASS_REFERENCE ||
               ref.context === ReferenceContext.CONSTRUCTOR_CALL ||
-              ref.context === ReferenceContext.TYPE_DECLARATION)
-          ) {
+              ref.context === ReferenceContext.TYPE_DECLARATION);
+          // Supertype edges: `extends` (INHERITANCE) and `implements` / interface
+          // `extends` (INTERFACE_IMPLEMENTATION). These must be fetched EVEN WHEN
+          // the data-owner already resolved them (resolvedSymbolId set): the
+          // resolvedSymbolId only names the target — goto-definition and hover on
+          // the supertype still need the DECLARING FILE's symbol table PRESENT in
+          // this pool worker to produce a location. Without this, goto-def on a
+          // base class / interface declared in another file returns nothing.
+          const isSupertypeRef =
+            ref.context === ReferenceContext.INHERITANCE ||
+            ref.context === ReferenceContext.INTERFACE_IMPLEMENTATION;
+          if (isUnresolvedTypeRef || isSupertypeRef) {
             classNames.add(ref.name);
           }
         }
@@ -1666,6 +1679,21 @@ const requestHandlers = {
         req.content,
       );
 
+      // The data-owner serves the cursor file at PUBLIC-API detail only — the
+      // compilation worker collects it with VisibilitySymbolListener('public-api'),
+      // so implicit-private fields, locals, and private members are absent from
+      // that table. Hover on any such member would resolve to nothing. Recompile
+      // the cursor file locally at FULL detail from the live buffer (same move
+      // DispatchReferences makes) so member-level symbols exist for processHover.
+      // Runs AFTER loadSymbolDataForEnrichment so the full-detail table wins over
+      // the public-api one and the cross-file dep tables it loaded stay present
+      // for the re-resolve inside recompileCursorFileAtFullDetail.
+      await recompileCursorFileAtFullDetail(
+        svc,
+        req.textDocument.uri,
+        req.content,
+      );
+
       // Hover requires 'full' detail level per LspRequestPrerequisiteMapping
       const requiredLevel = 'full';
       const needsEnrichment = shouldEnrich(detailLevel, requiredLevel);
@@ -1797,6 +1825,21 @@ const requestHandlers = {
       const { version, detailLevel } = await loadSymbolDataForEnrichment(
         svc,
         req.textDocument.uri,
+        // Pass the live buffer so enrichment and the recompile below operate on
+        // the unsaved editor text, not the data-owner's last-stored version.
+        // (Previously omitted — definition resolved against stale stored state.)
+        req.content,
+      );
+
+      // Same as DispatchHover: the data-owner holds only public-api detail for
+      // the cursor file, so definition on a field/local/private member would
+      // resolve to nothing. Recompile the cursor file locally at full detail
+      // from the live buffer (after the enrichment load) so member-level symbols
+      // exist for processDefinition.
+      await recompileCursorFileAtFullDetail(
+        svc,
+        req.textDocument.uri,
+        req.content,
       );
 
       // Definition requires 'full' detail level per LspRequestPrerequisiteMapping

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -629,20 +629,17 @@ export async function loadSymbolDataForEnrichment(
         const classNames = new Set<string>();
         for (const ref of refs) {
           // Unresolved outbound type refs: fetch the owning file so the name
-          // resolves. Skipped once resolved (the resolvedSymbolId already points
-          // at the target for on-demand hover/definition).
+          // resolves. Skipped once resolved — the resolvedSymbolId already
+          // points at the target for on-demand hover/definition.
           const isUnresolvedTypeRef =
             !ref.resolvedSymbolId &&
             (ref.context === ReferenceContext.CLASS_REFERENCE ||
               ref.context === ReferenceContext.CONSTRUCTOR_CALL ||
               ref.context === ReferenceContext.TYPE_DECLARATION);
-          // Supertype edges: `extends` (INHERITANCE) and `implements` / interface
-          // `extends` (INTERFACE_IMPLEMENTATION). These must be fetched EVEN WHEN
-          // the data-owner already resolved them (resolvedSymbolId set): the
-          // resolvedSymbolId only names the target — goto-definition and hover on
-          // the supertype still need the DECLARING FILE's symbol table PRESENT in
-          // this pool worker to produce a location. Without this, goto-def on a
-          // base class / interface declared in another file returns nothing.
+          // Supertype edges (`extends`/`implements`) must be fetched even when
+          // already resolved: the resolvedSymbolId only names the target, but
+          // goto-definition still needs the declaring file's symbol table
+          // present in this pool worker to produce a location.
           const isSupertypeRef =
             ref.context === ReferenceContext.INHERITANCE ||
             ref.context === ReferenceContext.INTERFACE_IMPLEMENTATION;
@@ -1168,15 +1165,13 @@ export const ensureRequestServices: Effect.Effect<RequestServices> =
         // apex/findMissingArtifact to the coordinator (which holds the LSP
         // client connection) rather than silently dropping the request.
         //
-        // blocking=true: the coordinator mediator must AWAIT its handler (drive
+        // blocking=true: the coordinator mediator must await its handler (drive
         // the client to open the artifact, which flows to the data-owner via
         // didOpen) and return the real FindMissingArtifactResult. With
-        // blocking=false the mediator returns {accepted:true} immediately, which
-        // the blocking-resolution caller would mis-read as "resolved" before the
-        // artifact actually loaded — so goto-definition's re-query saw nothing.
-        // The background caller doesn't await this promise, so blocking=true is
-        // harmless there (the coordinator queues background work Low-priority and
-        // returns promptly).
+        // blocking=false it returns {accepted:true} immediately, which the
+        // blocking-resolution caller mis-reads as "resolved" before the artifact
+        // loads. The background caller doesn't await, so blocking=true is
+        // harmless there.
         EnhancedMissingArtifactResolutionService.setAssistanceProxy((params) =>
           requestCoordinatorAssistancePromiseShared(
             'apex/findMissingArtifact',
@@ -1689,15 +1684,12 @@ const requestHandlers = {
         req.content,
       );
 
-      // The data-owner serves the cursor file at PUBLIC-API detail only — the
-      // compilation worker collects it with VisibilitySymbolListener('public-api'),
-      // so implicit-private fields, locals, and private members are absent from
-      // that table. Hover on any such member would resolve to nothing. Recompile
-      // the cursor file locally at FULL detail from the live buffer (same move
-      // DispatchReferences makes) so member-level symbols exist for processHover.
-      // Runs AFTER loadSymbolDataForEnrichment so the full-detail table wins over
-      // the public-api one and the cross-file dep tables it loaded stay present
-      // for the re-resolve inside recompileCursorFileAtFullDetail.
+      // The data-owner holds the cursor file at public-api detail only, so
+      // implicit-private fields, locals, and private members are absent and
+      // hover on them resolves to nothing. Recompile locally at full detail
+      // from the live buffer. Runs after loadSymbolDataForEnrichment so the
+      // full-detail table wins while the cross-file dep tables it loaded stay
+      // present for the re-resolve inside recompileCursorFileAtFullDetail.
       await recompileCursorFileAtFullDetail(
         svc,
         req.textDocument.uri,
@@ -1835,17 +1827,14 @@ const requestHandlers = {
       const { version, detailLevel } = await loadSymbolDataForEnrichment(
         svc,
         req.textDocument.uri,
-        // Pass the live buffer so enrichment and the recompile below operate on
-        // the unsaved editor text, not the data-owner's last-stored version.
-        // (Previously omitted — definition resolved against stale stored state.)
+        // Live buffer so enrichment and the recompile below run on the unsaved
+        // editor text, not the data-owner's last-stored version.
         req.content,
       );
 
-      // Same as DispatchHover: the data-owner holds only public-api detail for
-      // the cursor file, so definition on a field/local/private member would
-      // resolve to nothing. Recompile the cursor file locally at full detail
-      // from the live buffer (after the enrichment load) so member-level symbols
-      // exist for processDefinition.
+      // As in DispatchHover: the data-owner holds only public-api detail, so
+      // definition on a field/local/private member resolves to nothing.
+      // Recompile locally at full detail from the live buffer.
       await recompileCursorFileAtFullDetail(
         svc,
         req.textDocument.uri,

--- a/packages/apex-lsp-shared/src/workerWireSchemas.ts
+++ b/packages/apex-lsp-shared/src/workerWireSchemas.ts
@@ -568,11 +568,10 @@ export class DispatchDefinition extends Schema.TaggedRequest<DispatchDefinition>
     payload: {
       textDocument: WireTextDocumentId,
       position: WirePosition,
-      // Live (possibly unsaved) document text. The request worker recompiles
-      // this at full detail so member-level symbols (fields, locals, private
-      // members) — which the dataOwner only stores at public-api detail — exist
-      // for position→declaration resolution. Without it, goto-definition on a
-      // field/local/private member returns nothing. Mirrors DispatchHover.
+      // Live (possibly unsaved) document text. The request worker recompiles it
+      // at full detail so member-level symbols (fields, locals, private members)
+      // — which the dataOwner only stores at public-api detail — exist for
+      // position→declaration resolution. Mirrors DispatchHover.
       content: Schema.optional(Schema.String),
     },
   },

--- a/packages/apex-lsp-shared/src/workerWireSchemas.ts
+++ b/packages/apex-lsp-shared/src/workerWireSchemas.ts
@@ -568,6 +568,12 @@ export class DispatchDefinition extends Schema.TaggedRequest<DispatchDefinition>
     payload: {
       textDocument: WireTextDocumentId,
       position: WirePosition,
+      // Live (possibly unsaved) document text. The request worker recompiles
+      // this at full detail so member-level symbols (fields, locals, private
+      // members) — which the dataOwner only stores at public-api detail — exist
+      // for position→declaration resolution. Without it, goto-definition on a
+      // field/local/private member returns nothing. Mirrors DispatchHover.
+      content: Schema.optional(Schema.String),
     },
   },
 ) {}

--- a/packages/apex-lsp-vscode-extension/src/missing-artifact-handler.ts
+++ b/packages/apex-lsp-vscode-extension/src/missing-artifact-handler.ts
@@ -119,12 +119,11 @@ async function resolveFromWorkspace(
     return { notFound: true };
   }
 
-  // The origin file is already open — re-opening it can never resolve a
-  // *missing* artifact. It must be excluded from candidates: the
-  // parentContext.containingType strategy generates a pattern for the class
-  // enclosing the reference (always the origin file for supertype refs like
-  // `implements DataProcessor`), which otherwise sorts highest and
-  // short-circuits the loop before the correct target strategy runs.
+  // Exclude the origin file from candidates — it's already open, so re-opening
+  // it can never resolve a *missing* artifact. The parentContext.containingType
+  // strategy targets the class enclosing the reference (the origin file itself
+  // for supertype refs like `implements DataProcessor`), which otherwise sorts
+  // highest and short-circuits the loop before the correct target strategy runs.
   const originPath = originPathFor(params.origin?.uri);
 
   const uniqueSpecs = dedupeByIdentifierName(identifiers);

--- a/packages/apex-lsp-vscode-extension/src/missing-artifact-handler.ts
+++ b/packages/apex-lsp-vscode-extension/src/missing-artifact-handler.ts
@@ -17,6 +17,30 @@ import { findFilesAcrossWorkspaceFolders } from './workspace-find-files';
 /** sObject suffix patterns — these types have no .cls file. */
 const SOBJECT_SUFFIX_RE = /__[cCrReEbBmMxX]$/;
 
+/**
+ * Reduce a URI to a scheme-independent path for origin comparison. The
+ * missing-artifact request carries the origin URI in whatever scheme the
+ * client opened it (file, vscode-vfs, vscode-test-web…), while candidate
+ * matches come back from findFiles/walkDirectory. Comparing the decoded
+ * path segment sidesteps scheme/encoding differences.
+ */
+function originPathFor(uri: string | undefined): string | undefined {
+  if (!uri) return undefined;
+  try {
+    return vscode.Uri.parse(uri).path;
+  } catch {
+    return undefined;
+  }
+}
+
+/** True when a candidate URI is the origin file itself. */
+function isOriginFile(
+  candidate: vscode.Uri,
+  originPath: string | undefined,
+): boolean {
+  return originPath !== undefined && candidate.path === originPath;
+}
+
 export async function handleFindMissingArtifact(
   params: FindMissingArtifactParams,
   _context: vscode.ExtensionContext,
@@ -95,6 +119,14 @@ async function resolveFromWorkspace(
     return { notFound: true };
   }
 
+  // The origin file is already open — re-opening it can never resolve a
+  // *missing* artifact. It must be excluded from candidates: the
+  // parentContext.containingType strategy generates a pattern for the class
+  // enclosing the reference (always the origin file for supertype refs like
+  // `implements DataProcessor`), which otherwise sorts highest and
+  // short-circuits the loop before the correct target strategy runs.
+  const originPath = originPathFor(params.origin?.uri);
+
   const uniqueSpecs = dedupeByIdentifierName(identifiers);
   const allFiles = new Set<string>();
 
@@ -102,7 +134,8 @@ async function resolveFromWorkspace(
     const searchStrategies = generateSearchStrategiesForSpec(spec);
 
     for (const strategy of searchStrategies) {
-      const files = await searchWithStrategy(strategy, maxCandidates);
+      const found = await searchWithStrategy(strategy, maxCandidates);
+      const files = found.filter((f) => !isOriginFile(f, originPath));
       for (const f of files) {
         allFiles.add(f.toString());
       }

--- a/packages/lsp-compliant-services/src/services/DefinitionProcessingService.ts
+++ b/packages/lsp-compliant-services/src/services/DefinitionProcessingService.ts
@@ -322,7 +322,14 @@ export class DefinitionProcessingService implements IDefinitionProcessor {
 
       // Check for duplicate definitions (same unifiedId)
       // For duplicate symbols, return all definition locations so users can see all duplicates
-      // This helps users identify duplicate declaration errors
+      // This helps users identify duplicate declaration errors.
+      //
+      // Match on kind as well as unifiedId: a genuine duplicate declaration is
+      // always the same kind (e.g. two fields sharing a name), whereas a field
+      // and a same-named constructor parameter can share a unifiedId today — the
+      // parser derives the id from a scope path that collapses a constructor's
+      // scope onto its enclosing class — yet they are different kinds and must
+      // not be grouped.
       let allSymbols: ApexSymbol[] = [symbol];
       if (symbol.key?.unifiedId) {
         // Try to find duplicates by getting all symbols in the file and checking for same unifiedId
@@ -330,7 +337,8 @@ export class DefinitionProcessingService implements IDefinitionProcessor {
           symbol.fileUri,
         );
         const duplicates = fileSymbols.filter(
-          (s) => s.key?.unifiedId === symbol.key.unifiedId,
+          (s) =>
+            s.key?.unifiedId === symbol.key.unifiedId && s.kind === symbol.kind,
         );
         if (duplicates.length > 1) {
           // Found duplicates - include all of them
@@ -353,13 +361,29 @@ export class DefinitionProcessingService implements IDefinitionProcessor {
         locations.push(...symLocations);
       }
 
+      // Collapse locations that point at the same declaration line. A genuine
+      // duplicate declaration lives on its own line, but layered compilation
+      // (public-api load + full recompile) can leave two same-kind entries for
+      // one declaration on the SAME line — one anchored to the identifier, one
+      // to the type token. Returning both makes VS Code open a peek instead of
+      // jumping, so keep only the first location per (uri, line).
+      const seen = new Set<string>();
+      const dedupedLocations = locations.filter((loc) => {
+        const lineKey = `${loc.uri}#${loc.range.start.line}`;
+        if (seen.has(lineKey)) {
+          return false;
+        }
+        seen.add(lineKey);
+        return true;
+      });
+
       this.logger.debug(
         () =>
-          `Returning ${locations.length} definition location(s) for: ${symbol?.name ?? 'null'}`,
+          `Returning ${dedupedLocations.length} definition location(s) for: ${symbol?.name ?? 'null'}`,
       );
 
       // Return the locations array (may contain multiple locations for duplicates)
-      return locations;
+      return dedupedLocations;
     } catch (error) {
       this.logger.error(() => `Error processing definition request: ${error}`);
       return null;

--- a/packages/lsp-compliant-services/src/services/DefinitionProcessingService.ts
+++ b/packages/lsp-compliant-services/src/services/DefinitionProcessingService.ts
@@ -361,6 +361,16 @@ export class DefinitionProcessingService implements IDefinitionProcessor {
       // recompile) can leave two same-kind entries for one declaration on the
       // same line — one on the identifier, one on the type token. Returning both
       // makes VS Code open a peek instead of jumping, so keep one per (uri, line).
+      //
+      // DEFERRED (W-23408848, do NOT "fix" by adding column to the key): keying
+      // on (uri, line) can also collapse two GENUINE duplicate declarations that
+      // happen to share a line, e.g. a multi-declarator `String a, a;`. That is
+      // a rare, already-degenerate case. Adding startColumn to the key would
+      // separate such duplicates — BUT it would also re-separate the layered
+      // identifier/type-token artifacts above (which differ ONLY by column) and
+      // reintroduce the peek bug this fix removes. If genuine same-line
+      // duplicates must be surfaced later, dedup on (uri, line, unifiedId+kind)
+      // — NOT column.
       const seen = new Set<string>();
       const dedupedLocations = locations.filter((loc) => {
         const lineKey = `${loc.uri}#${loc.range.start.line}`;

--- a/packages/lsp-compliant-services/src/services/DefinitionProcessingService.ts
+++ b/packages/lsp-compliant-services/src/services/DefinitionProcessingService.ts
@@ -320,19 +320,14 @@ export class DefinitionProcessingService implements IDefinitionProcessor {
         wasResolvedFromMissingArtifact,
       };
 
-      // Check for duplicate definitions (same unifiedId)
-      // For duplicate symbols, return all definition locations so users can see all duplicates
-      // This helps users identify duplicate declaration errors.
-      //
-      // Match on kind as well as unifiedId: a genuine duplicate declaration is
+      // Return all locations for a genuine duplicate declaration so users can
+      // spot the error. Match on kind as well as unifiedId: a real duplicate is
       // always the same kind (e.g. two fields sharing a name), whereas a field
-      // and a same-named constructor parameter can share a unifiedId today — the
-      // parser derives the id from a scope path that collapses a constructor's
-      // scope onto its enclosing class — yet they are different kinds and must
-      // not be grouped.
+      // and a same-named constructor parameter can share a unifiedId today (the
+      // parser collapses a constructor's scope onto its enclosing class) yet are
+      // different kinds and must not be grouped.
       let allSymbols: ApexSymbol[] = [symbol];
       if (symbol.key?.unifiedId) {
-        // Try to find duplicates by getting all symbols in the file and checking for same unifiedId
         const fileSymbols = await this.symbolManager.findSymbolsInFile(
           symbol.fileUri,
         );
@@ -361,12 +356,11 @@ export class DefinitionProcessingService implements IDefinitionProcessor {
         locations.push(...symLocations);
       }
 
-      // Collapse locations that point at the same declaration line. A genuine
-      // duplicate declaration lives on its own line, but layered compilation
-      // (public-api load + full recompile) can leave two same-kind entries for
-      // one declaration on the SAME line — one anchored to the identifier, one
-      // to the type token. Returning both makes VS Code open a peek instead of
-      // jumping, so keep only the first location per (uri, line).
+      // Collapse locations on the same declaration line. A genuine duplicate
+      // lives on its own line, but layered compilation (public-api load + full
+      // recompile) can leave two same-kind entries for one declaration on the
+      // same line — one on the identifier, one on the type token. Returning both
+      // makes VS Code open a peek instead of jumping, so keep one per (uri, line).
       const seen = new Set<string>();
       const dedupedLocations = locations.filter((loc) => {
         const lineKey = `${loc.uri}#${loc.range.start.line}`;
@@ -382,7 +376,6 @@ export class DefinitionProcessingService implements IDefinitionProcessor {
           `Returning ${dedupedLocations.length} definition location(s) for: ${symbol?.name ?? 'null'}`,
       );
 
-      // Return the locations array (may contain multiple locations for duplicates)
       return dedupedLocations;
     } catch (error) {
       this.logger.error(() => `Error processing definition request: ${error}`);

--- a/packages/lsp-compliant-services/src/services/MissingArtifactResolutionService.ts
+++ b/packages/lsp-compliant-services/src/services/MissingArtifactResolutionService.ts
@@ -158,16 +158,13 @@ export class EnhancedMissingArtifactResolutionService implements MissingArtifact
 
     const requestPromise = (async (): Promise<BlockingResult> => {
       try {
-        // Worker context (enrichment/request pool): there is no LSP connection
-        // and this worker's queue manager cannot reach the client, so submitting
-        // findMissingArtifact to the local queue would resolve nothing. Forward
-        // the blocking request through the coordinator assistance proxy and AWAIT
-        // it — the coordinator owns the connection, drives the client to open the
-        // artifact (which flows to the data-owner via didOpen), and returns the
-        // FindMissingArtifactResult. Only the background path used the proxy
-        // before, so blocking resolution (goto-definition's responsive path)
-        // silently failed in the pool. Awaiting here means the caller's re-query
-        // sees the freshly-loaded artifact.
+        // Worker context (enrichment/request pool): no LSP connection, so the
+        // local queue can't reach the client and would resolve nothing. Forward
+        // the blocking request through the coordinator assistance proxy and
+        // await it — the coordinator owns the connection, drives the client to
+        // open the artifact (which flows to the data-owner via didOpen), and
+        // returns the result. Awaiting here means the caller's re-query sees the
+        // freshly-loaded artifact.
         const proxy = EnhancedMissingArtifactResolutionService.assistanceProxy;
         if (!this.getConnection() && proxy) {
           this.logger.debug(

--- a/packages/lsp-compliant-services/src/services/MissingArtifactResolutionService.ts
+++ b/packages/lsp-compliant-services/src/services/MissingArtifactResolutionService.ts
@@ -156,6 +156,13 @@ export class EnhancedMissingArtifactResolutionService implements MissingArtifact
       return 'unsupported';
     }
 
+    // Sanitize once and reuse for every sink (proxy + queue). Both terminate in
+    // a structured-clone postMessage, and symbol-manager class instances
+    // (typeReference, parentContext.*) are not cloneable — an unsanitized
+    // payload throws DataCloneError and silently fails resolution.
+    const safeParams = this.sanitizeParams(params);
+    const timeoutMs = params.timeoutMsHint || this.config.blockingWaitTimeoutMs;
+
     const requestPromise = (async (): Promise<BlockingResult> => {
       try {
         // Worker context (enrichment/request pool): no LSP connection, so the
@@ -171,13 +178,24 @@ export class EnhancedMissingArtifactResolutionService implements MissingArtifact
             () =>
               `Forwarding blocking resolution via assistance proxy for: ${names}`,
           );
-          const proxyResult = await proxy(params);
+          // The proxy chain (requestCoordinatorAssistance) has no self-imposed
+          // rejection; without a bound, a lost/errored coordinator response
+          // would hang hover/definition on the hot path forever. Race against
+          // the same budget the queue path uses; a timeout throws and is
+          // handled by the shared catch below (records cooldown, returns
+          // 'timeout').
+          const proxyResult = await this.withTimeout(
+            proxy(safeParams),
+            timeoutMs,
+          );
+          // Reaching here means the proxy resolved without throwing, so any
+          // prior timeout cooldown for this key is stale — clear it.
+          // (mapResultToBlockingResult only yields 'resolved'/'not-found';
+          // timeouts surface as a thrown error handled by the catch below.)
           const mappedProxy = this.mapResultToBlockingResult(proxyResult);
-          if (mappedProxy !== 'timeout') {
-            EnhancedMissingArtifactResolutionService.recentBlockingTimeouts.delete(
-              key,
-            );
-          }
+          EnhancedMissingArtifactResolutionService.recentBlockingTimeouts.delete(
+            key,
+          );
           if (shouldObserve) {
             this.logger.debug(
               () =>
@@ -194,22 +212,23 @@ export class EnhancedMissingArtifactResolutionService implements MissingArtifact
           requestKind === 'definition' ? Priority.High : Priority.Normal;
         const result = await this.getQueueManager().submitRequest(
           'findMissingArtifact',
-          params,
+          safeParams,
           {
             priority,
-            timeout: params.timeoutMsHint || this.config.blockingWaitTimeoutMs,
+            timeout: timeoutMs,
           },
         );
 
         this.logger.debug(() => `Blocking resolution completed for: ${names}`);
 
-        // Map the result to BlockingResult
+        // Map the result to BlockingResult. Reaching here means the queue
+        // resolved without throwing, so clear any stale timeout cooldown for
+        // this key. (mapResultToBlockingResult only yields
+        // 'resolved'/'not-found'; queue timeouts throw and are handled below.)
         const mapped = this.mapResultToBlockingResult(result);
-        if (mapped !== 'timeout') {
-          EnhancedMissingArtifactResolutionService.recentBlockingTimeouts.delete(
-            key,
-          );
-        }
+        EnhancedMissingArtifactResolutionService.recentBlockingTimeouts.delete(
+          key,
+        );
         if (shouldObserve) {
           this.logger.debug(
             () =>
@@ -281,25 +300,8 @@ export class EnhancedMissingArtifactResolutionService implements MissingArtifact
     }
 
     try {
-      // Get LSP connection to send request to client
       // Sanitize params before sending via postMessage (structured clone).
-      // Symbol manager class instances (typeReference, parentContext.*) are not
-      // cloneable. Schema.decodeUnknownSync creates a new plain object containing
-      // only the declared wire-schema fields, stripping all class extras.
-      const decodeIdentifier = Schema.decodeUnknownSync(
-        WireIdentifierSpecSchema,
-      );
-      const safeParams = {
-        ...params,
-        identifiers: params.identifiers.map((id) => {
-          try {
-            return decodeIdentifier(id);
-          } catch {
-            // Fallback: name-only if the identifier deviates from the wire schema
-            return { name: id.name };
-          }
-        }),
-      };
+      const safeParams = this.sanitizeParams(params);
 
       const connection = this.getConnection();
       if (!connection) {
@@ -366,6 +368,52 @@ export class EnhancedMissingArtifactResolutionService implements MissingArtifact
       );
       // Don't throw - background resolution failures shouldn't block the main flow
     }
+  }
+
+  /**
+   * Sanitize params before sending via postMessage (structured clone).
+   * Symbol manager class instances (typeReference, parentContext.*) are not
+   * cloneable. Schema.decodeUnknownSync creates a new plain object containing
+   * only the declared wire-schema fields, stripping all class extras. Shared by
+   * every sink that forwards params across a worker boundary (proxy + queue).
+   */
+  private sanitizeParams(
+    params: FindMissingArtifactParams,
+  ): FindMissingArtifactParams {
+    const decodeIdentifier = Schema.decodeUnknownSync(WireIdentifierSpecSchema);
+    // Schema.decode yields deeply-readonly values; the runtime object is a
+    // plain structured-clone-safe payload, so cast back to the mutable param
+    // type for the sinks that consume it.
+    return {
+      ...params,
+      identifiers: params.identifiers.map((id) => {
+        try {
+          return decodeIdentifier(id);
+        } catch {
+          // Fallback: name-only if the identifier deviates from the wire schema
+          return { name: id.name };
+        }
+      }),
+    } as FindMissingArtifactParams;
+  }
+
+  /**
+   * Race a promise against a timeout. Rejects with a timeout Error (matched by
+   * the caller's `error.message.includes('timeout')` cooldown handling) if the
+   * budget elapses first.
+   */
+  private withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+    let timer: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(
+        () =>
+          reject(new Error(`Blocking resolution timeout after ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+    });
+    return Promise.race([promise, timeout]).finally(() =>
+      clearTimeout(timer),
+    ) as Promise<T>;
   }
 
   /**

--- a/packages/lsp-compliant-services/src/services/MissingArtifactResolutionService.ts
+++ b/packages/lsp-compliant-services/src/services/MissingArtifactResolutionService.ts
@@ -158,6 +158,39 @@ export class EnhancedMissingArtifactResolutionService implements MissingArtifact
 
     const requestPromise = (async (): Promise<BlockingResult> => {
       try {
+        // Worker context (enrichment/request pool): there is no LSP connection
+        // and this worker's queue manager cannot reach the client, so submitting
+        // findMissingArtifact to the local queue would resolve nothing. Forward
+        // the blocking request through the coordinator assistance proxy and AWAIT
+        // it — the coordinator owns the connection, drives the client to open the
+        // artifact (which flows to the data-owner via didOpen), and returns the
+        // FindMissingArtifactResult. Only the background path used the proxy
+        // before, so blocking resolution (goto-definition's responsive path)
+        // silently failed in the pool. Awaiting here means the caller's re-query
+        // sees the freshly-loaded artifact.
+        const proxy = EnhancedMissingArtifactResolutionService.assistanceProxy;
+        if (!this.getConnection() && proxy) {
+          this.logger.debug(
+            () =>
+              `Forwarding blocking resolution via assistance proxy for: ${names}`,
+          );
+          const proxyResult = await proxy(params);
+          const mappedProxy = this.mapResultToBlockingResult(proxyResult);
+          if (mappedProxy !== 'timeout') {
+            EnhancedMissingArtifactResolutionService.recentBlockingTimeouts.delete(
+              key,
+            );
+          }
+          if (shouldObserve) {
+            this.logger.debug(
+              () =>
+                `[REQ-HARDEN] missingArtifact blocking end (proxy) kind=${requestKind} ` +
+                `result=${mappedProxy} durationMs=${Date.now() - startedAt}`,
+            );
+          }
+          return mappedProxy;
+        }
+
         // Priority tuning: keep definition responsive, but avoid starving hover/startup
         // with high-priority artifact loads during workspace churn.
         const priority =

--- a/packages/lsp-compliant-services/test/integration/DefinitionFieldParamDuplicate.integration.test.ts
+++ b/packages/lsp-compliant-services/test/integration/DefinitionFieldParamDuplicate.integration.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Regression: go-to-definition on a field must return a SINGLE location so VS
+ * Code jumps rather than opening a peek (W-23408848). Two distinct duplicate
+ * sources produced extra locations for a plain field:
+ *
+ *   1. Field vs. same-named constructor parameter. The parser derives a
+ *      symbol's unifiedId from its scope path, and a constructor's scope name
+ *      equals the enclosing class name, so a class field and a same-named
+ *      constructor parameter collapse onto one unifiedId
+ *      (`<file>#block.<Class>.<name>`). The duplicate grouping keyed only on
+ *      unifiedId returned both — a field AND a parameter. Fixed by also
+ *      matching on kind (a genuine duplicate declaration is always the same
+ *      kind; a field and a parameter never are).
+ *
+ *   2. Layered compilation artifacts. The pool worker loads the file at
+ *      public-api detail then recompiles it at full detail; the two passes can
+ *      leave two same-kind field entries on the SAME line — one anchored to the
+ *      identifier, one to the type token. Fixed by collapsing definition
+ *      locations that share a (uri, line): a real duplicate declaration lives
+ *      on its own line.
+ *
+ * Both broke the "navigate to field definition" e2e (multiple locations → peek
+ * → the harness escapes the peek → cursor never moves).
+ */
+
+import { DefinitionParams } from 'vscode-languageserver-protocol';
+
+import { DefinitionProcessingService } from '../../src/services/DefinitionProcessingService';
+import {
+  ApexSymbolManager,
+  CompilerService,
+  FullSymbolCollectorListener,
+  VisibilitySymbolListener,
+  SymbolTable,
+} from '@salesforce/apex-lsp-parser-ast';
+import {
+  enableConsoleLogging,
+  setLogLevel,
+  getLogger,
+} from '@salesforce/apex-lsp-shared';
+import { Effect } from 'effect';
+
+const URI = 'file:///ApexClassExample.cls';
+// A class field shadowed by a same-named constructor parameter — the exact
+// shape that collapses onto one unifiedId in the parser.
+const SRC = `public class ApexClassExample {
+    private String instanceId;
+
+    public ApexClassExample(String instanceId) {
+        if (String.isBlank(instanceId)) {
+            instanceId = 'default';
+        }
+        this.instanceId = instanceId;
+    }
+}`;
+
+// line index 1 (0-based): "    private String instanceId;"
+const FIELD_LINE = 1;
+
+describe('DefinitionProcessingService - field definition single location', () => {
+  const fieldDeclParams = (): DefinitionParams => {
+    const line = SRC.split('\n')[FIELD_LINE];
+    return {
+      textDocument: { uri: URI },
+      position: { line: FIELD_LINE, character: line.indexOf('instanceId') },
+    };
+  };
+
+  beforeAll(() => {
+    enableConsoleLogging();
+    setLogLevel('error');
+  });
+
+  it('returns a single location for a field shadowed by a same-named constructor parameter', async () => {
+    const symbolManager = new ApexSymbolManager();
+    const compilerService = new CompilerService();
+    const table = new SymbolTable();
+    const listener = new FullSymbolCollectorListener(table);
+    compilerService.compile(SRC, URI, listener, {});
+    await Effect.runPromise(symbolManager.addSymbolTable(table, URI));
+    const definitionService = new DefinitionProcessingService(
+      getLogger(),
+      symbolManager,
+    );
+
+    const result = await definitionService.processDefinition(fieldDeclParams());
+
+    expect(result).toBeDefined();
+    // Exactly one location — the field declaration — NOT the field plus the
+    // same-named constructor parameter.
+    expect(result!.length).toBe(1);
+    expect(result![0].range.start.line).toBe(FIELD_LINE);
+  });
+
+  it('returns a single location after a layered public-api + full recompile (same-line artifacts)', async () => {
+    // Mirror the pool worker: ingest the file at public-api detail, then
+    // recompile it at full detail. The two passes can leave two same-kind field
+    // entries on the field's line; the (uri, line) collapse must fold them.
+    const symbolManager = new ApexSymbolManager();
+    const compilerService = new CompilerService();
+
+    const publicApiTable = new SymbolTable();
+    compilerService.compile(
+      SRC,
+      URI,
+      new VisibilitySymbolListener('public-api', publicApiTable),
+      {},
+    );
+    await Effect.runPromise(symbolManager.addSymbolTable(publicApiTable, URI));
+
+    const fullTable = new SymbolTable();
+    compilerService.compile(
+      SRC,
+      URI,
+      new FullSymbolCollectorListener(fullTable),
+      { collectReferences: true, resolveReferences: true },
+    );
+    await Effect.runPromise(symbolManager.addSymbolTable(fullTable, URI));
+
+    const definitionService = new DefinitionProcessingService(
+      getLogger(),
+      symbolManager,
+    );
+
+    const result = await definitionService.processDefinition(fieldDeclParams());
+
+    expect(result).toBeDefined();
+    expect(result!.length).toBe(1);
+    expect(result![0].range.start.line).toBe(FIELD_LINE);
+  });
+});

--- a/packages/lsp-compliant-services/test/services/MissingArtifactResolutionService-blocking-proxy.test.ts
+++ b/packages/lsp-compliant-services/test/services/MissingArtifactResolutionService-blocking-proxy.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  LSPConfigurationManager,
+  getLogger,
+  ApexSettingsManager,
+} from '@salesforce/apex-lsp-shared';
+import { EnhancedMissingArtifactResolutionService } from '../../src/services/MissingArtifactResolutionService';
+
+/**
+ * Tests for the blocking assistance-proxy path (worker context, no LSP
+ * connection). Covers the two review-blocking fixes:
+ *   1. params forwarded to the proxy are sanitized (non-cloneable symbol
+ *      manager instances stripped) so structured-clone postMessage can't throw.
+ *   2. a proxy that never settles is bounded by a timeout instead of hanging
+ *      the hover/definition hot path forever.
+ */
+describe('MissingArtifactResolutionService — blocking assistance proxy', () => {
+  let service: EnhancedMissingArtifactResolutionService;
+
+  beforeEach(() => {
+    LSPConfigurationManager.resetInstance();
+    ApexSettingsManager.resetInstance();
+
+    const settingsManager = ApexSettingsManager.getInstance(
+      undefined,
+      'desktop',
+    );
+    settingsManager.updateSettings({
+      apex: {
+        findMissingArtifact: {
+          enabled: true,
+          maxCandidatesToOpen: 3,
+          timeoutMsHint: 2000,
+          blockingWaitTimeoutMs: 5000,
+          indexingBarrierPollMs: 100,
+          enablePerfMarks: false,
+        },
+      },
+    } as any);
+
+    // No connection set on the config manager → resolveBlocking takes the
+    // assistance-proxy branch.
+    LSPConfigurationManager.getInstance();
+
+    service = new EnhancedMissingArtifactResolutionService(getLogger(), {
+      blockingWaitTimeoutMs: 5000,
+      indexingBarrierPollMs: 100,
+    });
+  });
+
+  afterEach(() => {
+    EnhancedMissingArtifactResolutionService.setAssistanceProxy(
+      undefined as any,
+    );
+    LSPConfigurationManager.resetInstance();
+    ApexSettingsManager.resetInstance();
+  });
+
+  // A non-cloneable identifier: a class instance carrying a method. Passing
+  // this straight into structured clone (postMessage) throws DataCloneError.
+  class NonCloneableTypeReference {
+    name = 'MissingClass';
+    resolve() {
+      return this.name;
+    }
+  }
+
+  const makeParams = () => ({
+    identifiers: [
+      {
+        name: 'MissingClass',
+        typeReference: new NonCloneableTypeReference(),
+      } as any,
+    ],
+    mode: 'blocking' as const,
+    origin: {
+      uri: 'file:///test.cls',
+      requestKind: 'definition' as const,
+    },
+  });
+
+  it('sanitizes params before forwarding through the assistance proxy', async () => {
+    const proxy = jest
+      .fn()
+      .mockResolvedValue({ opened: ['file:///Found.cls'] });
+    EnhancedMissingArtifactResolutionService.setAssistanceProxy(proxy);
+
+    const result = await service.resolveBlocking(makeParams());
+
+    expect(result).toBe('resolved');
+    expect(proxy).toHaveBeenCalledTimes(1);
+
+    // The forwarded identifier must be a plain, structured-clone-safe object:
+    // no class prototype, no methods.
+    const forwarded = proxy.mock.calls[0][0];
+    const forwardedId = forwarded.identifiers[0];
+    expect(forwardedId.name).toBe('MissingClass');
+    expect(typeof (forwardedId.typeReference as any)?.resolve).not.toBe(
+      'function',
+    );
+    // structuredClone must not throw on the sanitized payload.
+    expect(() => structuredClone(forwarded)).not.toThrow();
+  });
+
+  it('returns timeout when the proxy never settles', async () => {
+    // A proxy that hangs forever.
+    const proxy = jest.fn().mockReturnValue(new Promise(() => {}));
+    EnhancedMissingArtifactResolutionService.setAssistanceProxy(proxy);
+
+    // Tight budget so the test is fast.
+    const fastService = new EnhancedMissingArtifactResolutionService(
+      getLogger(),
+      { blockingWaitTimeoutMs: 50, indexingBarrierPollMs: 100 },
+    );
+
+    const result = await fastService.resolveBlocking(makeParams());
+
+    expect(result).toBe('timeout');
+    expect(proxy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes web request-pool resolution: hover, go-to-definition, and find-references all returned empty (or opened the wrong widget) in VS Code Web. The worker topology was silently dead in the browser and several pool code paths dropped the detail/content needed to resolve members and cross-file symbols. #544 masked the regression by falling back to a coordinator-local path.

Verified via the node worker topology harness (same `worker.platform.shared.ts` the web bundle uses) and web e2e on fresh bundles: **hover 21/21, goto-definition 29/29, find-references 4/4** — all web pool resolution green.

**Root causes fixed (all verified, not assumed):**

**1. Topology was dead in web** (`286b737ac`). The browser branch built the worker URL from `location.href`, but VS Code Web serves the server bundle from a `blob:` URL — invalid as a URL base → topology init threw → the dispatcher was never wired → hover/goto silently fell back to coordinator-local and references (empty-stub local handler) returned `[]`. Now falls back to the absolute `workerPlatformWebUrl` when href is `blob:`; the fetched script is re-wrapped in a same-origin blob (no CORS issue). Topology now reliably active (pool size 2).

**2. Data-owner held only public-api detail** (`286b737ac`). The compilation worker compiles with `VisibilitySymbolListener('public-api')`, dropping implicit-private fields/locals/private members, so pool hover/def on a field or local resolved to nothing. `DispatchHover` + `DispatchDefinition` now `recompileCursorFileAtFullDetail(req.content)` after enrichment load.

**3. `DispatchDefinition` wire schema was missing `content`** (`286b737ac`). Without it `req.content` was always `undefined` → the full-detail recompile returned early → definition on members returned `[]`. Added `content` to the schema and populated it in `buildLspRequestMessage`.

**4. Cross-file supertype dep-fetch gap** (`286b737ac`). The Phase-2 dependency prefetch only collected `CLASS_REFERENCE`/`CONSTRUCTOR_CALL`/`TYPE_DECLARATION` and only when unresolved. `implements`/`extends` refs are `INTERFACE_IMPLEMENTATION`/`INHERITANCE` and come back already-resolved, so the supertype's declaring file was never ingested into the pool worker. Now fetches supertype refs even when resolved (the declaring file's table must be present locally for goto-def to yield a location).

**5. Pool blocking missing-artifact resolution was a no-op** (`a333b35c0`). `resolveBlocking` always submitted to the pool worker's own queue (no client connection → no-op). Now routes through the awaited assistance proxy when there's no local connection; paired with `setAssistanceProxy` blocking so the coordinator mediator awaits its handler instead of returning `{accepted:true}` prematurely. Makes cross-file inherited-method goto pass.

**6. Missing-artifact finder re-opened the origin file** (`753e17368`). `resolveFromWorkspace` broke on the first strategy returning any file, and the `parentContext.containingType` strategy targets the enclosing class (= the origin file, always present) at higher confidence than the correct `**/Target.cls` strategies — so it re-opened the already-open origin (a no-op for a *missing* artifact) and never reached the target. Now filters the origin file out of each strategy's matches before the first-hit short-circuit. Web goto-def 25/29 → 28/29; all cross-file interface/base/inherited cases pass.

**7. Field go-to-definition opened a peek instead of jumping** (`4cc8c126c`). Two duplicate sources fed `DefinitionProcessingService`'s duplicate-declaration grouping: (a) a field and a same-named constructor parameter collapse onto one `unifiedId` because the constructor's scope name equals the enclosing class name — now also matched on `kind` (a real duplicate declaration is always the same kind; a field and a parameter never are); (b) layered public-api + full recompile can leave two same-kind field entries on the same line (one anchored to the identifier, one to the type token) — now collapsed by `(uri, line)`, since a genuine duplicate declaration lives on its own line. Added `DefinitionFieldParamDuplicate.integration.test.ts` covering both. Web goto-def 28/29 → 29/29.

**Test/harness fix** (`d83cd23f9`): find-references web e2e was 1/4 due entirely to the harness (the LSP resolved references correctly). `findReferences()` waited on the go-to-definition peek selector instead of the find-all-references `reference-zone-widget`; the result tree is virtualized so row counting undercounted (now parses the authoritative total from the peek title); and the tests targeted minimal same-file symbols that VS Code Web won't open a peek for. Retargeted to a field with multiple same-file references; deterministic 4/4.

### What issues does this PR fix or reference?

@W-23408848@
