### PR TITLE
chore: merge main (#549, #551) into W-23354947 + resolve conflicts

### DIFF
--- a/docs/plans/W-23163187.md
+++ b/docs/plans/W-23163187.md
@@ -1,0 +1,139 @@
+# W-23163187 — Typed apex/* surface for ApexClientCore
+
+## Context
+
+- `APEX_METHODS` registry (13 methods) lives in `apex-lsp-shared/src/methods/ApexCustomMethods.ts`
+- Param/result types exist in `apex-lsp-shared/src/index.ts` (`FindMissingArtifactParams`, `FindMissingArtifactResult`, `RequestWorkspaceLoadParams`, `WorkspaceLoadCompleteParams`, `SendWorkspaceBatchParams/Result`, `ProcessWorkspaceBatchesParams/Result`) and `queueStateGraphData.ts` (`QueueStateParams/Result`, `GraphDataParams/Result`)
+- `ApexClientCore` has generic `request()`/`notify()` + an inline `findMissingArtifact` responder with TODO(3.1) markers
+- Profiling param/result shapes are inline in LCSAdapter (not yet exported as types); source-of-truth shapes live in `ProfilingService.ts` (`StartProfilingResult`, `StopProfilingResult`, `ProfilingStatus`, `ProfilingType`)
+- Client capability advertisement exists in `apex-lsp-shared/src/client/ApexClientCapabilities.ts` with `getClientCapabilitiesForMode(mode)` returning mode-appropriate `ClientCapabilities`
+- `_registerIncomingNotification` exists as a LOCAL closure inside `makeCore` (apexClientCore.ts:213) but is NOT currently exposed on `CoreHandle` — it wraps `connection.onNotification()` with middleware composition
+- Goal: typed senders for all 13 `apex/*` methods, `on*` handler registrations, `onFindMissingArtifact` answerable-request path with `{ notFound: true }` fallback, capability advertisement composed at `initialize`
+- PUBLIC API SURFACE: every new method on `ApexClientCore` is a public API expansion consumed by `apex-lsp-vscode-extension` (wired in 4.1). This WI expands the public surface by 13 typed senders + 4 `on*` registrations.
+
+## Phases
+
+### Phase 1 — Define and export profiling + notification param/result types in shared
+
+These types DO NOT currently exist in the codebase. They must be DEFINED (not merely re-exported) based on the inline shapes in `LCSAdapter.ts` and `ProfilingService.ts`:
+
+- **Define** the following interfaces in `packages/apex-lsp-shared/src/index.ts`:
+  - `ProfilingStartParams` = `{ readonly type?: 'cpu' | 'heap' | 'both' }` (from LCSAdapter:1171 inline param)
+  - `ProfilingStartResult` = `{ readonly success: boolean; readonly message: string; readonly type?: 'cpu' | 'heap' | 'both' }` (from LCSAdapter:1173-1176 inline return, mirrors `StartProfilingResult` in ProfilingService.ts:26)
+  - `ProfilingStopParams` = `{ readonly tag?: string }` (from LCSAdapter:1219 inline param)
+  - `ProfilingStopResult` = `{ readonly success: boolean; readonly message: string; readonly files?: readonly string[] }` (from LCSAdapter:1221-1224 inline return, mirrors `StopProfilingResult` in ProfilingService.ts:35)
+  - `ProfilingStatusParams` = `Record<string, never>` (no params; LCSAdapter:1268)
+  - `ProfilingStatusResult` = `{ readonly isProfiling: boolean; readonly type: 'idle' | 'cpu' | 'heap' | 'both'; readonly available: boolean }` (from LCSAdapter:1269-1271, mirrors `ProfilingStatus` in ProfilingService.ts:59)
+  - `WorkspaceLoadFailedParams` = `WorkspaceLoadCompleteParams` (alias — already exported at index.ts:320; same shape `{ success: boolean; error?: string }` used for both methods)
+  - `QueueStateChangedParams` = `{ readonly metrics: Record<string, unknown>; readonly metadata: { readonly timestamp: number } }` (from LCSAdapter:1658-1662 sendNotification payload)
+  - `WorkspaceIngestionCompleteParams` = `Record<string, never>` (empty object; LCSAdapter:966 sends `{}`)
+- Export all from barrel
+- Files: `packages/apex-lsp-shared/src/index.ts`
+
+```
+feat(shared): define and export profiling + workspace notification param/result types
+```
+
+### Phase 2 — Typed apex/* surface module in apex-lsp-client
+
+- New file `packages/apex-lsp-client/src/apexMethods.ts`:
+  - Typed sender methods for all 13 methods (direction-aware: clientToServer = send, serverToClient = on-handler)
+  - `on*` handler registration type for each serverToClient method (4 handlers):
+    - `onFindMissingArtifact(handler: (params: FindMissingArtifactParams) => FindMissingArtifactResult | Promise<FindMissingArtifactResult>): Disposable`
+    - `onRequestWorkspaceLoad(handler: (params: RequestWorkspaceLoadParams) => void): Disposable`
+    - `onWorkspaceIngestionComplete(handler: (params: WorkspaceIngestionCompleteParams) => void): Disposable`
+    - `onQueueStateChanged(handler: (params: QueueStateChangedParams) => void): Disposable`
+  - Export an `ApexMethodSurface` interface + factory `createApexMethodSurface(connection, cleanupRef, runtime, options)`
+  - Factory accepts the existing `_registerIncomingNotification` and `registerIncomingRequest` closures (dependency injection, not re-implementation)
+- Use `APEX_METHODS` registry constants for method strings (resolves TODO(1.1/3.1))
+- Import param/result types from `@salesforce/apex-lsp-shared`
+- Files: `packages/apex-lsp-client/src/apexMethods.ts`
+
+```
+feat(client): add typed apex/* method surface with sender/handler registrations
+```
+
+### Phase 3 — Wire surface into ApexClientCore public API + onFindMissingArtifact answerable path
+
+This phase is a **public API expansion**. Every method listed below becomes part of the `ApexClientCore` public contract, callable by external consumers starting in 4.1.
+
+- Expose `_registerIncomingNotification` (existing local closure at makeCore:213) to the `ApexMethodSurface` factory by passing it as a parameter — do NOT add it to `CoreHandle` (it remains an internal construction-time dependency)
+- Expand `CoreHandle` interface with typed sender + registration methods:
+  - Typed clientToServer senders (9): `sendWorkspaceBatch`, `processWorkspaceBatches`, `workspaceLoadComplete`, `workspaceLoadFailed`, `queueState`, `graphData`, `profilingStart`, `profilingStop`, `profilingStatus`
+  - Typed serverToClient `on*` registrations (4): `onFindMissingArtifact`, `onRequestWorkspaceLoad`, `onWorkspaceIngestionComplete`, `onQueueStateChanged`
+- Replace inline `FIND_MISSING_ARTIFACT_METHOD` constant with `APEX_METHODS.findMissingArtifact.method`
+- Implement `onFindMissingArtifact` answerable-request pattern:
+  - Default handler remains `(_params) => ({ notFound: true })` (registered at construction before traffic)
+  - `onFindMissingArtifact(handler)` replaces the default by: disposing the existing registration, registering the new handler via `registerIncomingRequest`, pushing new disposable to `cleanupRef`
+  - Returns a `Disposable` that reverts to the default fallback handler
+- Wire `_registerIncomingNotification` (the existing local closure) for `onRequestWorkspaceLoad`, `onWorkspaceIngestionComplete`, `onQueueStateChanged`:
+  - Each `on*` method calls `_registerIncomingNotification(APEX_METHODS[id].method, handler)`, pushes the returned disposable to `cleanupRef`
+  - Returns a `Disposable` that removes the handler from `cleanupRef` and calls `disposable.dispose()`
+- Add corresponding public methods to `ApexClientCore` class (delegate to handle)
+- Re-export surface types from `packages/apex-lsp-client/src/index.ts`
+- **Lifecycle guarantee**: all `on*` registrations are valid only before `initialize()` is called (registration after traffic is a caller error). Typed senders guard against use-after-dispose identically to `request()`/`notify()`.
+- Files: `packages/apex-lsp-client/src/apexClientCore.ts`, `packages/apex-lsp-client/src/index.ts`
+
+```
+feat(client): expose 13 typed apex/* senders + 4 on* registrations on ApexClientCore public API
+```
+
+### Phase 4 — Capability advertisement composed at initialize
+
+Capabilities are determined by MODE, not by dynamic handler registration. The server uses capabilities to gate which notifications it sends; the client always has handlers ready (default fallback for findMissingArtifact, no-op or caller-registered for notifications).
+
+- In `ApexClientCore.initialize`, merge `getClientCapabilitiesForMode(settings.mode ?? 'production').experimental` into `initParams.capabilities.experimental`
+- The merge uses the mode from `ApexLanguageServerSettings` (the `settings` arg to `initialize()`):
+  - `mode = 'production'`: advertises `findMissingArtifactProvider`, `workspaceIngestionProvider`, `requestWorkspaceLoadProvider`
+  - `mode = 'development'`: additionally advertises `queueStateProvider` (and profiling caps are handled server-side via `profilingProvider` in server capabilities)
+- `findMissingArtifactProvider` is ALWAYS advertised (both modes) because the default `{ notFound: true }` handler satisfies the capability claim — the server can always send `apex/findMissingArtifact` and get a valid response
+- Profiling capabilities (`profilingProvider`) are NOT advertised in `InitializeParams.capabilities` — they are SERVER capabilities gated by server-side platform detection + settings (LCSAdapter:1107-1141). The client sends profiling requests; it does not advertise a provider.
+- No dynamic on* registration gating: capabilities are a static function of mode. If a notification arrives and no caller-registered handler exists, it flows through middleware (logged) and is silently dropped (standard LSP behavior for unhandled notifications).
+- Import `getClientCapabilitiesForMode` from `@salesforce/apex-lsp-shared`
+- Files: `packages/apex-lsp-client/src/apexClientCore.ts`
+
+```
+feat(client): compose mode-based capability advertisement at initialize
+```
+
+### Phase 5 — Unit tests + e2e coverage
+
+- **Unit tests** (`packages/apex-lsp-client/test/apexMethods.test.ts`):
+  - Test typed senders dispatch correct method string + params via mock connection
+  - Test `onFindMissingArtifact`: registered handler receives params, returns result; unregistered falls back to `{ notFound: true }`; re-registration disposes old handler and installs new
+  - Test `onRequestWorkspaceLoad`/`onWorkspaceIngestionComplete`/`onQueueStateChanged` registration + dispatch through middleware chain
+  - Test dispose semantics: disposing an `on*` registration removes it from cleanupRef
+- **Capability tests** (`packages/apex-lsp-client/test/apexClientCore.capabilities.test.ts`):
+  - Test `initialize` with mode=production merges correct experimental keys
+  - Test `initialize` with mode=development merges queueStateProvider additionally
+  - Test findMissingArtifactProvider is present in both modes
+  - Test profilingProvider is NOT in client capabilities (server-side only)
+- **E2e coverage** (`packages/apex-lsp-client/test/integration/`):
+  - Add integration test exercising typed sender round-trip against a real spawned server (same pattern as existing integration tests)
+  - Verify `onFindMissingArtifact` fallback response when server sends the request during integration startup
+  - Verify `onRequestWorkspaceLoad` handler receives notification from live server
+- Files: `packages/apex-lsp-client/test/apexMethods.test.ts`, `packages/apex-lsp-client/test/apexClientCore.capabilities.test.ts`, `packages/apex-lsp-client/test/integration/typedSurface.integration.test.ts`
+
+```
+test(client): typed apex/* surface unit + capability + e2e integration tests
+```
+
+## Skills to apply
+
+- effect-best-practices — Effect patterns for Ref/cleanupRef/Scope lifecycle management
+- lsp-custom-requests — URI wire format correctness
+- typescript — strict types, no `any`, readonly interfaces
+- writing-tests — vitest patterns
+- language-server-architecture — separation of concerns, data ownership
+- verification — pre-commit checks
+- services-extension-consumption — public API expansion awareness for downstream consumers
+
+## Verification
+
+- `npm run typecheck` passes across all packages (compile-time coverage)
+- `npm run test -- --filter apex-lsp-client` passes (unit tests)
+- `npm run test -- --filter apex-lsp-shared` passes (shared types compilable)
+- Lint clean (`npm run lint -- --filter apex-lsp-client`)
+- e2e integration test passes: `npx vitest run packages/apex-lsp-client/test/integration/typedSurface.integration.test.ts`
+- Verify no `any` types leaked into public API signatures (`rg 'any' packages/apex-lsp-client/src/apexMethods.ts` returns zero hits)
+- Verify CoreHandle expansion compiles: all 13 senders + 4 on* methods present in CoreHandle interface and delegated on ApexClientCore class

--- a/e2e-tests/pages/ApexEditorPage.ts
+++ b/e2e-tests/pages/ApexEditorPage.ts
@@ -198,9 +198,13 @@ export class ApexEditorPage extends BasePage {
 
     await this.page.keyboard.press('Shift+F12');
 
-    // The references peek widget appears for any non-empty result set. Give the
-    // LSP time to answer (references can fan out cross-file).
-    const peekWidget = this.page.locator('.editor-widget.peekview-widget');
+    // Find-all-references renders in the `reference-zone-widget` peek — a
+    // different DOM node than the go-to-definition peek
+    // (`.editor-widget.peekview-widget`). Match the references widget
+    // specifically so we don't miss it and report 0.
+    const peekWidget = this.page.locator(
+      '.peekview-widget.reference-zone-widget',
+    );
     await peekWidget
       .waitFor({ state: 'visible', timeout: this.defaultTimeout })
       .catch(() => {});
@@ -209,8 +213,31 @@ export class ApexEditorPage extends BasePage {
       return 0;
     }
 
-    // Each reference is a row in the peek's tree. Count the result entries
-    // (file/line rows), excluding the file-group headers.
+    // The peek's result tree is virtualized: only on-screen rows exist in the
+    // DOM (a 5-result peek may render just 2-3 `.monaco-list-row`s), so counting
+    // rows undercounts. The peek title carries the authoritative total —
+    // "References (5)" — so parse that first.
+    const titleText = await peekWidget
+      .locator('.head .peekview-title .meta')
+      .first()
+      .textContent()
+      .catch(() => null);
+    const match = titleText?.match(/References?\s*\((\d+)\)/i);
+    if (match) {
+      return Number(match[1]);
+    }
+
+    // Locale fallback: on non-English VS Code the word "References" is
+    // translated, so the word-anchored regex above misses. The count is still
+    // rendered in parentheses regardless of locale, so extract the last
+    // parenthesized integer from the title before resorting to row counting.
+    const localeMatch = titleText?.match(/\((\d+)\)\s*$/);
+    if (localeMatch) {
+      return Number(localeMatch[1]);
+    }
+
+    // Fallback: no parseable title (older VS Code, or a single-result peek that
+    // navigates instead of showing a count) — count the rendered result rows.
     const entries = peekWidget.locator(
       '.monaco-list-row .referenceMatch, .monaco-list-row[role="treeitem"]',
     );
@@ -222,7 +249,11 @@ export class ApexEditorPage extends BasePage {
    * Close any open peek widget (references / definition peek).
    */
   async closePeek(): Promise<void> {
-    const peekWidget = this.page.locator('.editor-widget.peekview-widget');
+    // Both peek variants share the `.peekview-widget` base class: the
+    // go-to-definition peek (`.editor-widget.peekview-widget`) and the
+    // find-references peek (`.reference-zone-widget`). Match the base class so
+    // either is dismissed.
+    const peekWidget = this.page.locator('.peekview-widget');
     for (let i = 0; i < 3; i++) {
       if (!(await peekWidget.isVisible())) {
         return;

--- a/e2e-tests/tests/apex-find-references.spec.ts
+++ b/e2e-tests/tests/apex-find-references.spec.ts
@@ -29,8 +29,11 @@ test.describe('Apex Find All References', () => {
     });
 
     await test.step('Position on a symbol that is used more than once', async () => {
-      // `sayHello` is declared and called within ApexClassExample.
-      await apexEditor.positionCursorOnWord('sayHello');
+      // `accounts` is the instance field with several intra-file references. A
+      // field with multiple same-file references reliably surfaces the peek in
+      // VS Code Web; a symbol with only a declaration + single usage does not
+      // (VS Code collapses a near-empty same-file result set).
+      await apexEditor.positionCursorOnWord('accounts');
     });
 
     await test.step('Trigger find-references and assert results appear', async () => {
@@ -95,7 +98,7 @@ test.describe('Apex Find All References', () => {
   test('find-references is responsive', async ({ apexEditor }) => {
     await apexEditor.openFile('ApexClassExample.cls');
     await apexEditor.waitForLanguageServerReady();
-    await apexEditor.positionCursorOnWord('sayHello');
+    await apexEditor.positionCursorOnWord('accounts');
 
     const startTime = Date.now();
     await apexEditor.findReferences();

--- a/packages/apex-ls/src/server/LCSAdapter.ts
+++ b/packages/apex-ls/src/server/LCSAdapter.ts
@@ -2333,18 +2333,26 @@ export class LCSAdapter {
           scope,
         );
       } else {
-        // Resolve the worker script relative to the parent server bundle's own
-        // origin. Using the client-injected extension URL directly (a different
-        // origin — the extension's dist/) breaks sub-worker spawning for
-        // resolution-heavy roles: makeBrowserWorkerLayer's cross-origin
-        // fetch→blob misbehaves, silently degrading hover/definition symbol
-        // resolution while basic requests still work. workerPlatformWebUrl is
-        // kept only as a last-resort base when location.href is unavailable.
-        const selfHref =
-          (globalThis as any).location?.href ??
-          this.workerPlatformWebUrl ??
-          'file:///server.web.js';
-        const workerUrl = new URL('./worker.platform.web.js', selfHref).href;
+        // Resolve the worker script URL relative to the parent server bundle's
+        // own origin (location.href) — same-origin, no CORS. But VS Code Web
+        // serves the bundle from a `blob:` URL, which is NOT a valid base for
+        // `new URL(relative, base)` — it throws, aborting topology init and
+        // silently dropping the whole worker pool (hover/definition/references
+        // fall back to the coordinator-local path, and references — an empty
+        // stub there — returns nothing). When href is unusable as a base, use
+        // the client-injected absolute worker URL, then a file:// placeholder.
+        // makeBrowserWorkerLayer re-wraps the fetched script in a SAME-ORIGIN
+        // blob regardless, so the sub-worker always shares the parent's origin.
+        const resolveWorkerUrl = (base: string) =>
+          new URL('./worker.platform.web.js', base).href;
+        const rawHref = (globalThis as any).location?.href;
+        const workerUrl =
+          typeof rawHref === 'string' && !rawHref.startsWith('blob:')
+            ? resolveWorkerUrl(rawHref)
+            : // `||` (not `??`): an empty string is as unusable a base as
+              // undefined, so fall through to the placeholder in both cases.
+              this.workerPlatformWebUrl ||
+              resolveWorkerUrl('file:///server.web.js');
         this.logger.alwaysLog(
           () => `[WorkerCoordinator] Worker script (browser): ${workerUrl}`,
         );

--- a/packages/apex-ls/src/server/LCSAdapter.ts
+++ b/packages/apex-ls/src/server/LCSAdapter.ts
@@ -2391,18 +2391,26 @@ export class LCSAdapter {
           scope,
         );
       } else {
-        // Resolve the worker script relative to the parent server bundle's own
-        // origin. Using the client-injected extension URL directly (a different
-        // origin — the extension's dist/) breaks sub-worker spawning for
-        // resolution-heavy roles: makeBrowserWorkerLayer's cross-origin
-        // fetch→blob misbehaves, silently degrading hover/definition symbol
-        // resolution while basic requests still work. workerPlatformWebUrl is
-        // kept only as a last-resort base when location.href is unavailable.
-        const selfHref =
-          (globalThis as any).location?.href ??
-          this.workerPlatformWebUrl ??
-          'file:///server.web.js';
-        const workerUrl = new URL('./worker.platform.web.js', selfHref).href;
+        // Resolve the worker script URL relative to the parent server bundle's
+        // own origin (location.href) — same-origin, no CORS. But VS Code Web
+        // serves the bundle from a `blob:` URL, which is NOT a valid base for
+        // `new URL(relative, base)` — it throws, aborting topology init and
+        // silently dropping the whole worker pool (hover/definition/references
+        // fall back to the coordinator-local path, and references — an empty
+        // stub there — returns nothing). When href is unusable as a base, use
+        // the client-injected absolute worker URL, then a file:// placeholder.
+        // makeBrowserWorkerLayer re-wraps the fetched script in a SAME-ORIGIN
+        // blob regardless, so the sub-worker always shares the parent's origin.
+        const resolveWorkerUrl = (base: string) =>
+          new URL('./worker.platform.web.js', base).href;
+        const rawHref = (globalThis as any).location?.href;
+        const workerUrl =
+          typeof rawHref === 'string' && !rawHref.startsWith('blob:')
+            ? resolveWorkerUrl(rawHref)
+            : // `||` (not `??`): an empty string is as unusable a base as
+              // undefined, so fall through to the placeholder in both cases.
+              this.workerPlatformWebUrl ||
+              resolveWorkerUrl('file:///server.web.js');
         this.logger.alwaysLog(
           () => `[WorkerCoordinator] Worker script (browser): ${workerUrl}`,
         );

--- a/packages/apex-ls/src/server/WorkerCoordinator.ts
+++ b/packages/apex-ls/src/server/WorkerCoordinator.ts
@@ -1127,6 +1127,7 @@ function buildLspRequestMessage(
       return new DispatchDefinition({
         textDocument: { uri: p.textDocument.uri },
         position: (p as PositionBasedParams).position,
+        content: getDocumentContent?.(p.textDocument.uri),
       });
     case 'signatureHelp': {
       const s = p as PositionBasedParams & { context?: unknown };

--- a/packages/apex-ls/src/server/WorkerCoordinator.ts
+++ b/packages/apex-ls/src/server/WorkerCoordinator.ts
@@ -922,10 +922,7 @@ function createDispatcher(
             documentVersion: number;
             enrichedSymbolTable: unknown;
             enrichedDetailLevel:
-              | 'public-api'
-              | 'protected'
-              | 'private'
-              | 'full';
+              'public-api' | 'protected' | 'private' | 'full';
             sourceWorkerId: string;
           };
           return callbacks.sendToDataOwner(
@@ -1190,6 +1187,7 @@ function buildLspRequestMessage(
       return new DispatchDefinition({
         textDocument: { uri: p.textDocument.uri },
         position: (p as PositionBasedParams).position,
+        content: getDocumentContent?.(p.textDocument.uri),
       });
     case 'signatureHelp': {
       const s = p as PositionBasedParams & { context?: unknown };

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -683,12 +683,22 @@ export function loadSymbolDataForEnrichment(
           }>;
           const classNames = new Set<string>();
           for (const ref of refs) {
-            if (
+            // Unresolved outbound type refs: fetch the owning file so the name
+            // resolves. Skipped once resolved — the resolvedSymbolId already
+            // points at the target for on-demand hover/definition.
+            const isUnresolvedTypeRef =
               !ref.resolvedSymbolId &&
               (ref.context === ReferenceContext.CLASS_REFERENCE ||
                 ref.context === ReferenceContext.CONSTRUCTOR_CALL ||
-                ref.context === ReferenceContext.TYPE_DECLARATION)
-            ) {
+                ref.context === ReferenceContext.TYPE_DECLARATION);
+            // Supertype edges (`extends`/`implements`) must be fetched even when
+            // already resolved: the resolvedSymbolId only names the target, but
+            // goto-definition still needs the declaring file's symbol table
+            // present in this pool worker to produce a location.
+            const isSupertypeRef =
+              ref.context === ReferenceContext.INHERITANCE ||
+              ref.context === ReferenceContext.INTERFACE_IMPLEMENTATION;
+            if (isUnresolvedTypeRef || isSupertypeRef) {
               classNames.add(ref.name);
             }
           }
@@ -1218,11 +1228,19 @@ export const ensureRequestServices: Effect.Effect<RequestServices> =
         // Wire coordinator assistance so the enrichment worker can forward
         // apex/findMissingArtifact to the coordinator (which holds the LSP
         // client connection) rather than silently dropping the request.
+        //
+        // blocking=true: the coordinator mediator must await its handler (drive
+        // the client to open the artifact, which flows to the data-owner via
+        // didOpen) and return the real FindMissingArtifactResult. With
+        // blocking=false it returns {accepted:true} immediately, which the
+        // blocking-resolution caller mis-reads as "resolved" before the artifact
+        // loads. The background caller doesn't await, so blocking=true is
+        // harmless there.
         EnhancedMissingArtifactResolutionService.setAssistanceProxy((params) =>
           requestCoordinatorAssistancePromiseShared(
             'apex/findMissingArtifact',
             params,
-            false,
+            true,
           ),
         );
 
@@ -1646,8 +1664,7 @@ export async function targetSymbolForCursor(
     if (!name) return null;
     const leaf = name.includes('.') ? name.split('.').pop()! : name;
     const named = (await svc.symbolManager.findSymbolByName(leaf))?.[0] as
-      | { name?: string; kind?: unknown }
-      | undefined;
+      { name?: string; kind?: unknown } | undefined;
     return {
       name: named?.name ?? leaf,
       kind: named && typeof named.kind === 'string' ? named.kind : undefined,
@@ -1739,6 +1756,29 @@ const requestHandlers = {
           svc,
           req.textDocument.uri,
           req.content,
+        );
+
+        // The data-owner holds the cursor file at public-api detail only, so
+        // implicit-private fields, locals, and private members are absent and
+        // hover on them resolves to nothing. Recompile locally at full detail
+        // from the live buffer. Runs after loadSymbolDataForEnrichment so the
+        // full-detail table wins while the cross-file dep tables it loaded stay
+        // present for the re-resolve inside recompileCursorFileAtFullDetail.
+        //
+        // DEFERRED perf (W-23408848): this runs on every hover on ALL platforms,
+        // not just web. It is NOT safe to gate on the data-owner's reported
+        // detailLevel (`shouldEnrich(detailLevel, 'full')`): that level reflects
+        // the DATA-OWNER's stored table, not what THIS pool member holds locally,
+        // so a fresh pool worker with detailLevel='full' still lacks the member
+        // symbols and skipping the recompile regresses field/instance-variable
+        // hover+definition (verified: 3 web e2e failures). A correct gate needs a
+        // LOCAL full-detail marker for the uri; deferred until one exists.
+        yield* Effect.promise(() =>
+          recompileCursorFileAtFullDetail(
+            svc,
+            req.textDocument.uri,
+            req.content,
+          ),
         );
 
         // Hover requires 'full' detail level per LspRequestPrerequisiteMapping
@@ -1886,6 +1926,22 @@ const requestHandlers = {
         const { version, detailLevel } = yield* loadSymbolDataForEnrichment(
           svc,
           req.textDocument.uri,
+          // Live buffer so enrichment and the recompile below run on the unsaved
+          // editor text, not the data-owner's last-stored version.
+          req.content,
+        );
+
+        // As in DispatchHover: the data-owner holds only public-api detail, so
+        // definition on a field/local/private member resolves to nothing.
+        // Recompile locally at full detail from the live buffer. See DispatchHover
+        // for why this can't safely be gated on the reported detailLevel
+        // (DEFERRED perf, W-23408848).
+        yield* Effect.promise(() =>
+          recompileCursorFileAtFullDetail(
+            svc,
+            req.textDocument.uri,
+            req.content,
+          ),
         );
 
         // Definition requires 'full' detail level per LspRequestPrerequisiteMapping

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -628,12 +628,22 @@ export async function loadSymbolDataForEnrichment(
         }>;
         const classNames = new Set<string>();
         for (const ref of refs) {
-          if (
+          // Unresolved outbound type refs: fetch the owning file so the name
+          // resolves. Skipped once resolved — the resolvedSymbolId already
+          // points at the target for on-demand hover/definition.
+          const isUnresolvedTypeRef =
             !ref.resolvedSymbolId &&
             (ref.context === ReferenceContext.CLASS_REFERENCE ||
               ref.context === ReferenceContext.CONSTRUCTOR_CALL ||
-              ref.context === ReferenceContext.TYPE_DECLARATION)
-          ) {
+              ref.context === ReferenceContext.TYPE_DECLARATION);
+          // Supertype edges (`extends`/`implements`) must be fetched even when
+          // already resolved: the resolvedSymbolId only names the target, but
+          // goto-definition still needs the declaring file's symbol table
+          // present in this pool worker to produce a location.
+          const isSupertypeRef =
+            ref.context === ReferenceContext.INHERITANCE ||
+            ref.context === ReferenceContext.INTERFACE_IMPLEMENTATION;
+          if (isUnresolvedTypeRef || isSupertypeRef) {
             classNames.add(ref.name);
           }
         }
@@ -1154,11 +1164,19 @@ export const ensureRequestServices: Effect.Effect<RequestServices> =
         // Wire coordinator assistance so the enrichment worker can forward
         // apex/findMissingArtifact to the coordinator (which holds the LSP
         // client connection) rather than silently dropping the request.
+        //
+        // blocking=true: the coordinator mediator must await its handler (drive
+        // the client to open the artifact, which flows to the data-owner via
+        // didOpen) and return the real FindMissingArtifactResult. With
+        // blocking=false it returns {accepted:true} immediately, which the
+        // blocking-resolution caller mis-reads as "resolved" before the artifact
+        // loads. The background caller doesn't await, so blocking=true is
+        // harmless there.
         EnhancedMissingArtifactResolutionService.setAssistanceProxy((params) =>
           requestCoordinatorAssistancePromiseShared(
             'apex/findMissingArtifact',
             params,
-            false,
+            true,
           ),
         );
 
@@ -1666,7 +1684,28 @@ const requestHandlers = {
         req.content,
       );
 
-      // Hover requires 'full' detail level per LspRequestPrerequisiteMapping
+      // The data-owner holds the cursor file at public-api detail only, so
+      // implicit-private fields, locals, and private members are absent and
+      // hover on them resolves to nothing. Recompile locally at full detail
+      // from the live buffer. Runs after loadSymbolDataForEnrichment so the
+      // full-detail table wins while the cross-file dep tables it loaded stay
+      // present for the re-resolve inside recompileCursorFileAtFullDetail.
+      //
+      // DEFERRED perf (W-23408848): this runs on every hover on ALL platforms,
+      // not just web. It is NOT safe to gate on the data-owner's reported
+      // detailLevel (`shouldEnrich(detailLevel, 'full')`): that level reflects
+      // the DATA-OWNER's stored table, not what THIS pool member holds locally,
+      // so a fresh pool worker with detailLevel='full' still lacks the member
+      // symbols and skipping the recompile regresses field/instance-variable
+      // hover+definition (verified: 3 web e2e failures). A correct gate needs a
+      // LOCAL full-detail marker for the uri; deferred until one exists.
+      await recompileCursorFileAtFullDetail(
+        svc,
+        req.textDocument.uri,
+        req.content,
+      );
+
+      // Hover requires 'full' detail level per LspRequestPrerequisiteMapping.
       const requiredLevel = 'full';
       const needsEnrichment = shouldEnrich(detailLevel, requiredLevel);
 
@@ -1797,9 +1836,23 @@ const requestHandlers = {
       const { version, detailLevel } = await loadSymbolDataForEnrichment(
         svc,
         req.textDocument.uri,
+        // Live buffer so enrichment and the recompile below run on the unsaved
+        // editor text, not the data-owner's last-stored version.
+        req.content,
       );
 
-      // Definition requires 'full' detail level per LspRequestPrerequisiteMapping
+      // As in DispatchHover: the data-owner holds only public-api detail, so
+      // definition on a field/local/private member resolves to nothing.
+      // Recompile locally at full detail from the live buffer. See DispatchHover
+      // for why this can't safely be gated on the reported detailLevel
+      // (DEFERRED perf, W-23408848).
+      await recompileCursorFileAtFullDetail(
+        svc,
+        req.textDocument.uri,
+        req.content,
+      );
+
+      // Definition requires 'full' detail level per LspRequestPrerequisiteMapping.
       const requiredLevel = 'full';
       const needsEnrichment = shouldEnrich(detailLevel, requiredLevel);
 

--- a/packages/apex-ls/src/worker.platform.ts
+++ b/packages/apex-ls/src/worker.platform.ts
@@ -61,8 +61,7 @@ import { parentPort, workerData } from 'node:worker_threads';
 // Worker channel that @effect/platform uses for its wire protocol.
 const assistPort: import('node:worker_threads').MessagePort | null =
   ((workerData as Record<string, unknown> | undefined)?.assistPort as
-    | import('node:worker_threads').MessagePort
-    | null) ?? null;
+    import('node:worker_threads').MessagePort | null) ?? null;
 
 const pendingAssistanceCallbacks = new Map<
   string,

--- a/packages/apex-ls/test/integration/EnrichmentRoundTrip.node.test.ts
+++ b/packages/apex-ls/test/integration/EnrichmentRoundTrip.node.test.ts
@@ -158,9 +158,7 @@ describe('Enrichment round-trip through the worker topology (live assistance bus
 
   const runFeature = (
     makeRequest: () =>
-      | DispatchHover
-      | DispatchReferences
-      | DispatchImplementation,
+      DispatchHover | DispatchReferences | DispatchImplementation,
   ) =>
     Effect.gen(function* () {
       const topology = yield* initializeTopology({

--- a/packages/apex-lsp-client/README.md
+++ b/packages/apex-lsp-client/README.md
@@ -99,7 +99,11 @@ connection.listen();
 
 `ApexClientCore.create` registers default handlers (the logging middleware and
 the `findMissingArtifact` responder) during construction, **before** any message
-flows. The `RpcConnection` you pass MUST NOT be started/listening yet — start it
+flows. The default `findMissingArtifact` handler (responds `{ notFound: true }`)
+is managed through the `ApexMethodSurface` factory and can be customized via
+`core.onFindMissingArtifact(handler)` before or after `initialize()`.
+
+The `RpcConnection` you pass MUST NOT be started/listening yet — start it
 only after the core is built.
 
 ```typescript
@@ -184,6 +188,55 @@ const disposable = core.use(timingMiddleware);
 disposable.dispose();
 ```
 
+### Typed apex/* methods
+
+The core exposes typed sender methods for all client-to-server `apex/*`
+requests/notifications, and `on*` registration methods for server-to-client
+handlers. These are type-safe alternatives to the generic `request()`/`notify()`
+escape hatches:
+
+```typescript
+// --- Typed senders (client → server) ---
+
+// Send workspace batch data to the server
+const result = await core.sendWorkspaceBatch({ batch: myBatch });
+
+// Trigger batch processing
+const processResult = await core.processWorkspaceBatches({ options: {} });
+
+// Notify the server that workspace load is complete (void notification)
+core.workspaceLoadComplete({ timestamp: Date.now() });
+
+// Query profiling status
+const status = await core.profilingStatus({ verbose: true });
+
+// --- Handler registrations (server → client) ---
+
+// Register a custom findMissingArtifact handler (replaces the default)
+const disposable = core.onFindMissingArtifact(async (params) => {
+  const resolved = await resolveArtifact(params.artifactPath);
+  return resolved ?? { notFound: true };
+});
+// Disposing reverts to the default { notFound: true } fallback
+disposable.dispose();
+
+// Listen for server workspace-load requests
+const loadDisposable = core.onRequestWorkspaceLoad((params) => {
+  console.log('Server requests workspace load:', params);
+});
+
+// Listen for ingestion-complete and queue-state-changed notifications
+core.onWorkspaceIngestionComplete((params) => {
+  console.log('Ingestion complete:', params);
+});
+core.onQueueStateChanged((params) => {
+  console.log('Queue state:', params);
+});
+```
+
+All typed senders reject with `ApexClientDisposedError` after `dispose()`. All
+`on*` registrations throw synchronously if called after `dispose()`.
+
 ## API Reference
 
 ### Core
@@ -205,6 +258,27 @@ disposable.dispose();
     chain.
   - `documentSymbol(params)` — send `textDocument/documentSymbol` through the
     middleware chain.
+  - `sendWorkspaceBatch(params)` — send `apex/sendWorkspaceBatch` request.
+  - `processWorkspaceBatches(params)` — send `apex/processWorkspaceBatches`
+    request.
+  - `workspaceLoadComplete(params)` — send `apex/workspaceLoadComplete`
+    notification.
+  - `workspaceLoadFailed(params)` — send `apex/workspaceLoadFailed`
+    notification.
+  - `queueState(params)` — send `apex/queueState` request.
+  - `graphData(params)` — send `apex/graphData` request.
+  - `profilingStart(params)` — send `apex/profiling/start` request.
+  - `profilingStop(params)` — send `apex/profiling/stop` request.
+  - `profilingStatus(params)` — send `apex/profiling/status` request.
+  - `onFindMissingArtifact(handler)` — register a handler for
+    `apex/findMissingArtifact`; returns a `Disposable` that reverts to the
+    default `{ notFound: true }` fallback.
+  - `onRequestWorkspaceLoad(handler)` — register a handler for
+    `apex/requestWorkspaceLoad`; returns a `Disposable`.
+  - `onWorkspaceIngestionComplete(handler)` — register a handler for
+    `apex/workspaceIngestionComplete`; returns a `Disposable`.
+  - `onQueueStateChanged(handler)` — register a handler for
+    `apex/queueStateChanged`; returns a `Disposable`.
   - `isDisposed()` — whether the core has been disposed.
   - `dispose()` — tear down (finalizers run LIFO); idempotent.
 - `ApexClientCoreOptions` — construction options (additional `middlewares`).

--- a/packages/apex-lsp-client/src/apexClientCore.ts
+++ b/packages/apex-lsp-client/src/apexClientCore.ts
@@ -9,10 +9,32 @@
 import { Effect, Exit, Option, Ref, Runtime, Scope } from 'effect';
 import {
   DEFAULT_APEX_SETTINGS,
+  getClientCapabilitiesForMode,
   type ApexLanguageServerSettings,
   type Disposable,
+  type FindMissingArtifactParams,
+  type FindMissingArtifactResult,
+  type GraphDataParams,
+  type GraphDataResult,
   type InitializeParams,
   type InitializeResult,
+  type ProcessWorkspaceBatchesParams,
+  type ProcessWorkspaceBatchesResult,
+  type ProfilingStartParams,
+  type ProfilingStartResult,
+  type ProfilingStatusParams,
+  type ProfilingStatusResult,
+  type ProfilingStopParams,
+  type ProfilingStopResult,
+  type QueueStateChangedParams,
+  type QueueStateParams,
+  type QueueStateResult,
+  type RequestWorkspaceLoadParams,
+  type SendWorkspaceBatchParams,
+  type SendWorkspaceBatchResult,
+  type WorkspaceIngestionCompleteParams,
+  type WorkspaceLoadCompleteParams,
+  type WorkspaceLoadFailedParams,
 } from '@salesforce/apex-lsp-shared';
 import type { RpcConnection } from './rpcConnection';
 import type { ApexClientMiddleware } from './apexClientMiddleware';
@@ -38,17 +60,7 @@ import {
   composeRequestChain,
   composeNotificationChain,
 } from './middleware/composeMiddleware';
-
-/**
- * The server→client request the core answers by default. Temporary literal —
- * replace with the shared registry constant + `FindMissingArtifactResult` type
- * in 1.1/3.1.
- *
- * TODO(1.1/3.1): replace `'apex/findMissingArtifact'` and the inline
- * `{ notFound: true }` with the canonical registry constant and the
- * `FindMissingArtifactResult` type from `@salesforce/apex-lsp-shared`.
- */
-const FIND_MISSING_ARTIFACT_METHOD = 'apex/findMissingArtifact';
+import { createApexMethodSurface } from './apexMethods';
 
 /**
  * Caller-supplied `initialize` params. `initializationOptions` is intentionally
@@ -101,6 +113,43 @@ interface CoreHandle {
   readonly notify: (method: string, params?: unknown) => void;
   readonly isDisposed: () => boolean;
   readonly dispose: () => Promise<void>;
+
+  // --- Typed apex/* senders (9 clientToServer) ---
+  readonly sendWorkspaceBatch: (
+    params: SendWorkspaceBatchParams,
+  ) => Promise<SendWorkspaceBatchResult>;
+  readonly processWorkspaceBatches: (
+    params: ProcessWorkspaceBatchesParams,
+  ) => Promise<ProcessWorkspaceBatchesResult>;
+  readonly workspaceLoadComplete: (params: WorkspaceLoadCompleteParams) => void;
+  readonly workspaceLoadFailed: (params: WorkspaceLoadFailedParams) => void;
+  readonly queueState: (params: QueueStateParams) => Promise<QueueStateResult>;
+  readonly graphData: (params: GraphDataParams) => Promise<GraphDataResult>;
+  readonly profilingStart: (
+    params: ProfilingStartParams,
+  ) => Promise<ProfilingStartResult>;
+  readonly profilingStop: (
+    params: ProfilingStopParams,
+  ) => Promise<ProfilingStopResult>;
+  readonly profilingStatus: (
+    params: ProfilingStatusParams,
+  ) => Promise<ProfilingStatusResult>;
+
+  // --- Typed apex/* handler registrations (4 serverToClient) ---
+  readonly onFindMissingArtifact: (
+    handler: (
+      params: FindMissingArtifactParams,
+    ) => FindMissingArtifactResult | Promise<FindMissingArtifactResult>,
+  ) => Disposable;
+  readonly onRequestWorkspaceLoad: (
+    handler: (params: RequestWorkspaceLoadParams) => void,
+  ) => Disposable;
+  readonly onWorkspaceIngestionComplete: (
+    handler: (params: WorkspaceIngestionCompleteParams) => void,
+  ) => Disposable;
+  readonly onQueueStateChanged: (
+    handler: (params: QueueStateChangedParams) => void,
+  ) => Disposable;
 }
 
 /**
@@ -225,15 +274,38 @@ const makeCore = Effect.fn('ApexClientCore.make')(function* (
       );
     });
 
-  // Default findMissingArtifact responder: { notFound: true }. Registered here,
-  // before traffic. Logging middleware observes the incoming request via the chain.
-  const findMissingArtifactDisposable = registerIncomingRequest(
-    FIND_MISSING_ARTIFACT_METHOD,
-    // TODO(3.1): delegate to a registered onFindMissingArtifact handler when
-    // the typed apex/* surface lands; fall back to { notFound: true }.
-    (_params) => ({ notFound: true }),
-  );
-  yield* Ref.update(cleanupRef, (ds) => [...ds, findMissingArtifactDisposable]);
+  // --- Guarded send helpers for the typed surface ---
+  // These wrap the raw chain closures with the same disposed-check that
+  // `request()` / `notify()` use, so typed senders fail fast after dispose.
+  const guardedSendRequest = <R>(
+    method: string,
+    params?: unknown,
+  ): Promise<R> => {
+    if (Runtime.runSync(runtime)(Ref.get(disposedRef))) {
+      return Promise.reject(new ApexClientDisposedError('request'));
+    }
+    return sendRequestThroughChain<R>(method, params);
+  };
+
+  const guardedSendNotification = (method: string, params?: unknown): void => {
+    if (Runtime.runSync(runtime)(Ref.get(disposedRef))) {
+      throw new ApexClientDisposedError('notify');
+    }
+    sendNotificationThroughChain(method, params);
+  };
+
+  // Create the typed apex/* method surface. This registers the default
+  // findMissingArtifact responder ({ notFound: true }) and exposes typed
+  // senders + on* handler registrations. Replaces the inline registration.
+  const apexSurface = createApexMethodSurface({
+    sendRequest: guardedSendRequest,
+    sendNotification: guardedSendNotification,
+    registerIncomingRequest,
+    registerIncomingNotification: _registerIncomingNotification,
+    cleanupRef,
+    disposedRef,
+    runtime,
+  });
 
   // Register handler/middleware cleanup LAST so LIFO runs it FIRST (before the
   // transport is torn down).
@@ -283,14 +355,30 @@ const makeCore = Effect.fn('ApexClientCore.make')(function* (
           if (Option.isSome(existing)) {
             return existing.value;
           }
+          // Determine mode from settings for capability advertisement.
+          const mode = settings.apex.environment.serverMode ?? 'production';
+          const modeCapabilities = getClientCapabilitiesForMode(mode);
+          const experimentalCaps = modeCapabilities.experimental ?? {};
+          const textDocumentCaps = modeCapabilities.textDocument ?? {};
+
           const initParams: InitializeParams = {
             processId:
               typeof process !== 'undefined' && process.pid
                 ? process.pid
                 : null,
             rootUri: null,
-            capabilities: {},
             ...params,
+            capabilities: {
+              ...params?.capabilities,
+              textDocument: {
+                ...params?.capabilities?.textDocument,
+                ...textDocumentCaps,
+              },
+              experimental: {
+                ...params?.capabilities?.experimental,
+                ...experimentalCaps,
+              },
+            },
             initializationOptions: settings,
           };
           // Strict LSP order: the `initialized` notification is sent ONLY after
@@ -395,6 +483,7 @@ const makeCore = Effect.fn('ApexClientCore.make')(function* (
     notify,
     isDisposed,
     disposedRef,
+    apexSurface,
   };
 });
 
@@ -481,6 +570,22 @@ export class ApexClientCore {
       notify: built.notify,
       isDisposed: built.isDisposed,
       dispose: closeScope,
+      // Typed apex/* senders
+      sendWorkspaceBatch: built.apexSurface.sendWorkspaceBatch,
+      processWorkspaceBatches: built.apexSurface.processWorkspaceBatches,
+      workspaceLoadComplete: built.apexSurface.workspaceLoadComplete,
+      workspaceLoadFailed: built.apexSurface.workspaceLoadFailed,
+      queueState: built.apexSurface.queueState,
+      graphData: built.apexSurface.graphData,
+      profilingStart: built.apexSurface.profilingStart,
+      profilingStop: built.apexSurface.profilingStop,
+      profilingStatus: built.apexSurface.profilingStatus,
+      // Typed apex/* handler registrations
+      onFindMissingArtifact: built.apexSurface.onFindMissingArtifact,
+      onRequestWorkspaceLoad: built.apexSurface.onRequestWorkspaceLoad,
+      onWorkspaceIngestionComplete:
+        built.apexSurface.onWorkspaceIngestionComplete,
+      onQueueStateChanged: built.apexSurface.onQueueStateChanged,
     };
     return new ApexClientCore(handle, closeScope);
   }
@@ -579,6 +684,122 @@ export class ApexClientCore {
       'textDocument/documentSymbol',
       params,
     );
+  }
+
+  // --- Typed apex/* senders (9 clientToServer) ---
+
+  /**
+   * Send `apex/sendWorkspaceBatch` through the middleware chain.
+   */
+  sendWorkspaceBatch(
+    params: SendWorkspaceBatchParams,
+  ): Promise<SendWorkspaceBatchResult> {
+    return this.handle.sendWorkspaceBatch(params);
+  }
+
+  /**
+   * Send `apex/processWorkspaceBatches` through the middleware chain.
+   */
+  processWorkspaceBatches(
+    params: ProcessWorkspaceBatchesParams,
+  ): Promise<ProcessWorkspaceBatchesResult> {
+    return this.handle.processWorkspaceBatches(params);
+  }
+
+  /**
+   * Send `apex/workspaceLoadComplete` notification through the middleware chain.
+   */
+  workspaceLoadComplete(params: WorkspaceLoadCompleteParams): void {
+    this.handle.workspaceLoadComplete(params);
+  }
+
+  /**
+   * Send `apex/workspaceLoadFailed` notification through the middleware chain.
+   */
+  workspaceLoadFailed(params: WorkspaceLoadFailedParams): void {
+    this.handle.workspaceLoadFailed(params);
+  }
+
+  /**
+   * Send `apex/queueState` through the middleware chain.
+   */
+  queueState(params: QueueStateParams): Promise<QueueStateResult> {
+    return this.handle.queueState(params);
+  }
+
+  /**
+   * Send `apex/graphData` through the middleware chain.
+   */
+  graphData(params: GraphDataParams): Promise<GraphDataResult> {
+    return this.handle.graphData(params);
+  }
+
+  /**
+   * Send `apex/profiling/start` through the middleware chain.
+   */
+  profilingStart(params: ProfilingStartParams): Promise<ProfilingStartResult> {
+    return this.handle.profilingStart(params);
+  }
+
+  /**
+   * Send `apex/profiling/stop` through the middleware chain.
+   */
+  profilingStop(params: ProfilingStopParams): Promise<ProfilingStopResult> {
+    return this.handle.profilingStop(params);
+  }
+
+  /**
+   * Send `apex/profiling/status` through the middleware chain.
+   */
+  profilingStatus(
+    params: ProfilingStatusParams,
+  ): Promise<ProfilingStatusResult> {
+    return this.handle.profilingStatus(params);
+  }
+
+  // --- Typed apex/* handler registrations (4 serverToClient) ---
+
+  /**
+   * Register a handler for the `apex/findMissingArtifact` server request.
+   * Returns a Disposable that, when disposed, reverts to the default
+   * `{ notFound: true }` fallback handler.
+   */
+  onFindMissingArtifact(
+    handler: (
+      params: FindMissingArtifactParams,
+    ) => FindMissingArtifactResult | Promise<FindMissingArtifactResult>,
+  ): Disposable {
+    return this.handle.onFindMissingArtifact(handler);
+  }
+
+  /**
+   * Register a handler for the `apex/requestWorkspaceLoad` notification.
+   * Returns a Disposable that removes the handler.
+   */
+  onRequestWorkspaceLoad(
+    handler: (params: RequestWorkspaceLoadParams) => void,
+  ): Disposable {
+    return this.handle.onRequestWorkspaceLoad(handler);
+  }
+
+  /**
+   * Register a handler for the `apex/workspaceIngestionComplete` notification.
+   * Returns a Disposable that removes the handler.
+   */
+  onWorkspaceIngestionComplete(
+    handler: (params: WorkspaceIngestionCompleteParams) => void,
+  ): Disposable {
+    return this.handle.onWorkspaceIngestionComplete(handler);
+  }
+
+  /**
+   * Register a handler for the `apex/queueStateChanged` notification.
+   * Returns a Disposable that removes the handler.
+   */
+  onQueueStateChanged(
+    handler: (params: QueueStateChangedParams) => void,
+  ): Disposable {
+    return this.handle.onQueueStateChanged(handler);
   }
 
   /**

--- a/packages/apex-lsp-client/src/apexMethods.ts
+++ b/packages/apex-lsp-client/src/apexMethods.ts
@@ -1,0 +1,422 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Typed sender + handler surface for all 13 canonical `apex/*` methods.
+ *
+ * Direction-aware:
+ * - clientToServer methods get typed SENDER functions (9)
+ * - serverToClient methods get typed `on*` handler registrations (4)
+ *
+ * Factory accepts the existing `_registerIncomingNotification` and
+ * `registerIncomingRequest` closures via dependency injection rather than
+ * re-implementing their middleware composition.
+ */
+
+import { Ref, Runtime } from 'effect';
+import {
+  APEX_METHODS,
+  type Disposable,
+  type FindMissingArtifactParams,
+  type FindMissingArtifactResult,
+  type RequestWorkspaceLoadParams,
+  type SendWorkspaceBatchParams,
+  type SendWorkspaceBatchResult,
+  type ProcessWorkspaceBatchesParams,
+  type ProcessWorkspaceBatchesResult,
+  type WorkspaceLoadCompleteParams,
+  type WorkspaceLoadFailedParams,
+  type QueueStateParams,
+  type QueueStateResult,
+  type GraphDataParams,
+  type GraphDataResult,
+  type ProfilingStartParams,
+  type ProfilingStartResult,
+  type ProfilingStopParams,
+  type ProfilingStopResult,
+  type ProfilingStatusParams,
+  type ProfilingStatusResult,
+  type QueueStateChangedParams,
+  type WorkspaceIngestionCompleteParams,
+} from '@salesforce/apex-lsp-shared';
+
+// ---------------------------------------------------------------------------
+// Public API surface interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed sender methods for clientToServer `apex/*` requests/notifications.
+ */
+export interface ApexMethodSenders {
+  /** Send `apex/sendWorkspaceBatch` request. */
+  readonly sendWorkspaceBatch: (
+    params: SendWorkspaceBatchParams,
+  ) => Promise<SendWorkspaceBatchResult>;
+
+  /** Send `apex/processWorkspaceBatches` request. */
+  readonly processWorkspaceBatches: (
+    params: ProcessWorkspaceBatchesParams,
+  ) => Promise<ProcessWorkspaceBatchesResult>;
+
+  /** Send `apex/workspaceLoadComplete` notification. */
+  readonly workspaceLoadComplete: (params: WorkspaceLoadCompleteParams) => void;
+
+  /** Send `apex/workspaceLoadFailed` notification. */
+  readonly workspaceLoadFailed: (params: WorkspaceLoadFailedParams) => void;
+
+  /** Send `apex/queueState` request. */
+  readonly queueState: (params: QueueStateParams) => Promise<QueueStateResult>;
+
+  /** Send `apex/graphData` request. */
+  readonly graphData: (params: GraphDataParams) => Promise<GraphDataResult>;
+
+  /** Send `apex/profiling/start` request. */
+  readonly profilingStart: (
+    params: ProfilingStartParams,
+  ) => Promise<ProfilingStartResult>;
+
+  /** Send `apex/profiling/stop` request. */
+  readonly profilingStop: (
+    params: ProfilingStopParams,
+  ) => Promise<ProfilingStopResult>;
+
+  /** Send `apex/profiling/status` request. */
+  readonly profilingStatus: (
+    params: ProfilingStatusParams,
+  ) => Promise<ProfilingStatusResult>;
+}
+
+/**
+ * Handler registrations for serverToClient `apex/*` methods.
+ */
+export interface ApexMethodHandlers {
+  /**
+   * Register a handler for the `apex/findMissingArtifact` server request.
+   * Returns a Disposable that, when disposed, reverts to the default
+   * `{ notFound: true }` fallback handler.
+   */
+  readonly onFindMissingArtifact: (
+    handler: (
+      params: FindMissingArtifactParams,
+    ) => FindMissingArtifactResult | Promise<FindMissingArtifactResult>,
+  ) => Disposable;
+
+  /**
+   * Register a handler for the `apex/requestWorkspaceLoad` notification.
+   * Returns a Disposable that removes the handler.
+   */
+  readonly onRequestWorkspaceLoad: (
+    handler: (params: RequestWorkspaceLoadParams) => void,
+  ) => Disposable;
+
+  /**
+   * Register a handler for the `apex/workspaceIngestionComplete` notification.
+   * Returns a Disposable that removes the handler.
+   */
+  readonly onWorkspaceIngestionComplete: (
+    handler: (params: WorkspaceIngestionCompleteParams) => void,
+  ) => Disposable;
+
+  /**
+   * Register a handler for the `apex/queueStateChanged` notification.
+   * Returns a Disposable that removes the handler.
+   */
+  readonly onQueueStateChanged: (
+    handler: (params: QueueStateChangedParams) => void,
+  ) => Disposable;
+}
+
+/**
+ * The full typed apex/* method surface: senders + handler registrations.
+ */
+export interface ApexMethodSurface
+  extends ApexMethodSenders, ApexMethodHandlers {}
+
+// ---------------------------------------------------------------------------
+// Factory dependencies (injected from makeCore closures)
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link createApexMethodSurface}. Accepts the closures from
+ * `makeCore` so the surface module composes over existing middleware without
+ * re-implementing the chain.
+ */
+export interface ApexMethodSurfaceOptions {
+  /**
+   * The existing `sendRequestThroughChain` closure — sends a request via
+   * the outgoing middleware chain.
+   */
+  readonly sendRequest: <R>(method: string, params?: unknown) => Promise<R>;
+
+  /**
+   * The existing `sendNotificationThroughChain` closure — sends a notification
+   * via the outgoing middleware chain (synchronous).
+   */
+  readonly sendNotification: (method: string, params?: unknown) => void;
+
+  /**
+   * The existing `registerIncomingRequest` closure — registers an incoming
+   * request handler that flows through middleware.
+   */
+  readonly registerIncomingRequest: (
+    method: string,
+    rawHandler: (params: unknown) => unknown | Promise<unknown>,
+  ) => Disposable;
+
+  /**
+   * The existing `_registerIncomingNotification` closure — registers an
+   * incoming notification handler that flows through middleware.
+   */
+  readonly registerIncomingNotification: (
+    method: string,
+    rawHandler: (params: unknown) => void,
+  ) => Disposable;
+
+  /**
+   * The `cleanupRef` from makeCore — disposables pushed here are torn down
+   * when the scope closes.
+   */
+  readonly cleanupRef: Ref.Ref<ReadonlyArray<Disposable>>;
+
+  /**
+   * The `disposedRef` from makeCore — checked before mutating state to
+   * prevent use-after-dispose errors from Runtime.runSync on a closed scope.
+   */
+  readonly disposedRef: Ref.Ref<boolean>;
+
+  /**
+   * The captured runtime from makeCore — used for synchronous Ref operations.
+   */
+  readonly runtime: Runtime.Runtime<never>;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the typed `apex/*` method surface. All methods delegate to the
+ * injected closures (which already compose middleware). No Effect types leak
+ * into the returned surface.
+ */
+export const createApexMethodSurface = (
+  options: ApexMethodSurfaceOptions,
+): ApexMethodSurface => {
+  const {
+    sendRequest,
+    sendNotification,
+    registerIncomingRequest,
+    registerIncomingNotification,
+    cleanupRef,
+    disposedRef,
+    runtime,
+  } = options;
+
+  // Helper: check if core is disposed; throws if so
+  const ensureNotDisposed = (operation: string): void => {
+    if (Runtime.runSync(runtime)(Ref.get(disposedRef))) {
+      throw new Error(`Cannot ${operation}: ApexClientCore has been disposed`);
+    }
+  };
+
+  // Helper to push a disposable to cleanupRef
+  const pushCleanup = (d: Disposable): void => {
+    Runtime.runSync(runtime)(Ref.update(cleanupRef, (ds) => [...ds, d]));
+  };
+
+  // Helper to remove a specific disposable from cleanupRef
+  const removeCleanup = (d: Disposable): void => {
+    Runtime.runSync(runtime)(
+      Ref.update(cleanupRef, (ds) => ds.filter((x) => x !== d)),
+    );
+  };
+
+  // --- clientToServer SENDERS (9) ---
+
+  const sendWorkspaceBatch = (
+    params: SendWorkspaceBatchParams,
+  ): Promise<SendWorkspaceBatchResult> =>
+    sendRequest<SendWorkspaceBatchResult>(
+      APEX_METHODS.sendWorkspaceBatch.method,
+      params,
+    );
+
+  const processWorkspaceBatches = (
+    params: ProcessWorkspaceBatchesParams,
+  ): Promise<ProcessWorkspaceBatchesResult> =>
+    sendRequest<ProcessWorkspaceBatchesResult>(
+      APEX_METHODS.processWorkspaceBatches.method,
+      params,
+    );
+
+  const workspaceLoadComplete = (params: WorkspaceLoadCompleteParams): void => {
+    sendNotification(APEX_METHODS.workspaceLoadComplete.method, params);
+  };
+
+  const workspaceLoadFailed = (params: WorkspaceLoadFailedParams): void => {
+    sendNotification(APEX_METHODS.workspaceLoadFailed.method, params);
+  };
+
+  const queueState = (params: QueueStateParams): Promise<QueueStateResult> =>
+    sendRequest<QueueStateResult>(APEX_METHODS.queueState.method, params);
+
+  const graphData = (params: GraphDataParams): Promise<GraphDataResult> =>
+    sendRequest<GraphDataResult>(APEX_METHODS.graphData.method, params);
+
+  const profilingStart = (
+    params: ProfilingStartParams,
+  ): Promise<ProfilingStartResult> =>
+    sendRequest<ProfilingStartResult>(
+      APEX_METHODS.profilingStart.method,
+      params,
+    );
+
+  const profilingStop = (
+    params: ProfilingStopParams,
+  ): Promise<ProfilingStopResult> =>
+    sendRequest<ProfilingStopResult>(APEX_METHODS.profilingStop.method, params);
+
+  const profilingStatus = (
+    params: ProfilingStatusParams,
+  ): Promise<ProfilingStatusResult> =>
+    sendRequest<ProfilingStatusResult>(
+      APEX_METHODS.profilingStatus.method,
+      params,
+    );
+
+  // --- serverToClient HANDLER REGISTRATIONS (4) ---
+
+  // Track the current findMissingArtifact registration so it can be swapped
+  let currentFindMissingArtifactDisposable: Disposable | null = null;
+
+  /**
+   * Default fallback: always answers `{ notFound: true }`.
+   */
+  const defaultFindMissingArtifactHandler = (
+    _params: unknown,
+  ): FindMissingArtifactResult => ({ notFound: true });
+
+  // Register the default handler at surface-creation time
+  currentFindMissingArtifactDisposable = registerIncomingRequest(
+    APEX_METHODS.findMissingArtifact.method,
+    defaultFindMissingArtifactHandler,
+  );
+  pushCleanup(currentFindMissingArtifactDisposable);
+
+  const onFindMissingArtifact = (
+    handler: (
+      params: FindMissingArtifactParams,
+    ) => FindMissingArtifactResult | Promise<FindMissingArtifactResult>,
+  ): Disposable => {
+    ensureNotDisposed('register onFindMissingArtifact handler');
+    // Dispose the current registration (default or previously-set handler)
+    if (currentFindMissingArtifactDisposable) {
+      removeCleanup(currentFindMissingArtifactDisposable);
+      currentFindMissingArtifactDisposable.dispose();
+    }
+
+    // Register the new handler
+    const newDisposable = registerIncomingRequest(
+      APEX_METHODS.findMissingArtifact.method,
+      handler as (params: unknown) => unknown | Promise<unknown>,
+    );
+    currentFindMissingArtifactDisposable = newDisposable;
+    pushCleanup(newDisposable);
+
+    // Return a Disposable that reverts to the default fallback.
+    // Staleness check: if onFindMissingArtifact was called again after this
+    // disposable was created, the current handler has already been replaced —
+    // disposing a stale disposable must be a no-op to avoid clobbering.
+    return {
+      dispose: () => {
+        if (currentFindMissingArtifactDisposable !== newDisposable) {
+          // This disposable is stale — a newer handler has been registered.
+          return;
+        }
+        removeCleanup(newDisposable);
+        newDisposable.dispose();
+        // Re-register the default fallback
+        const fallback = registerIncomingRequest(
+          APEX_METHODS.findMissingArtifact.method,
+          defaultFindMissingArtifactHandler,
+        );
+        currentFindMissingArtifactDisposable = fallback;
+        pushCleanup(fallback);
+      },
+    };
+  };
+
+  const onRequestWorkspaceLoad = (
+    handler: (params: RequestWorkspaceLoadParams) => void,
+  ): Disposable => {
+    ensureNotDisposed('register onRequestWorkspaceLoad handler');
+    const disposable = registerIncomingNotification(
+      APEX_METHODS.requestWorkspaceLoad.method,
+      handler as (params: unknown) => void,
+    );
+    pushCleanup(disposable);
+    return {
+      dispose: () => {
+        removeCleanup(disposable);
+        disposable.dispose();
+      },
+    };
+  };
+
+  const onWorkspaceIngestionComplete = (
+    handler: (params: WorkspaceIngestionCompleteParams) => void,
+  ): Disposable => {
+    ensureNotDisposed('register onWorkspaceIngestionComplete handler');
+    const disposable = registerIncomingNotification(
+      APEX_METHODS.workspaceIngestionComplete.method,
+      handler as (params: unknown) => void,
+    );
+    pushCleanup(disposable);
+    return {
+      dispose: () => {
+        removeCleanup(disposable);
+        disposable.dispose();
+      },
+    };
+  };
+
+  const onQueueStateChanged = (
+    handler: (params: QueueStateChangedParams) => void,
+  ): Disposable => {
+    ensureNotDisposed('register onQueueStateChanged handler');
+    const disposable = registerIncomingNotification(
+      APEX_METHODS.queueStateChanged.method,
+      handler as (params: unknown) => void,
+    );
+    pushCleanup(disposable);
+    return {
+      dispose: () => {
+        removeCleanup(disposable);
+        disposable.dispose();
+      },
+    };
+  };
+
+  return {
+    // Senders
+    sendWorkspaceBatch,
+    processWorkspaceBatches,
+    workspaceLoadComplete,
+    workspaceLoadFailed,
+    queueState,
+    graphData,
+    profilingStart,
+    profilingStop,
+    profilingStatus,
+    // Handlers
+    onFindMissingArtifact,
+    onRequestWorkspaceLoad,
+    onWorkspaceIngestionComplete,
+    onQueueStateChanged,
+  };
+};

--- a/packages/apex-lsp-client/src/index.ts
+++ b/packages/apex-lsp-client/src/index.ts
@@ -47,6 +47,16 @@ export type {
   ApexClientInitializeParams,
 } from './apexClientCore';
 
+// Typed apex/* method surface types — public API for typed sender/handler usage.
+// Note: ApexMethodSurfaceOptions is intentionally NOT exported — it is an
+// internal factory dependency that exposes raw middleware closures and Effect
+// types (Ref, Runtime). Consumers receive the built surface via ApexClientCore.
+export type {
+  ApexMethodSurface,
+  ApexMethodSenders,
+  ApexMethodHandlers,
+} from './apexMethods';
+
 // LSP param/result types re-exported for SDK consumers.
 export type {
   CompletionItem,

--- a/packages/apex-lsp-client/src/middleware/composeMiddleware.ts
+++ b/packages/apex-lsp-client/src/middleware/composeMiddleware.ts
@@ -100,8 +100,7 @@ export function composeNotificationChain<P>(
   for (let i = middlewares.length - 1; i >= 0; i--) {
     const mw = middlewares[i];
     const hookFn = mw[hook] as
-      | ((method: string, params: P, next: (p: P) => void) => void)
-      | undefined;
+      ((method: string, params: P, next: (p: P) => void) => void) | undefined;
     if (hookFn) {
       const currentNext = next;
       next = (p: P) => {

--- a/packages/apex-lsp-client/test/apexClientCore.capabilities.test.ts
+++ b/packages/apex-lsp-client/test/apexClientCore.capabilities.test.ts
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import {
+  DEFAULT_APEX_SETTINGS,
+  enableConsoleLogging,
+  setLogLevel,
+  type ApexLanguageServerSettings,
+  type Disposable,
+  type InitializeParams,
+} from '@salesforce/apex-lsp-shared';
+import { ApexClientCore } from '../src/apexClientCore';
+import type { RpcConnection } from '../src/rpcConnection';
+
+/**
+ * Captures the initialize params so we can inspect capabilities.
+ */
+const makeMockConnection = (
+  captureInitParams: (params: InitializeParams) => void,
+): RpcConnection => {
+  const sendRequest = jest.fn(
+    (method: string, params?: unknown): Promise<unknown> => {
+      if (method === 'initialize') {
+        captureInitParams(params as InitializeParams);
+        return Promise.resolve({ capabilities: {} });
+      }
+      return Promise.resolve(undefined);
+    },
+  );
+  const sendNotification = jest.fn(
+    (_method: string, _params?: unknown): Promise<void> => Promise.resolve(),
+  );
+  const onRequest = jest.fn(
+    (_method: string, _handler: (params: unknown) => unknown): Disposable => ({
+      dispose: jest.fn(),
+    }),
+  );
+  const onNotification = jest.fn(
+    (_method: string, _handler: (params: unknown) => void): Disposable => ({
+      dispose: jest.fn(),
+    }),
+  );
+  const onError = jest.fn((_handler: (e: Error) => void): Disposable => ({
+    dispose: jest.fn(),
+  }));
+  const onClose = jest.fn((_handler: () => void): Disposable => ({
+    dispose: jest.fn(),
+  }));
+  const dispose = jest.fn((): void => undefined);
+
+  return {
+    sendRequest,
+    sendNotification,
+    onRequest,
+    onNotification,
+    onError,
+    onClose,
+    dispose,
+  } as unknown as RpcConnection;
+};
+
+describe('ApexClientCore capability advertisement', () => {
+  beforeEach(() => {
+    enableConsoleLogging();
+    setLogLevel('error');
+  });
+
+  it('initialize with mode=production merges correct experimental keys', async () => {
+    let captured: InitializeParams | undefined;
+    const connection = makeMockConnection((params) => {
+      captured = params;
+    });
+
+    const core = await ApexClientCore.create(connection);
+    await core.initialize(DEFAULT_APEX_SETTINGS);
+
+    expect(captured).toBeDefined();
+    const experimental = captured!.capabilities.experimental as Record<
+      string,
+      unknown
+    >;
+    expect(experimental.findMissingArtifactProvider).toEqual({
+      enabled: true,
+      supportedModes: ['blocking', 'background'],
+    });
+    expect(experimental.workspaceIngestionProvider).toEqual({ enabled: true });
+    expect(experimental.requestWorkspaceLoadProvider).toEqual({
+      enabled: true,
+    });
+
+    await core.dispose();
+  });
+
+  it('initialize with mode=development merges queueStateProvider additionally', async () => {
+    let captured: InitializeParams | undefined;
+    const connection = makeMockConnection((params) => {
+      captured = params;
+    });
+
+    const devSettings: ApexLanguageServerSettings = {
+      apex: {
+        ...DEFAULT_APEX_SETTINGS.apex,
+        environment: {
+          ...DEFAULT_APEX_SETTINGS.apex.environment,
+          serverMode: 'development',
+        },
+      },
+    };
+
+    const core = await ApexClientCore.create(connection);
+    await core.initialize(devSettings);
+
+    expect(captured).toBeDefined();
+    const experimental = captured!.capabilities.experimental as Record<
+      string,
+      unknown
+    >;
+    expect(experimental.findMissingArtifactProvider).toEqual({
+      enabled: true,
+      supportedModes: ['blocking', 'background'],
+    });
+    expect(experimental.workspaceIngestionProvider).toEqual({ enabled: true });
+    expect(experimental.requestWorkspaceLoadProvider).toEqual({
+      enabled: true,
+    });
+    expect(experimental.queueStateProvider).toEqual({ enabled: true });
+
+    await core.dispose();
+  });
+
+  it('findMissingArtifactProvider is present in both modes', async () => {
+    // Production
+    let capturedProd: InitializeParams | undefined;
+    const connProd = makeMockConnection((params) => {
+      capturedProd = params;
+    });
+    const coreProd = await ApexClientCore.create(connProd);
+    await coreProd.initialize(DEFAULT_APEX_SETTINGS);
+    const expProd = capturedProd!.capabilities.experimental as Record<
+      string,
+      unknown
+    >;
+    expect(expProd.findMissingArtifactProvider).toBeDefined();
+    await coreProd.dispose();
+
+    // Development
+    let capturedDev: InitializeParams | undefined;
+    const connDev = makeMockConnection((params) => {
+      capturedDev = params;
+    });
+    const coreDev = await ApexClientCore.create(connDev);
+    const devSettings: ApexLanguageServerSettings = {
+      apex: {
+        ...DEFAULT_APEX_SETTINGS.apex,
+        environment: {
+          ...DEFAULT_APEX_SETTINGS.apex.environment,
+          serverMode: 'development',
+        },
+      },
+    };
+    await coreDev.initialize(devSettings);
+    const expDev = capturedDev!.capabilities.experimental as Record<
+      string,
+      unknown
+    >;
+    expect(expDev.findMissingArtifactProvider).toBeDefined();
+    await coreDev.dispose();
+  });
+
+  it('profilingProvider is NOT in client capabilities (server-side only)', async () => {
+    let captured: InitializeParams | undefined;
+    const connection = makeMockConnection((params) => {
+      captured = params;
+    });
+
+    const devSettings: ApexLanguageServerSettings = {
+      apex: {
+        ...DEFAULT_APEX_SETTINGS.apex,
+        environment: {
+          ...DEFAULT_APEX_SETTINGS.apex.environment,
+          serverMode: 'development',
+        },
+      },
+    };
+
+    const core = await ApexClientCore.create(connection);
+    await core.initialize(devSettings);
+
+    const experimental = captured!.capabilities.experimental as Record<
+      string,
+      unknown
+    >;
+    // profilingProvider is a SERVER capability, not client
+    expect(experimental.profilingProvider).toBeUndefined();
+
+    await core.dispose();
+  });
+});

--- a/packages/apex-lsp-client/test/apexClientCore.incomingChain.test.ts
+++ b/packages/apex-lsp-client/test/apexClientCore.incomingChain.test.ts
@@ -46,16 +46,12 @@ const makeMockConnection = (): MockConnection => {
       return { dispose: jest.fn() };
     },
   );
-  const onError = jest.fn(
-    (_handler: (e: Error) => void): Disposable => ({
-      dispose: jest.fn(),
-    }),
-  );
-  const onClose = jest.fn(
-    (_handler: () => void): Disposable => ({
-      dispose: jest.fn(),
-    }),
-  );
+  const onError = jest.fn((_handler: (e: Error) => void): Disposable => ({
+    dispose: jest.fn(),
+  }));
+  const onClose = jest.fn((_handler: () => void): Disposable => ({
+    dispose: jest.fn(),
+  }));
   const dispose = jest.fn((): void => undefined);
 
   return {

--- a/packages/apex-lsp-client/test/apexClientCore.passThrough.test.ts
+++ b/packages/apex-lsp-client/test/apexClientCore.passThrough.test.ts
@@ -41,16 +41,12 @@ const makeMockConnection = (): MockConnection => {
       dispose: jest.fn(),
     }),
   );
-  const onError = jest.fn(
-    (_handler: (e: Error) => void): Disposable => ({
-      dispose: jest.fn(),
-    }),
-  );
-  const onClose = jest.fn(
-    (_handler: () => void): Disposable => ({
-      dispose: jest.fn(),
-    }),
-  );
+  const onError = jest.fn((_handler: (e: Error) => void): Disposable => ({
+    dispose: jest.fn(),
+  }));
+  const onClose = jest.fn((_handler: () => void): Disposable => ({
+    dispose: jest.fn(),
+  }));
   const dispose = jest.fn((): void => undefined);
 
   return {

--- a/packages/apex-lsp-client/test/apexClientCore.test.ts
+++ b/packages/apex-lsp-client/test/apexClientCore.test.ts
@@ -61,16 +61,12 @@ const makeMockConnection = (
       dispose: jest.fn(),
     }),
   );
-  const onError = jest.fn(
-    (_handler: (e: Error) => void): Disposable => ({
-      dispose: jest.fn(),
-    }),
-  );
-  const onClose = jest.fn(
-    (_handler: () => void): Disposable => ({
-      dispose: jest.fn(),
-    }),
-  );
+  const onError = jest.fn((_handler: (e: Error) => void): Disposable => ({
+    dispose: jest.fn(),
+  }));
+  const onClose = jest.fn((_handler: () => void): Disposable => ({
+    dispose: jest.fn(),
+  }));
   const dispose = jest.fn((): void => undefined);
 
   return {

--- a/packages/apex-lsp-client/test/apexMethods.test.ts
+++ b/packages/apex-lsp-client/test/apexMethods.test.ts
@@ -1,0 +1,391 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import {
+  APEX_METHODS,
+  type Disposable,
+  type FindMissingArtifactParams,
+  type FindMissingArtifactResult,
+  type RequestWorkspaceLoadParams,
+  type QueueStateChangedParams,
+  type WorkspaceIngestionCompleteParams,
+  enableConsoleLogging,
+  setLogLevel,
+} from '@salesforce/apex-lsp-shared';
+import { ApexClientCore } from '../src/apexClientCore';
+import type { RpcConnection } from '../src/rpcConnection';
+
+/**
+ * Hand-rolled `RpcConnection` mock (mirrors apexClientCore.test.ts style).
+ * Captures notification and request handlers so tests can invoke them.
+ */
+interface MockConnection extends RpcConnection {
+  readonly requestHandlers: Map<string, (params: unknown) => unknown>;
+  readonly notificationHandlers: Map<string, (params: unknown) => void>;
+}
+
+const makeMockConnection = (): MockConnection => {
+  const requestHandlers = new Map<string, (params: unknown) => unknown>();
+  const notificationHandlers = new Map<string, (params: unknown) => void>();
+
+  const sendRequest = jest.fn(
+    (method: string, _params?: unknown): Promise<unknown> =>
+      Promise.resolve(
+        method === 'initialize' ? { capabilities: {} } : { success: true },
+      ),
+  );
+  const sendNotification = jest.fn(
+    (_method: string, _params?: unknown): Promise<void> => Promise.resolve(),
+  );
+  const onRequest = jest.fn(
+    (method: string, handler: (params: unknown) => unknown): Disposable => {
+      requestHandlers.set(method, handler);
+      return {
+        dispose: () => {
+          requestHandlers.delete(method);
+        },
+      };
+    },
+  );
+  const onNotification = jest.fn(
+    (method: string, handler: (params: unknown) => void): Disposable => {
+      notificationHandlers.set(method, handler);
+      return {
+        dispose: () => {
+          notificationHandlers.delete(method);
+        },
+      };
+    },
+  );
+  const onError = jest.fn((_handler: (e: Error) => void): Disposable => ({
+    dispose: jest.fn(),
+  }));
+  const onClose = jest.fn((_handler: () => void): Disposable => ({
+    dispose: jest.fn(),
+  }));
+  const dispose = jest.fn((): void => undefined);
+
+  return {
+    sendRequest,
+    sendNotification,
+    onRequest,
+    onNotification,
+    onError,
+    onClose,
+    dispose,
+    requestHandlers,
+    notificationHandlers,
+  } as unknown as MockConnection;
+};
+
+describe('ApexMethods typed surface', () => {
+  let connection: MockConnection;
+
+  beforeEach(() => {
+    connection = makeMockConnection();
+    enableConsoleLogging();
+    setLogLevel('error');
+  });
+
+  describe('typed senders dispatch correct method string + params', () => {
+    it('sendWorkspaceBatch sends apex/sendWorkspaceBatch', async () => {
+      const core = await ApexClientCore.create(connection);
+      const params = {
+        batchIndex: 0,
+        totalBatches: 1,
+        isLastBatch: true,
+        compressedData: 'base64==',
+        fileMetadata: [],
+      };
+
+      await core.sendWorkspaceBatch(params);
+
+      const sendReq = connection.sendRequest as jest.Mock;
+      expect(sendReq).toHaveBeenCalledWith(
+        APEX_METHODS.sendWorkspaceBatch.method,
+        params,
+      );
+
+      await core.dispose();
+    });
+
+    it('processWorkspaceBatches sends apex/processWorkspaceBatches', async () => {
+      const core = await ApexClientCore.create(connection);
+      const params = { totalBatches: 5 };
+
+      await core.processWorkspaceBatches(params);
+
+      const sendReq = connection.sendRequest as jest.Mock;
+      expect(sendReq).toHaveBeenCalledWith(
+        APEX_METHODS.processWorkspaceBatches.method,
+        params,
+      );
+
+      await core.dispose();
+    });
+
+    it('workspaceLoadComplete sends apex/workspaceLoadComplete notification', async () => {
+      const core = await ApexClientCore.create(connection);
+      const params = { success: true };
+
+      core.workspaceLoadComplete(params);
+
+      const sendNotif = connection.sendNotification as jest.Mock;
+      expect(sendNotif).toHaveBeenCalledWith(
+        APEX_METHODS.workspaceLoadComplete.method,
+        params,
+      );
+
+      await core.dispose();
+    });
+
+    it('workspaceLoadFailed sends apex/workspaceLoadFailed notification', async () => {
+      const core = await ApexClientCore.create(connection);
+      const params = { success: false, error: 'timeout' };
+
+      core.workspaceLoadFailed(params);
+
+      const sendNotif = connection.sendNotification as jest.Mock;
+      expect(sendNotif).toHaveBeenCalledWith(
+        APEX_METHODS.workspaceLoadFailed.method,
+        params,
+      );
+
+      await core.dispose();
+    });
+
+    it('profilingStart sends apex/profiling/start', async () => {
+      const core = await ApexClientCore.create(connection);
+      const params = { type: 'cpu' as const };
+
+      await core.profilingStart(params);
+
+      const sendReq = connection.sendRequest as jest.Mock;
+      expect(sendReq).toHaveBeenCalledWith(
+        APEX_METHODS.profilingStart.method,
+        params,
+      );
+
+      await core.dispose();
+    });
+
+    it('profilingStop sends apex/profiling/stop', async () => {
+      const core = await ApexClientCore.create(connection);
+      const params = { tag: 'test-run' };
+
+      await core.profilingStop(params);
+
+      const sendReq = connection.sendRequest as jest.Mock;
+      expect(sendReq).toHaveBeenCalledWith(
+        APEX_METHODS.profilingStop.method,
+        params,
+      );
+
+      await core.dispose();
+    });
+
+    it('profilingStatus sends apex/profiling/status', async () => {
+      const core = await ApexClientCore.create(connection);
+      const params = {} as Record<string, never>;
+
+      await core.profilingStatus(params);
+
+      const sendReq = connection.sendRequest as jest.Mock;
+      expect(sendReq).toHaveBeenCalledWith(
+        APEX_METHODS.profilingStatus.method,
+        params,
+      );
+
+      await core.dispose();
+    });
+  });
+
+  describe('onFindMissingArtifact', () => {
+    it('registered handler receives params and returns result', async () => {
+      const core = await ApexClientCore.create(connection);
+
+      const handler = jest.fn(
+        (_params: FindMissingArtifactParams): FindMissingArtifactResult => ({
+          opened: ['file:///Found.cls'],
+        }),
+      );
+      core.onFindMissingArtifact(handler);
+
+      // Simulate server sending the request
+      const registeredHandler = connection.requestHandlers.get(
+        APEX_METHODS.findMissingArtifact.method,
+      );
+      expect(registeredHandler).toBeDefined();
+
+      const params: FindMissingArtifactParams = {
+        identifiers: [{ name: 'MyClass' }],
+        origin: {
+          uri: 'file:///Test.cls',
+          requestKind: 'definition',
+        },
+        mode: 'blocking',
+      };
+      const result = await registeredHandler!(params);
+      expect(result).toEqual({ opened: ['file:///Found.cls'] });
+
+      await core.dispose();
+    });
+
+    it('unregistered falls back to { notFound: true }', async () => {
+      const core = await ApexClientCore.create(connection);
+
+      // Without registering a custom handler, the default should answer
+      const handler = connection.requestHandlers.get(
+        APEX_METHODS.findMissingArtifact.method,
+      );
+      expect(handler).toBeDefined();
+
+      const result = await handler!({
+        identifiers: [],
+        origin: {},
+        mode: 'blocking',
+      });
+      expect(result).toEqual({ notFound: true });
+
+      await core.dispose();
+    });
+
+    it('re-registration disposes old handler and installs new', async () => {
+      const core = await ApexClientCore.create(connection);
+
+      const handler1 = jest.fn((): FindMissingArtifactResult => ({
+        opened: ['file:///A.cls'],
+      }));
+      const handler2 = jest.fn((): FindMissingArtifactResult => ({
+        opened: ['file:///B.cls'],
+      }));
+
+      core.onFindMissingArtifact(handler1);
+      core.onFindMissingArtifact(handler2);
+
+      const registeredHandler = connection.requestHandlers.get(
+        APEX_METHODS.findMissingArtifact.method,
+      );
+      const result = await registeredHandler!({});
+      // Should call handler2, not handler1
+      expect(result).toEqual({ opened: ['file:///B.cls'] });
+
+      await core.dispose();
+    });
+
+    it('disposing the registration reverts to the default fallback', async () => {
+      const core = await ApexClientCore.create(connection);
+
+      const handler = jest.fn((): FindMissingArtifactResult => ({
+        opened: ['file:///X.cls'],
+      }));
+      const disposable = core.onFindMissingArtifact(handler);
+
+      // Dispose reverts to default
+      disposable.dispose();
+
+      const registeredHandler = connection.requestHandlers.get(
+        APEX_METHODS.findMissingArtifact.method,
+      );
+      const result = await registeredHandler!({});
+      expect(result).toEqual({ notFound: true });
+
+      await core.dispose();
+    });
+  });
+
+  describe('onRequestWorkspaceLoad', () => {
+    it('registered handler receives notification params', async () => {
+      const core = await ApexClientCore.create(connection);
+      const received: RequestWorkspaceLoadParams[] = [];
+
+      core.onRequestWorkspaceLoad((params) => {
+        received.push(params);
+      });
+
+      // Simulate server sending the notification
+      const handler = connection.notificationHandlers.get(
+        APEX_METHODS.requestWorkspaceLoad.method,
+      );
+      expect(handler).toBeDefined();
+
+      const params: RequestWorkspaceLoadParams = { reason: 'implementation' };
+      handler!(params);
+      expect(received).toEqual([params]);
+
+      await core.dispose();
+    });
+
+    it('dispose removes the handler', async () => {
+      const core = await ApexClientCore.create(connection);
+      const received: RequestWorkspaceLoadParams[] = [];
+
+      const disposable = core.onRequestWorkspaceLoad((params) => {
+        received.push(params);
+      });
+
+      disposable.dispose();
+
+      // Handler should be gone from the connection
+      const handler = connection.notificationHandlers.get(
+        APEX_METHODS.requestWorkspaceLoad.method,
+      );
+      expect(handler).toBeUndefined();
+
+      await core.dispose();
+    });
+  });
+
+  describe('onWorkspaceIngestionComplete', () => {
+    it('registered handler receives notification', async () => {
+      const core = await ApexClientCore.create(connection);
+      const received: WorkspaceIngestionCompleteParams[] = [];
+
+      core.onWorkspaceIngestionComplete((params) => {
+        received.push(params);
+      });
+
+      const handler = connection.notificationHandlers.get(
+        APEX_METHODS.workspaceIngestionComplete.method,
+      );
+      expect(handler).toBeDefined();
+
+      const params = {} as Record<string, never>;
+      handler!(params);
+      expect(received).toHaveLength(1);
+
+      await core.dispose();
+    });
+  });
+
+  describe('onQueueStateChanged', () => {
+    it('registered handler receives notification params', async () => {
+      const core = await ApexClientCore.create(connection);
+      const received: QueueStateChangedParams[] = [];
+
+      core.onQueueStateChanged((params) => {
+        received.push(params);
+      });
+
+      const handler = connection.notificationHandlers.get(
+        APEX_METHODS.queueStateChanged.method,
+      );
+      expect(handler).toBeDefined();
+
+      const params: QueueStateChangedParams = {
+        metrics: { pending: 3 },
+        metadata: { timestamp: Date.now() },
+      };
+      handler!(params);
+      expect(received).toEqual([params]);
+
+      await core.dispose();
+    });
+  });
+});

--- a/packages/apex-lsp-client/test/integration/typedSurface.integration.test.ts
+++ b/packages/apex-lsp-client/test/integration/typedSurface.integration.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { describe, it, expect, afterAll, beforeEach } from '@jest/globals';
+import { join } from 'path';
+import { existsSync } from 'fs';
+import { DEFAULT_APEX_SETTINGS } from '@salesforce/apex-lsp-shared';
+import { createHeadlessClient } from '../../src/hosts/headlessHost';
+import type { HeadlessClientResult } from '../../src/hosts/headlessHost';
+
+/**
+ * Integration test for the typed apex/* surface. Spawns the real Node language
+ * server, performs the LSP initialize handshake, and validates that typed
+ * senders and handler registrations work end-to-end.
+ *
+ * Gated: requires `RUN_INTEGRATION=1` AND the server binary must exist.
+ */
+const serverPath = join(__dirname, '../../../apex-ls/dist/server.node.js');
+const serverAvailable = existsSync(serverPath);
+const runIntegration = process.env.RUN_INTEGRATION === '1' && serverAvailable;
+const describeIntegration = runIntegration ? describe : describe.skip;
+
+describeIntegration('typed apex/* surface integration', () => {
+  let result: HeadlessClientResult | undefined;
+
+  beforeEach(() => {
+    // Each test gets a fresh client if needed
+  });
+
+  afterAll(async () => {
+    if (result) {
+      try {
+        await result.core.shutdown();
+      } catch {
+        // Server may already be gone.
+      }
+      await result.core.dispose();
+    }
+  });
+
+  it('typed sender round-trip: sendWorkspaceBatch against live server', async () => {
+    result = await createHeadlessClient(serverPath, {
+      nodeArgs: ['--nolazy'],
+      serverArgs: ['--stdio'],
+    });
+
+    await result.core.initialize(DEFAULT_APEX_SETTINGS);
+
+    // The server should accept (or reject with an error) a workspace batch
+    // request. We just verify the typed sender dispatches correctly and gets
+    // a response (success or error) without throwing a transport error.
+    try {
+      const response = await result.core.sendWorkspaceBatch({
+        batchIndex: 0,
+        totalBatches: 1,
+        isLastBatch: true,
+        compressedData: '',
+        fileMetadata: [],
+      });
+      // If server responds, it should have a success field
+      expect(response).toHaveProperty('success');
+    } catch (e: unknown) {
+      // Server may reject with a response error — that's valid; it means the
+      // typed sender dispatched correctly to the wire.
+      expect(e).toBeDefined();
+    }
+  }, 30000);
+
+  it('onFindMissingArtifact fallback response when server sends the request', async () => {
+    if (!result) {
+      result = await createHeadlessClient(serverPath, {
+        nodeArgs: ['--nolazy'],
+        serverArgs: ['--stdio'],
+      });
+      await result.core.initialize(DEFAULT_APEX_SETTINGS);
+    }
+
+    // The default handler is { notFound: true }. We verify the handler is
+    // registered by checking the core has the method. In a real scenario,
+    // the server would send this request during workspace operations.
+    // Here we verify the registration doesn't throw and the core is healthy.
+    expect(result.core.isDisposed()).toBe(false);
+
+    // Register a custom handler and verify it can be set without error
+    const disposable = result.core.onFindMissingArtifact((_params) => ({
+      notFound: true,
+    }));
+    expect(disposable).toBeDefined();
+    expect(disposable.dispose).toBeInstanceOf(Function);
+
+    // Revert to default
+    disposable.dispose();
+  }, 30000);
+
+  it('onRequestWorkspaceLoad handler receives notification from live server', async () => {
+    if (!result) {
+      result = await createHeadlessClient(serverPath, {
+        nodeArgs: ['--nolazy'],
+        serverArgs: ['--stdio'],
+      });
+      await result.core.initialize(DEFAULT_APEX_SETTINGS);
+    }
+
+    // Register the handler — verifies the registration completes without error
+    // and the returned Disposable is valid. Actual notification receipt depends
+    // on server triggering it, which requires a workspace load flow.
+    const received: unknown[] = [];
+    const disposable = result.core.onRequestWorkspaceLoad((params) => {
+      received.push(params);
+    });
+    expect(disposable).toBeDefined();
+    expect(disposable.dispose).toBeInstanceOf(Function);
+
+    // Clean up
+    disposable.dispose();
+  }, 30000);
+});

--- a/packages/apex-lsp-shared/src/index.ts
+++ b/packages/apex-lsp-shared/src/index.ts
@@ -224,9 +224,7 @@ export interface FindMissingArtifactParams {
 }
 
 export type FindMissingArtifactResult =
-  | { opened: string[] }
-  | { notFound: true }
-  | { accepted: true };
+  { opened: string[] } | { notFound: true } | { accepted: true };
 
 /**
  * Result type for findApexTests command
@@ -416,9 +414,7 @@ export interface WorkDoneProgressEnd {
 }
 
 export type WorkDoneProgress =
-  | WorkDoneProgressBegin
-  | WorkDoneProgressReport
-  | WorkDoneProgressEnd;
+  WorkDoneProgressBegin | WorkDoneProgressReport | WorkDoneProgressEnd;
 
 // Wire schemas for IdentifierSpec — safe for postMessage / structured clone
 export {
@@ -514,6 +510,76 @@ export type {
   WorkerLogMessage,
   WorkerLogLevel,
 } from './workerWireSchemas';
+
+// Profiling param/result types for apex/profiling/* methods (3.1 typed surface)
+// Structurally mirror the inline shapes in LCSAdapter + ProfilingService without
+// importing them (shared stays adapter-free).
+
+/**
+ * Parameters for `apex/profiling/start` request.
+ */
+export interface ProfilingStartParams {
+  readonly type?: 'cpu' | 'heap' | 'both';
+}
+
+/**
+ * Result for `apex/profiling/start` request.
+ */
+export interface ProfilingStartResult {
+  readonly success: boolean;
+  readonly message: string;
+  readonly type?: 'cpu' | 'heap' | 'both';
+}
+
+/**
+ * Parameters for `apex/profiling/stop` request.
+ */
+export interface ProfilingStopParams {
+  readonly tag?: string;
+}
+
+/**
+ * Result for `apex/profiling/stop` request.
+ */
+export interface ProfilingStopResult {
+  readonly success: boolean;
+  readonly message: string;
+  readonly files?: readonly string[];
+}
+
+/**
+ * Parameters for `apex/profiling/status` request.
+ */
+export type ProfilingStatusParams = Record<string, never>;
+
+/**
+ * Result for `apex/profiling/status` request.
+ */
+export interface ProfilingStatusResult {
+  readonly isProfiling: boolean;
+  readonly type: 'idle' | 'cpu' | 'heap' | 'both';
+  readonly available: boolean;
+}
+
+/**
+ * Parameters for `apex/workspaceLoadFailed` notification (client→server).
+ * Same shape as WorkspaceLoadCompleteParams — aliased for semantic clarity.
+ */
+export type WorkspaceLoadFailedParams = WorkspaceLoadCompleteParams;
+
+/**
+ * Parameters for `apex/queueStateChanged` notification (server→client).
+ */
+export interface QueueStateChangedParams {
+  readonly metrics: Record<string, unknown>;
+  readonly metadata: { readonly timestamp: number };
+}
+
+/**
+ * Parameters for `apex/workspaceIngestionComplete` notification (server→client).
+ * Empty object — no payload.
+ */
+export type WorkspaceIngestionCompleteParams = Record<string, never>;
 
 // QueueState/GraphData protocol types — shared contract for apex/queueState
 // and apex/graphData custom LSP requests. Structurally model the canonical

--- a/packages/apex-lsp-shared/src/index.ts
+++ b/packages/apex-lsp-shared/src/index.ts
@@ -504,6 +504,76 @@ export type {
   WorkerLogLevel,
 } from './workerWireSchemas';
 
+// Profiling param/result types for apex/profiling/* methods (3.1 typed surface)
+// Structurally mirror the inline shapes in LCSAdapter + ProfilingService without
+// importing them (shared stays adapter-free).
+
+/**
+ * Parameters for `apex/profiling/start` request.
+ */
+export interface ProfilingStartParams {
+  readonly type?: 'cpu' | 'heap' | 'both';
+}
+
+/**
+ * Result for `apex/profiling/start` request.
+ */
+export interface ProfilingStartResult {
+  readonly success: boolean;
+  readonly message: string;
+  readonly type?: 'cpu' | 'heap' | 'both';
+}
+
+/**
+ * Parameters for `apex/profiling/stop` request.
+ */
+export interface ProfilingStopParams {
+  readonly tag?: string;
+}
+
+/**
+ * Result for `apex/profiling/stop` request.
+ */
+export interface ProfilingStopResult {
+  readonly success: boolean;
+  readonly message: string;
+  readonly files?: readonly string[];
+}
+
+/**
+ * Parameters for `apex/profiling/status` request.
+ */
+export type ProfilingStatusParams = Record<string, never>;
+
+/**
+ * Result for `apex/profiling/status` request.
+ */
+export interface ProfilingStatusResult {
+  readonly isProfiling: boolean;
+  readonly type: 'idle' | 'cpu' | 'heap' | 'both';
+  readonly available: boolean;
+}
+
+/**
+ * Parameters for `apex/workspaceLoadFailed` notification (client→server).
+ * Same shape as WorkspaceLoadCompleteParams — aliased for semantic clarity.
+ */
+export type WorkspaceLoadFailedParams = WorkspaceLoadCompleteParams;
+
+/**
+ * Parameters for `apex/queueStateChanged` notification (server→client).
+ */
+export interface QueueStateChangedParams {
+  readonly metrics: Record<string, unknown>;
+  readonly metadata: { readonly timestamp: number };
+}
+
+/**
+ * Parameters for `apex/workspaceIngestionComplete` notification (server→client).
+ * Empty object — no payload.
+ */
+export type WorkspaceIngestionCompleteParams = Record<string, never>;
+
 // QueueState/GraphData protocol types — shared contract for apex/queueState
 // and apex/graphData custom LSP requests. Structurally model the canonical
 // apex-parser-ast runtime shapes without importing them (shared stays

--- a/packages/apex-lsp-shared/src/settings/ApexSettingsManager.ts
+++ b/packages/apex-lsp-shared/src/settings/ApexSettingsManager.ts
@@ -393,10 +393,7 @@ export class ApexSettingsManager {
    */
   public getCompilationOptions(
     operationType:
-      | 'documentChange'
-      | 'documentOpen'
-      | 'documentSymbols'
-      | 'foldingRanges',
+      'documentChange' | 'documentOpen' | 'documentSymbols' | 'foldingRanges',
     fileSize?: number,
   ): CompilationOptions {
     const settings = this.currentSettings;

--- a/packages/apex-lsp-shared/src/settings/ApexSettingsUtilities.ts
+++ b/packages/apex-lsp-shared/src/settings/ApexSettingsUtilities.ts
@@ -402,8 +402,7 @@ export function mergeWithDefaults(
                     number
                   >),
                   ...(userSettings.apex?.scheduler?.queueCapacity as
-                    | Record<string, number>
-                    | undefined),
+                    Record<string, number> | undefined),
                 },
       },
       deferredReferenceProcessing: baseApex.deferredReferenceProcessing
@@ -516,8 +515,7 @@ export function mergeWithExisting(
                     number
                   >),
                   ...(partialSettings.apex?.scheduler?.queueCapacity as
-                    | Record<string, number>
-                    | undefined),
+                    Record<string, number> | undefined),
                 },
       },
       deferredReferenceProcessing:

--- a/packages/apex-lsp-shared/src/settings/LSPConfigurationManager.ts
+++ b/packages/apex-lsp-shared/src/settings/LSPConfigurationManager.ts
@@ -817,10 +817,7 @@ export class LSPConfigurationManager {
    */
   public getCompilationOptions(
     operationType:
-      | 'documentChange'
-      | 'documentOpen'
-      | 'documentSymbols'
-      | 'foldingRanges',
+      'documentChange' | 'documentOpen' | 'documentSymbols' | 'foldingRanges',
     fileSize?: number,
   ) {
     return this.settingsManager.getCompilationOptions(operationType, fileSize);

--- a/packages/apex-lsp-shared/src/workerWireSchemas.ts
+++ b/packages/apex-lsp-shared/src/workerWireSchemas.ts
@@ -568,6 +568,11 @@ export class DispatchDefinition extends Schema.TaggedRequest<DispatchDefinition>
     payload: {
       textDocument: WireTextDocumentId,
       position: WirePosition,
+      // Live (possibly unsaved) document text. The request worker recompiles it
+      // at full detail so member-level symbols (fields, locals, private members)
+      // — which the dataOwner only stores at public-api detail — exist for
+      // position→declaration resolution. Mirrors DispatchHover.
+      content: Schema.optional(Schema.String),
     },
   },
 ) {}

--- a/packages/apex-lsp-shared/src/workerWireSchemas.ts
+++ b/packages/apex-lsp-shared/src/workerWireSchemas.ts
@@ -602,6 +602,11 @@ export class DispatchDefinition extends Schema.TaggedRequest<DispatchDefinition>
     payload: {
       textDocument: WireTextDocumentId,
       position: WirePosition,
+      // Live (possibly unsaved) document text. The request worker recompiles it
+      // at full detail so member-level symbols (fields, locals, private members)
+      // — which the dataOwner only stores at public-api detail — exist for
+      // position→declaration resolution. Mirrors DispatchHover.
+      content: Schema.optional(Schema.String),
       /** W3C traceparent for distributed tracing (optional) */
       traceContext: Schema.optional(Schema.String),
     },

--- a/packages/apex-lsp-testbed/src/utils/serverUtils.ts
+++ b/packages/apex-lsp-testbed/src/utils/serverUtils.ts
@@ -16,11 +16,7 @@ import { createJavaServerOptions } from '../servers/jorje/javaServerLauncher';
 
 // Define server types as a string union
 export type ServerType =
-  | 'demo'
-  | 'jorje'
-  | 'nodeServer'
-  | 'webServer'
-  | 'webWorker';
+  'demo' | 'jorje' | 'nodeServer' | 'webServer' | 'webWorker';
 
 // Define CLI options interface
 export interface CliOptions {

--- a/packages/apex-lsp-testbed/test/performance/eda-workspace.perf.ts
+++ b/packages/apex-lsp-testbed/test/performance/eda-workspace.perf.ts
@@ -239,8 +239,7 @@ describe('EDA Workspace Performance Tests', () => {
                 // Track metrics for each file in batch
                 batch.forEach((fileConfig, index) => {
                   const result = (results as Array<unknown>)[index] as
-                    | CompilationResult<SymbolTable>
-                    | undefined;
+                    CompilationResult<SymbolTable> | undefined;
                   const fileInfo = fileContents[currentBatchStart + index];
 
                   if (result) {
@@ -764,8 +763,7 @@ describe('EDA Workspace Performance Tests', () => {
               } else {
                 // Single listener compilation
                 const listener = testConfig.createListener() as
-                  | ApexSymbolCollectorListener
-                  | VisibilitySymbolListener;
+                  ApexSymbolCollectorListener | VisibilitySymbolListener;
 
                 // Compile all files
                 const compilationConfigs = fileContents.map((file) => ({
@@ -1087,8 +1085,7 @@ describe('EDA Workspace Performance Tests', () => {
             totalReferences = symbolTable.getAllReferences().length;
           } else {
             const listener = testConfig.createListener() as
-              | ApexSymbolCollectorListener
-              | VisibilitySymbolListener;
+              ApexSymbolCollectorListener | VisibilitySymbolListener;
 
             for (const file of sampleFiles) {
               const result = compilerService.compile(

--- a/packages/apex-lsp-testbed/test/performance/lsp-benchmarks.perf.ts
+++ b/packages/apex-lsp-testbed/test/performance/lsp-benchmarks.perf.ts
@@ -73,9 +73,7 @@ const getFilenameFromUri = (uri: string): string => {
 
 // Runtime server type configuration
 const serverType = (process.env.SERVER_TYPE || 'nodeServer') as
-  | 'nodeServer'
-  | 'jorje'
-  | 'webServer';
+  'nodeServer' | 'jorje' | 'webServer';
 const isValidServerType = ['nodeServer', 'jorje', 'webServer'].includes(
   serverType,
 );

--- a/packages/apex-lsp-vscode-extension/src/commands.ts
+++ b/packages/apex-lsp-vscode-extension/src/commands.ts
@@ -28,8 +28,7 @@ let serverStartRetries = 0;
 let lastRestartTime = 0;
 let isStarting = false;
 let restartHandler:
-  | ((context: vscode.ExtensionContext) => Promise<void>)
-  | undefined;
+  ((context: vscode.ExtensionContext) => Promise<void>) | undefined;
 
 /**
  * Initialize command state

--- a/packages/apex-lsp-vscode-extension/src/configuration.ts
+++ b/packages/apex-lsp-vscode-extension/src/configuration.ts
@@ -76,9 +76,7 @@ export const getDebugConfig = (): DebugConfig => {
 
   return {
     mode: config.get<string>('debug', 'off') as
-      | 'off'
-      | 'inspect'
-      | 'inspect-brk',
+      'off' | 'inspect' | 'inspect-brk',
     port: config.get<number>('debugPort', 6009),
   };
 };

--- a/packages/apex-lsp-vscode-extension/src/logging.ts
+++ b/packages/apex-lsp-vscode-extension/src/logging.ts
@@ -86,8 +86,7 @@ export const getClientOutputChannel = (): vscode.OutputChannel | undefined =>
  * @returns The worker/server output channel or undefined if not initialized
  */
 export const getWorkerServerOutputChannel = ():
-  | vscode.OutputChannel
-  | undefined => workerServerOutputChannel;
+  vscode.OutputChannel | undefined => workerServerOutputChannel;
 
 /**
  * Logs a message to the worker/server output channel (for worker and server logs)

--- a/packages/apex-lsp-vscode-extension/src/missing-artifact-handler.ts
+++ b/packages/apex-lsp-vscode-extension/src/missing-artifact-handler.ts
@@ -17,6 +17,30 @@ import { findFilesAcrossWorkspaceFolders } from './workspace-find-files';
 /** sObject suffix patterns — these types have no .cls file. */
 const SOBJECT_SUFFIX_RE = /__[cCrReEbBmMxX]$/;
 
+/**
+ * Reduce a URI to a scheme-independent path for origin comparison. The
+ * missing-artifact request carries the origin URI in whatever scheme the
+ * client opened it (file, vscode-vfs, vscode-test-web…), while candidate
+ * matches come back from findFiles/walkDirectory. Comparing the decoded
+ * path segment sidesteps scheme/encoding differences.
+ */
+function originPathFor(uri: string | undefined): string | undefined {
+  if (!uri) return undefined;
+  try {
+    return vscode.Uri.parse(uri).path;
+  } catch {
+    return undefined;
+  }
+}
+
+/** True when a candidate URI is the origin file itself. */
+function isOriginFile(
+  candidate: vscode.Uri,
+  originPath: string | undefined,
+): boolean {
+  return originPath !== undefined && candidate.path === originPath;
+}
+
 export async function handleFindMissingArtifact(
   params: FindMissingArtifactParams,
   _context: vscode.ExtensionContext,
@@ -95,6 +119,13 @@ async function resolveFromWorkspace(
     return { notFound: true };
   }
 
+  // Exclude the origin file from candidates — it's already open, so re-opening
+  // it can never resolve a *missing* artifact. The parentContext.containingType
+  // strategy targets the class enclosing the reference (the origin file itself
+  // for supertype refs like `implements DataProcessor`), which otherwise sorts
+  // highest and short-circuits the loop before the correct target strategy runs.
+  const originPath = originPathFor(params.origin?.uri);
+
   const uniqueSpecs = dedupeByIdentifierName(identifiers);
   const allFiles = new Set<string>();
 
@@ -102,7 +133,8 @@ async function resolveFromWorkspace(
     const searchStrategies = generateSearchStrategiesForSpec(spec);
 
     for (const strategy of searchStrategies) {
-      const files = await searchWithStrategy(strategy, maxCandidates);
+      const found = await searchWithStrategy(strategy, maxCandidates);
+      const files = found.filter((f) => !isOriginFile(f, originPath));
       for (const f of files) {
         allFiles.add(f.toString());
       }

--- a/packages/apex-lsp-vscode-extension/src/missing-artifact-handler.ts
+++ b/packages/apex-lsp-vscode-extension/src/missing-artifact-handler.ts
@@ -18,6 +18,30 @@ import { findFilesAcrossWorkspaceFolders } from './workspace-find-files';
 /** sObject suffix patterns — these types have no .cls file. */
 const SOBJECT_SUFFIX_RE = /__[cCrReEbBmMxX]$/;
 
+/**
+ * Reduce a URI to a scheme-independent path for origin comparison. The
+ * missing-artifact request carries the origin URI in whatever scheme the
+ * client opened it (file, vscode-vfs, vscode-test-web…), while candidate
+ * matches come back from findFiles/walkDirectory. Comparing the decoded
+ * path segment sidesteps scheme/encoding differences.
+ */
+function originPathFor(uri: string | undefined): string | undefined {
+  if (!uri) return undefined;
+  try {
+    return vscode.Uri.parse(uri).path;
+  } catch {
+    return undefined;
+  }
+}
+
+/** True when a candidate URI is the origin file itself. */
+function isOriginFile(
+  candidate: vscode.Uri,
+  originPath: string | undefined,
+): boolean {
+  return originPath !== undefined && candidate.path === originPath;
+}
+
 export async function handleFindMissingArtifact(
   params: FindMissingArtifactParams,
   _context: vscode.ExtensionContext,
@@ -96,6 +120,13 @@ async function resolveFromWorkspace(
     return { notFound: true };
   }
 
+  // Exclude the origin file from candidates — it's already open, so re-opening
+  // it can never resolve a *missing* artifact. The parentContext.containingType
+  // strategy targets the class enclosing the reference (the origin file itself
+  // for supertype refs like `implements DataProcessor`), which otherwise sorts
+  // highest and short-circuits the loop before the correct target strategy runs.
+  const originPath = originPathFor(params.origin?.uri);
+
   const uniqueSpecs = dedupeByIdentifierName(identifiers);
   const allFiles = new Set<string>();
 
@@ -103,7 +134,8 @@ async function resolveFromWorkspace(
     const searchStrategies = generateSearchStrategiesForSpec(spec);
 
     for (const strategy of searchStrategies) {
-      const files = await searchWithStrategy(strategy, maxCandidates);
+      const found = await searchWithStrategy(strategy, maxCandidates);
+      const files = found.filter((f) => !isOriginFile(f, originPath));
       for (const f of files) {
         allFiles.add(f.toString());
       }

--- a/packages/apex-lsp-vscode-extension/src/observability/extensionTracing.ts
+++ b/packages/apex-lsp-vscode-extension/src/observability/extensionTracing.ts
@@ -32,14 +32,12 @@ class ServicesExtensionActivationError extends Data.TaggedError(
 )<{ cause: unknown }> {}
 
 let extensionTracingRuntime:
-  | ManagedRuntime.ManagedRuntime<never, never>
-  | undefined;
+  ManagedRuntime.ManagedRuntime<never, never> | undefined;
 
 let salesforceServicesApi: SalesforceVSCodeServicesApi | undefined;
 
 export function getSalesforceServicesApi():
-  | SalesforceVSCodeServicesApi
-  | undefined {
+  SalesforceVSCodeServicesApi | undefined {
   return salesforceServicesApi;
 }
 

--- a/packages/apex-lsp-vscode-extension/src/types.ts
+++ b/packages/apex-lsp-vscode-extension/src/types.ts
@@ -13,8 +13,7 @@ import * as vscode from 'vscode';
  */
 export interface ExtensionState {
   client:
-    | { sendNotification: (method: string, params?: any) => void }
-    | undefined;
+    { sendNotification: (method: string, params?: any) => void } | undefined;
   outputChannel: vscode.OutputChannel;
   statusBarItem: vscode.StatusBarItem;
   globalContext: vscode.ExtensionContext;

--- a/packages/apex-lsp-vscode-extension/src/webviews/graphRenderer.ts
+++ b/packages/apex-lsp-vscode-extension/src/webviews/graphRenderer.ts
@@ -76,12 +76,7 @@ export interface GraphData {
 }
 
 export type LayoutType =
-  | 'forceatlas2'
-  | 'force'
-  | 'dagre'
-  | 'circular'
-  | 'grid'
-  | 'random';
+  'forceatlas2' | 'force' | 'dagre' | 'circular' | 'grid' | 'random';
 
 export class GraphRenderer {
   private canvas: HTMLCanvasElement;

--- a/packages/apex-lsp-vscode-extension/test/extensionTracing.test.ts
+++ b/packages/apex-lsp-vscode-extension/test/extensionTracing.test.ts
@@ -174,8 +174,7 @@ describe('extensionTracing', () => {
 
   describe('onDidChangeConfiguration listener', () => {
     let capturedListener:
-      | ((event: vscode.ConfigurationChangeEvent) => Promise<void>)
-      | undefined;
+      ((event: vscode.ConfigurationChangeEvent) => Promise<void>) | undefined;
 
     beforeEach(async () => {
       mockOnDidChangeConfiguration.mockImplementation((listener) => {

--- a/packages/apex-parser-ast/src/cache/stdlib-type-registry-data.ts
+++ b/packages/apex-parser-ast/src/cache/stdlib-type-registry-data.ts
@@ -19,8 +19,7 @@
  * @returns Data URL string or undefined
  */
 export function getEmbeddedStandardLibraryTypeRegistryDataUrl():
-  | string
-  | undefined {
+  string | undefined {
   try {
     // In bundled builds, esbuild will replace this require with a data URL
     // In unbundled builds, this will fail and we fall back to disk loading

--- a/packages/apex-parser-ast/src/parser/compilerService.ts
+++ b/packages/apex-parser-ast/src/parser/compilerService.ts
@@ -66,9 +66,7 @@ export interface CompilationResultWithAssociations<
 }
 
 export type RawParseTree =
-  | CompilationUnitContext
-  | TriggerUnitContext
-  | BlockContext;
+  CompilationUnitContext | TriggerUnitContext | BlockContext;
 
 export interface ParseTreeResult {
   fileName: string;

--- a/packages/apex-parser-ast/src/parser/listeners/ApexReferenceCollectorListener.ts
+++ b/packages/apex-parser-ast/src/parser/listeners/ApexReferenceCollectorListener.ts
@@ -73,8 +73,7 @@ export function isAssignInsideSObjectConstructor(
   ctx: AssignExpressionContext,
 ): boolean {
   let ancestor: ParserRuleContext | undefined = ctx.parentCtx as
-    | ParserRuleContext
-    | undefined;
+    ParserRuleContext | undefined;
   while (ancestor) {
     const name = ancestor.constructor?.name ?? '';
     if (name === 'ClassCreatorRestContext') return true;
@@ -2678,8 +2677,7 @@ export class ApexReferenceCollectorListener extends BaseApexParserListener<Symbo
    */
   private isClassExtendsTypeRef(ctx: TypeRefContext): boolean {
     const parent = ctx.parentCtx as
-      | (ParserRuleContext & { typeRef?: () => unknown })
-      | undefined;
+      (ParserRuleContext & { typeRef?: () => unknown }) | undefined;
     if (!parent || parent.constructor.name !== 'ClassDeclarationContext') {
       return false;
     }

--- a/packages/apex-parser-ast/src/parser/listeners/ApexSymbolCollectorListener.ts
+++ b/packages/apex-parser-ast/src/parser/listeners/ApexSymbolCollectorListener.ts
@@ -3586,12 +3586,7 @@ export class ApexSymbolCollectorListener
       const location = this.getLocation(ctx);
       let literalValue: string | number | boolean | null = null;
       let literalType:
-        | 'Integer'
-        | 'Long'
-        | 'Decimal'
-        | 'String'
-        | 'Boolean'
-        | 'Null' = 'Null';
+        'Integer' | 'Long' | 'Decimal' | 'String' | 'Boolean' | 'Null' = 'Null';
 
       // Extract literal value and determine type
       if (ctx.IntegerLiteral()) {

--- a/packages/apex-parser-ast/src/parser/listeners/FullSymbolCollectorListener.ts
+++ b/packages/apex-parser-ast/src/parser/listeners/FullSymbolCollectorListener.ts
@@ -61,10 +61,7 @@ export class FullSymbolCollectorListener extends BaseApexParserListener<SymbolTa
   // Track if we've been walked (to know when to apply reference collection/resolution)
   private hasBeenWalked: boolean = false;
   private parseTree:
-    | CompilationUnitContext
-    | TriggerUnitContext
-    | BlockContext
-    | null = null;
+    CompilationUnitContext | TriggerUnitContext | BlockContext | null = null;
 
   /**
    * Creates a new instance of the FullSymbolCollectorListener.

--- a/packages/apex-parser-ast/src/semantics/validation/SObjectTypeValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/SObjectTypeValidator.ts
@@ -68,11 +68,7 @@ export interface SObjectFieldInfo {
   isCustom: boolean;
   // Additional properties for method validation
   category?:
-    | 'REGULAR'
-    | 'RELATIONSHIP'
-    | 'FORMULA'
-    | 'ROLLUP_SUMMARY'
-    | 'VARIABLE';
+    'REGULAR' | 'RELATIONSHIP' | 'FORMULA' | 'ROLLUP_SUMMARY' | 'VARIABLE';
   isColumn?: boolean;
   isSoqlExpression?: boolean;
   hasSafeNavigation?: boolean;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/AbstractMethodImplementationValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/AbstractMethodImplementationValidator.ts
@@ -53,8 +53,7 @@ function findParentClassInSameFile(
   if (childClass.parentId) {
     // parentId may point to class block (scope) or directly to outer class
     let outerClass = allClasses.find((s) => s.id === childClass.parentId) as
-      | TypeSymbol
-      | undefined;
+      TypeSymbol | undefined;
 
     if (!outerClass) {
       // parentId points to class block; find class containing that block
@@ -66,8 +65,7 @@ function findParentClassInSameFile(
       );
       if (block) {
         outerClass = allClasses.find((s) => s.id === block.parentId) as
-          | TypeSymbol
-          | undefined;
+          TypeSymbol | undefined;
       }
     }
 

--- a/packages/apex-parser-ast/src/semantics/validation/validators/CollectionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/CollectionValidator.ts
@@ -141,13 +141,8 @@ class CollectionListener extends BaseApexParserListener<void> {
     }
 
     let literalType:
-      | 'integer'
-      | 'long'
-      | 'decimal'
-      | 'string'
-      | 'boolean'
-      | 'null'
-      | null = null;
+      'integer' | 'long' | 'decimal' | 'string' | 'boolean' | 'null' | null =
+      null;
 
     if (literal.IntegerLiteral()) {
       literalType = 'integer';
@@ -462,9 +457,7 @@ export const CollectionValidator: Validator = {
       try {
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           // Use cached parse tree from DocumentStateCache
           parseTree = options.parseTree;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ConstructorValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ConstructorValidator.ts
@@ -553,8 +553,7 @@ function isStringLiteral(expr: ExpressionContext | ParserRuleContext): boolean {
       if (isContextType(primary, LiteralPrimaryContext)) {
         const literalPrimary = primary as LiteralPrimaryContext;
         const literal = literalPrimary.literal?.() as
-          | LiteralContext
-          | undefined;
+          LiteralContext | undefined;
         if (literal) {
           // Use StringLiteral() method to check for string literal
           return !!literal.StringLiteral?.();
@@ -591,8 +590,7 @@ function isNumericLiteral(
     const primary = primaryExpr.primary?.();
     if (primary && isContextType(primary, LiteralPrimaryContext)) {
       const literal = (primary as LiteralPrimaryContext).literal?.() as
-        | LiteralContext
-        | undefined;
+        LiteralContext | undefined;
       if (literal) {
         const intLiteral = literal.IntegerLiteral?.();
         const longLiteral = literal.LongLiteral?.();
@@ -1188,8 +1186,7 @@ function findParentClassInSameFile(
   // Check if child class is an inner class extending its outer class
   if (childClass.parentId) {
     const outerClass = allClasses.find((s) => s.id === childClass.parentId) as
-      | TypeSymbol
-      | undefined;
+      TypeSymbol | undefined;
 
     if (outerClass && outerClass.name.toLowerCase() === superClassName) {
       return outerClass;
@@ -1274,9 +1271,7 @@ export const ConstructorValidator: Validator = {
       try {
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           // Use cached parse tree from DocumentStateCache
           parseTree = options.parseTree;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ControlFlowValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ControlFlowValidator.ts
@@ -212,9 +212,7 @@ export const ControlFlowValidator: Validator = {
       try {
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           // Use cached parse tree from DocumentStateCache
           parseTree = options.parseTree;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/DmlLoopQueryValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/DmlLoopQueryValidator.ts
@@ -168,9 +168,7 @@ export const DmlLoopQueryValidator: Validator = {
 
       try {
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           parseTree = options.parseTree;
         } else {

--- a/packages/apex-parser-ast/src/semantics/validation/validators/DmlStatementValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/DmlStatementValidator.ts
@@ -524,9 +524,7 @@ export const DmlStatementValidator: Validator = {
       try {
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           // Use cached parse tree from DocumentStateCache
           parseTree = options.parseTree;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/DuplicateFieldInitValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/DuplicateFieldInitValidator.ts
@@ -235,9 +235,7 @@ export const DuplicateFieldInitValidator: Validator = {
       try {
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           // Use cached parse tree from DocumentStateCache
           parseTree = options.parseTree;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ExceptionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ExceptionValidator.ts
@@ -266,9 +266,7 @@ export const ExceptionValidator: Validator = {
       try {
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           // Use cached parse tree from DocumentStateCache
           parseTree = options.parseTree;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ExpressionTypeValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ExpressionTypeValidator.ts
@@ -522,9 +522,7 @@ export const ExpressionTypeValidator: Validator = {
       try {
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           // Use cached parse tree from DocumentStateCache
           parseTree = options.parseTree;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ExpressionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ExpressionValidator.ts
@@ -358,13 +358,8 @@ class ExpressionListener extends BaseApexParserListener<void> {
 
     // Determine literal type
     let literalType:
-      | 'integer'
-      | 'long'
-      | 'decimal'
-      | 'string'
-      | 'boolean'
-      | 'null'
-      | null = null;
+      'integer' | 'long' | 'decimal' | 'string' | 'boolean' | 'null' | null =
+      null;
 
     if (literal.IntegerLiteral()) {
       literalType = 'integer';
@@ -1032,9 +1027,7 @@ export const ExpressionValidator: Validator = {
       try {
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           // Use cached parse tree from DocumentStateCache
           parseTree = options.parseTree;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/InnerTypeValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/InnerTypeValidator.ts
@@ -133,8 +133,7 @@ export const InnerTypeValidator: Validator = {
         if (!typeSymbol.parentId) continue;
 
         const parent = allSymbols.find((s) => s.id === typeSymbol.parentId) as
-          | ApexSymbol
-          | undefined;
+          ApexSymbol | undefined;
 
         if (!parent) continue;
 
@@ -180,9 +179,7 @@ export const InnerTypeValidator: Validator = {
           const parser = new ApexParser(tokenStream);
 
           let parseTree:
-            | CompilationUnitContext
-            | TriggerUnitContext
-            | BlockContext;
+            CompilationUnitContext | TriggerUnitContext | BlockContext;
           if (isTrigger) {
             parseTree = parser.triggerUnit();
           } else if (isAnonymous) {

--- a/packages/apex-parser-ast/src/semantics/validation/validators/InstanceofValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/InstanceofValidator.ts
@@ -92,13 +92,8 @@ class InstanceofCollectorListener extends BaseApexParserListener<
     const literal = ctx.literal?.();
     if (!literal) return;
     let litType:
-      | 'integer'
-      | 'long'
-      | 'decimal'
-      | 'string'
-      | 'boolean'
-      | 'null'
-      | null = null;
+      'integer' | 'long' | 'decimal' | 'string' | 'boolean' | 'null' | null =
+      null;
     if (literal.IntegerLiteral?.()) litType = 'integer';
     else if (literal.LongLiteral?.()) litType = 'long';
     else if (literal.NumberLiteral?.()) litType = 'decimal';
@@ -179,9 +174,7 @@ export const InstanceofValidator: Validator = {
       let tree: CompilationUnitContext | TriggerUnitContext | BlockContext;
       if (parseTree) {
         tree = parseTree as
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
       } else if (sourceContent) {
         const lexer = ApexParserFactory.createLexer(sourceContent);
         const tokenStream = new CommonTokenStream(lexer);

--- a/packages/apex-parser-ast/src/semantics/validation/validators/MethodCallValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/MethodCallValidator.ts
@@ -485,9 +485,7 @@ export const MethodCallValidator: Validator = {
       try {
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           parseTree = options.parseTree;
         } else {

--- a/packages/apex-parser-ast/src/semantics/validation/validators/MethodOverrideValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/MethodOverrideValidator.ts
@@ -82,8 +82,7 @@ function findParentClassInSameFile(
   // Check if the parent class matches the superClass name
   if (childClass.parentId) {
     const outerClass = allClasses.find((s) => s.id === childClass.parentId) as
-      | TypeSymbol
-      | undefined;
+      TypeSymbol | undefined;
 
     if (outerClass) {
       // Check if outer class name matches superClass name

--- a/packages/apex-parser-ast/src/semantics/validation/validators/NewExpressionValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/NewExpressionValidator.ts
@@ -178,8 +178,7 @@ export const NewExpressionValidator: Validator = {
         // Inner class parentId may point to class block; traverse to get outer type symbol
         let outerType: TypeSymbol | null = resolvedType.parentId
           ? ((allSymbols.find((s) => s.id === resolvedType.parentId) as
-              | TypeSymbol
-              | undefined) ?? null)
+              TypeSymbol | undefined) ?? null)
           : null;
         if (outerType && isBlockSymbol(outerType)) {
           const block = outerType as ScopeSymbol;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/PropertyAccessorValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/PropertyAccessorValidator.ts
@@ -179,9 +179,7 @@ export const PropertyAccessorValidator: Validator = {
       try {
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           parseTree = options.parseTree;
         } else {

--- a/packages/apex-parser-ast/src/semantics/validation/validators/ReturnStatementValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/ReturnStatementValidator.ts
@@ -185,13 +185,8 @@ class ReturnStatementListener extends BaseApexParserListener<void> {
     }
 
     let literalType:
-      | 'integer'
-      | 'long'
-      | 'decimal'
-      | 'string'
-      | 'boolean'
-      | 'null'
-      | null = null;
+      'integer' | 'long' | 'decimal' | 'string' | 'boolean' | 'null' | null =
+      null;
 
     if (literal.IntegerLiteral()) {
       literalType = 'integer';
@@ -390,9 +385,7 @@ export const ReturnStatementValidator: Validator = {
 
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           // Use cached parse tree from DocumentStateCache
           parseTree = options.parseTree;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/RunAsStatementValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/RunAsStatementValidator.ts
@@ -88,13 +88,8 @@ class RunAsStatementListener extends BaseApexParserListener<void> {
     }
 
     let literalType:
-      | 'integer'
-      | 'long'
-      | 'decimal'
-      | 'string'
-      | 'boolean'
-      | 'null'
-      | null = null;
+      'integer' | 'long' | 'decimal' | 'string' | 'boolean' | 'null' | null =
+      null;
 
     if (literal.IntegerLiteral()) {
       literalType = 'integer';
@@ -279,9 +274,7 @@ export const RunAsStatementValidator: Validator = {
       try {
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           // Use cached parse tree from DocumentStateCache
           parseTree = options.parseTree;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/StaticContextValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/StaticContextValidator.ts
@@ -223,8 +223,7 @@ export const StaticContextValidator: Validator = {
       const containingClass = (allSymbols.find(
         (s) => isClassOrInterfaceSymbol(s) && s.parentId === null,
       ) ?? allSymbols.find((s) => isClassOrInterfaceSymbol(s))) as
-        | TypeSymbol
-        | undefined;
+        TypeSymbol | undefined;
 
       if (!containingClass) {
         return { isValid: true, errors, warnings };
@@ -247,9 +246,7 @@ export const StaticContextValidator: Validator = {
             const parser = new ApexParser(tokenStream);
 
             let parseTree:
-              | CompilationUnitContext
-              | TriggerUnitContext
-              | BlockContext;
+              CompilationUnitContext | TriggerUnitContext | BlockContext;
             if (isTrigger) {
               parseTree = parser.triggerUnit();
             } else if (isAnonymous) {

--- a/packages/apex-parser-ast/src/semantics/validation/validators/SwitchStatementValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/SwitchStatementValidator.ts
@@ -151,13 +151,8 @@ class SwitchListener extends BaseApexParserListener<void> {
     }
 
     let literalType:
-      | 'integer'
-      | 'long'
-      | 'decimal'
-      | 'string'
-      | 'boolean'
-      | 'null'
-      | null = null;
+      'integer' | 'long' | 'decimal' | 'string' | 'boolean' | 'null' | null =
+      null;
 
     if (literal.IntegerLiteral()) {
       literalType = 'integer';
@@ -544,9 +539,7 @@ export const SwitchStatementValidator: Validator = {
       try {
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           // Use cached parse tree from DocumentStateCache
           parseTree = options.parseTree;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/TryCatchFinallyValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/TryCatchFinallyValidator.ts
@@ -170,9 +170,7 @@ export const TryCatchFinallyValidator: Validator = {
       try {
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           // Use cached parse tree from DocumentStateCache
           parseTree = options.parseTree;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/TypeVisibilityValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/TypeVisibilityValidator.ts
@@ -342,8 +342,7 @@ function resolveTypeSymbol(
       symbolManager.findSymbolByName(typeName),
     );
     const typeSymbol = symbols.find((s: ApexSymbol) => inTypeSymbolGroup(s)) as
-      | TypeSymbol
-      | undefined;
+      TypeSymbol | undefined;
 
     if (typeSymbol) {
       return typeSymbol;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/UnreachableStatementValidator.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/UnreachableStatementValidator.ts
@@ -166,9 +166,7 @@ export const UnreachableStatementValidator: Validator = {
       try {
         // Use cached parse tree if available, otherwise parse source content
         let parseTree:
-          | CompilationUnitContext
-          | TriggerUnitContext
-          | BlockContext;
+          CompilationUnitContext | TriggerUnitContext | BlockContext;
         if (options.parseTree) {
           // Use cached parse tree from DocumentStateCache
           parseTree = options.parseTree;

--- a/packages/apex-parser-ast/src/semantics/validation/validators/annotationModifierRules.ts
+++ b/packages/apex-parser-ast/src/semantics/validation/validators/annotationModifierRules.ts
@@ -26,10 +26,7 @@ export type AnnotationElementKind =
 
 /** Required modifier on defining type: isTest, RestResource, global, namespaceAccessible */
 export type RequiredDefiningModifier =
-  | 'isTest'
-  | 'RestResource'
-  | 'global'
-  | 'namespaceAccessibleOrGlobal';
+  'isTest' | 'RestResource' | 'global' | 'namespaceAccessibleOrGlobal';
 
 /**
  * Annotations that require a specific unit type (defining type).

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolIndexingService.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolIndexingService.ts
@@ -21,12 +21,7 @@ import {
  * Task status for tracking processing state
  */
 export type TaskStatus =
-  | 'PENDING'
-  | 'RUNNING'
-  | 'COMPLETED'
-  | 'FAILED'
-  | 'CANCELLED'
-  | 'UNKNOWN';
+  'PENDING' | 'RUNNING' | 'COMPLETED' | 'FAILED' | 'CANCELLED' | 'UNKNOWN';
 
 /**
  * Symbol processing options

--- a/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
+++ b/packages/apex-parser-ast/src/symbols/ApexSymbolManager.ts
@@ -2313,9 +2313,7 @@ export class ApexSymbolManager implements ISymbolManager, SymbolProvider {
           name: symbol.name,
           namespace,
           kind: symbol.kind as
-            | SymbolKind.Class
-            | SymbolKind.Interface
-            | SymbolKind.Enum,
+            SymbolKind.Class | SymbolKind.Interface | SymbolKind.Enum,
           symbolId: symbol.id,
           fileUri,
           isStdlib: false, // User type

--- a/packages/apex-parser-ast/src/symbols/ops/chainResolution.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/chainResolution.ts
@@ -2833,11 +2833,9 @@ export async function resolveQualifiedReferenceFromChain(
       collectionElementType =
         rawTypeName === 'List' || rawTypeName === 'Set'
           ? ((qualifierTypeObj?.typeParameters?.[0]?.originalTypeString as
-              | string
-              | undefined) ??
+              string | undefined) ??
             (qualifierTypeObj?.typeParameters?.[0]?.name as
-              | string
-              | undefined) ??
+              string | undefined) ??
             null)
           : null;
       let collectionTypeSymbol = await resolvePreferredTypeOp(

--- a/packages/apex-parser-ast/src/symbols/ops/symbolMutation.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/symbolMutation.ts
@@ -16,10 +16,7 @@ import { createFileUri } from '../../types/ProtocolHandler';
 import { extractFilePathFromUri } from '../../types/UriBasedIdGenerator';
 
 type MutationDeps =
-  | SymbolIndexStore
-  | ReferenceStore
-  | CacheStore
-  | FileStateStore;
+  SymbolIndexStore | ReferenceStore | CacheStore | FileStateStore;
 
 /** Remove a file and all its symbols from the graph, cache, and state */
 export const removeFile = (

--- a/packages/apex-parser-ast/src/symbols/ops/symbolResolution.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/symbolResolution.ts
@@ -19,10 +19,7 @@ import { ResourceLoaderService } from '../services/ResourceLoaderService';
 import { findByName, findInFile } from './symbolLookup';
 
 type ResolutionDeps =
-  | SymbolIndexStore
-  | CacheStore
-  | FileStateStore
-  | ResourceLoaderService;
+  SymbolIndexStore | CacheStore | FileStateStore | ResourceLoaderService;
 
 /** Resolve a symbol by name with context */
 export const resolveSymbol = (

--- a/packages/apex-parser-ast/src/symbols/resolution/types.ts
+++ b/packages/apex-parser-ast/src/symbols/resolution/types.ts
@@ -12,10 +12,7 @@ import { SymbolResolutionContext } from '../../types/ISymbolManager';
  * LSP request types that require position-based resolution
  */
 export type ResolutionRequestType =
-  | 'hover'
-  | 'definition'
-  | 'references'
-  | 'completion';
+  'hover' | 'definition' | 'references' | 'completion';
 
 /**
  * Position information for resolution requests

--- a/packages/apex-parser-ast/src/types/queue.ts
+++ b/packages/apex-parser-ast/src/types/queue.ts
@@ -164,5 +164,4 @@ export interface SchedulerUtilsInitializedState {
 }
 
 export type SchedulerUtilsState =
-  | SchedulerUtilsUninitializedState
-  | SchedulerUtilsInitializedState;
+  SchedulerUtilsUninitializedState | SchedulerUtilsInitializedState;

--- a/packages/apex-parser-ast/src/types/symbol.ts
+++ b/packages/apex-parser-ast/src/types/symbol.ts
@@ -809,9 +809,7 @@ export const getUnifiedId = (key: SymbolKey, fileUri?: string): string => {
 };
 
 export type SymbolTableParseCompleteness =
-  | 'complete'
-  | 'incomplete'
-  | 'unknown';
+  'complete' | 'incomplete' | 'unknown';
 
 export interface SymbolTableMetadata {
   fileUri: string;

--- a/packages/apex-parser-ast/src/types/symbolReference.ts
+++ b/packages/apex-parser-ast/src/types/symbolReference.ts
@@ -116,9 +116,7 @@ export interface SymbolReference {
   validatedAccess?: 'read' | 'write' | 'readwrite' | 'invalid';
   /** Optional: access validation state */
   accessValidationState?:
-    | 'syntax_only'
-    | 'partially_validated'
-    | 'fully_validated';
+    'syntax_only' | 'partially_validated' | 'fully_validated';
 }
 
 /**
@@ -154,9 +152,7 @@ export interface SymbolReferenceOptions {
   isFullyResolved?: boolean;
   validatedAccess?: 'read' | 'write' | 'readwrite' | 'invalid';
   accessValidationState?:
-    | 'syntax_only'
-    | 'partially_validated'
-    | 'fully_validated';
+    'syntax_only' | 'partially_validated' | 'fully_validated';
   argumentTypes?: string[];
   /** Call-site arity (see {@link SymbolReference.argumentCount}). */
   argumentCount?: number;
@@ -174,21 +170,14 @@ export class EnhancedSymbolReference implements SymbolReference {
   public isStatic?: boolean;
   public literalValue?: string | number | boolean | null;
   public literalType?:
-    | 'Integer'
-    | 'Long'
-    | 'Decimal'
-    | 'String'
-    | 'Boolean'
-    | 'Null';
+    'Integer' | 'Long' | 'Decimal' | 'String' | 'Boolean' | 'Null';
   public chainNodes?: SymbolReference[];
   public resolvedTypeId?: string;
   public resolutionTier?: 'TIER_1' | 'TIER_2';
   public isFullyResolved?: boolean;
   public validatedAccess?: 'read' | 'write' | 'readwrite' | 'invalid';
   public accessValidationState?:
-    | 'syntax_only'
-    | 'partially_validated'
-    | 'fully_validated';
+    'syntax_only' | 'partially_validated' | 'fully_validated';
   public argumentTypes?: string[];
   /**
    * Call-site arity (see {@link SymbolReference.argumentCount}). Like the other
@@ -486,8 +475,7 @@ export class SymbolReferenceFactory {
     typeName: string,
     location: SymbolLocation,
     context:
-      | ReferenceContext.INHERITANCE
-      | ReferenceContext.INTERFACE_IMPLEMENTATION,
+      ReferenceContext.INHERITANCE | ReferenceContext.INTERFACE_IMPLEMENTATION,
     parentContext?: string,
     preciseLocations?: SymbolLocation[],
   ): SymbolReference {

--- a/packages/apex-parser-ast/test/semantics/validation/validators/ValidatorIntegration.test.ts
+++ b/packages/apex-parser-ast/test/semantics/validation/validators/ValidatorIntegration.test.ts
@@ -353,11 +353,9 @@ describe('Validator Integration Tests', () => {
     const allErrors: ValidationErrorInfo[] = results.flatMap((r) => {
       if (r.errors.length > 0 && typeof r.errors[0] === 'string') {
         // Convert legacy string[] format to ValidationErrorInfo[]
-        return (r.errors as string[]).map(
-          (msg): ValidationErrorInfo => ({
-            message: msg,
-          }),
-        );
+        return (r.errors as string[]).map((msg): ValidationErrorInfo => ({
+          message: msg,
+        }));
       }
       return r.errors as ValidationErrorInfo[];
     });

--- a/packages/apex-parser-ast/test/utils/ApexSymbolManager.test.ts
+++ b/packages/apex-parser-ast/test/utils/ApexSymbolManager.test.ts
@@ -124,8 +124,7 @@ describe('ApexSymbolManager', () => {
     const rootScope = symbolTable
       .getAllSymbols()
       .find((s) => isBlockSymbol(s) && s.scopeType === 'file') as
-      | ScopeSymbol
-      | undefined;
+      ScopeSymbol | undefined;
     if (rootScope) {
       collectSymbols(rootScope);
     } else {
@@ -133,8 +132,7 @@ describe('ApexSymbolManager', () => {
       const fileScope = symbolTable
         .getAllSymbols()
         .find((s) => isBlockSymbol(s) && s.scopeType === 'file') as
-        | ScopeSymbol
-        | undefined;
+        ScopeSymbol | undefined;
       if (fileScope) {
         collectSymbols(fileScope);
       }

--- a/packages/apex-stubs-generator/src/scraper/main-scraper.ts
+++ b/packages/apex-stubs-generator/src/scraper/main-scraper.ts
@@ -523,19 +523,18 @@ const scrapeExceptions = (ref: ClassReference) =>
       ];
     }
 
-    return extracted.map(
-      ({ name, parentClass }): ExceptionScrapeResult =>
-        parentClass
-          ? { kind: 'inner', name, parentClass }
-          : {
-              kind: 'topLevel',
-              cls: new ApexClass({
-                name,
-                namespace: ref.namespace,
-                methods: [],
-                properties: [],
-              }),
-            },
+    return extracted.map(({ name, parentClass }): ExceptionScrapeResult =>
+      parentClass
+        ? { kind: 'inner', name, parentClass }
+        : {
+            kind: 'topLevel',
+            cls: new ApexClass({
+              name,
+              namespace: ref.namespace,
+              methods: [],
+              properties: [],
+            }),
+          },
     );
   });
 

--- a/packages/lsp-compliant-services/src/handlers/CompletionHandler.ts
+++ b/packages/lsp-compliant-services/src/handlers/CompletionHandler.ts
@@ -82,9 +82,7 @@ export class CompletionHandler {
           ),
         );
         return CompletionList.create(result.items, result.isIncomplete) as
-          | CompletionList
-          | CompletionItem[]
-          | null;
+          CompletionList | CompletionItem[] | null;
       }
 
       const items = yield* Effect.tryPromise(() =>

--- a/packages/lsp-compliant-services/src/services/DefinitionProcessingService.ts
+++ b/packages/lsp-compliant-services/src/services/DefinitionProcessingService.ts
@@ -320,17 +320,20 @@ export class DefinitionProcessingService implements IDefinitionProcessor {
         wasResolvedFromMissingArtifact,
       };
 
-      // Check for duplicate definitions (same unifiedId)
-      // For duplicate symbols, return all definition locations so users can see all duplicates
-      // This helps users identify duplicate declaration errors
+      // Return all locations for a genuine duplicate declaration so users can
+      // spot the error. Match on kind as well as unifiedId: a real duplicate is
+      // always the same kind (e.g. two fields sharing a name), whereas a field
+      // and a same-named constructor parameter can share a unifiedId today (the
+      // parser collapses a constructor's scope onto its enclosing class) yet are
+      // different kinds and must not be grouped.
       let allSymbols: ApexSymbol[] = [symbol];
       if (symbol.key?.unifiedId) {
-        // Try to find duplicates by getting all symbols in the file and checking for same unifiedId
         const fileSymbols = await this.symbolManager.findSymbolsInFile(
           symbol.fileUri,
         );
         const duplicates = fileSymbols.filter(
-          (s) => s.key?.unifiedId === symbol.key.unifiedId,
+          (s) =>
+            s.key?.unifiedId === symbol.key.unifiedId && s.kind === symbol.kind,
         );
         if (duplicates.length > 1) {
           // Found duplicates - include all of them
@@ -353,13 +356,37 @@ export class DefinitionProcessingService implements IDefinitionProcessor {
         locations.push(...symLocations);
       }
 
+      // Collapse locations on the same declaration line. A genuine duplicate
+      // lives on its own line, but layered compilation (public-api load + full
+      // recompile) can leave two same-kind entries for one declaration on the
+      // same line — one on the identifier, one on the type token. Returning both
+      // makes VS Code open a peek instead of jumping, so keep one per (uri, line).
+      //
+      // DEFERRED (W-23408848, do NOT "fix" by adding column to the key): keying
+      // on (uri, line) can also collapse two GENUINE duplicate declarations that
+      // happen to share a line, e.g. a multi-declarator `String a, a;`. That is
+      // a rare, already-degenerate case. Adding startColumn to the key would
+      // separate such duplicates — BUT it would also re-separate the layered
+      // identifier/type-token artifacts above (which differ ONLY by column) and
+      // reintroduce the peek bug this fix removes. If genuine same-line
+      // duplicates must be surfaced later, dedup on (uri, line, unifiedId+kind)
+      // — NOT column.
+      const seen = new Set<string>();
+      const dedupedLocations = locations.filter((loc) => {
+        const lineKey = `${loc.uri}#${loc.range.start.line}`;
+        if (seen.has(lineKey)) {
+          return false;
+        }
+        seen.add(lineKey);
+        return true;
+      });
+
       this.logger.debug(
         () =>
-          `Returning ${locations.length} definition location(s) for: ${symbol?.name ?? 'null'}`,
+          `Returning ${dedupedLocations.length} definition location(s) for: ${symbol?.name ?? 'null'}`,
       );
 
-      // Return the locations array (may contain multiple locations for duplicates)
-      return locations;
+      return dedupedLocations;
     } catch (error) {
       this.logger.error(() => `Error processing definition request: ${error}`);
       return null;

--- a/packages/lsp-compliant-services/src/services/MissingArtifactResolutionService.ts
+++ b/packages/lsp-compliant-services/src/services/MissingArtifactResolutionService.ts
@@ -156,30 +156,79 @@ export class EnhancedMissingArtifactResolutionService implements MissingArtifact
       return 'unsupported';
     }
 
+    // Sanitize once and reuse for every sink (proxy + queue). Both terminate in
+    // a structured-clone postMessage, and symbol-manager class instances
+    // (typeReference, parentContext.*) are not cloneable — an unsanitized
+    // payload throws DataCloneError and silently fails resolution.
+    const safeParams = this.sanitizeParams(params);
+    const timeoutMs = params.timeoutMsHint || this.config.blockingWaitTimeoutMs;
+
     const requestPromise = (async (): Promise<BlockingResult> => {
       try {
+        // Worker context (enrichment/request pool): no LSP connection, so the
+        // local queue can't reach the client and would resolve nothing. Forward
+        // the blocking request through the coordinator assistance proxy and
+        // await it — the coordinator owns the connection, drives the client to
+        // open the artifact (which flows to the data-owner via didOpen), and
+        // returns the result. Awaiting here means the caller's re-query sees the
+        // freshly-loaded artifact.
+        const proxy = EnhancedMissingArtifactResolutionService.assistanceProxy;
+        if (!this.getConnection() && proxy) {
+          this.logger.debug(
+            () =>
+              `Forwarding blocking resolution via assistance proxy for: ${names}`,
+          );
+          // The proxy chain (requestCoordinatorAssistance) has no self-imposed
+          // rejection; without a bound, a lost/errored coordinator response
+          // would hang hover/definition on the hot path forever. Race against
+          // the same budget the queue path uses; a timeout throws and is
+          // handled by the shared catch below (records cooldown, returns
+          // 'timeout').
+          const proxyResult = await this.withTimeout(
+            proxy(safeParams),
+            timeoutMs,
+          );
+          // Reaching here means the proxy resolved without throwing, so any
+          // prior timeout cooldown for this key is stale — clear it.
+          // (mapResultToBlockingResult only yields 'resolved'/'not-found';
+          // timeouts surface as a thrown error handled by the catch below.)
+          const mappedProxy = this.mapResultToBlockingResult(proxyResult);
+          EnhancedMissingArtifactResolutionService.recentBlockingTimeouts.delete(
+            key,
+          );
+          if (shouldObserve) {
+            this.logger.debug(
+              () =>
+                `[REQ-HARDEN] missingArtifact blocking end (proxy) kind=${requestKind} ` +
+                `result=${mappedProxy} durationMs=${Date.now() - startedAt}`,
+            );
+          }
+          return mappedProxy;
+        }
+
         // Priority tuning: keep definition responsive, but avoid starving hover/startup
         // with high-priority artifact loads during workspace churn.
         const priority =
           requestKind === 'definition' ? Priority.High : Priority.Normal;
         const result = await this.getQueueManager().submitRequest(
           'findMissingArtifact',
-          params,
+          safeParams,
           {
             priority,
-            timeout: params.timeoutMsHint || this.config.blockingWaitTimeoutMs,
+            timeout: timeoutMs,
           },
         );
 
         this.logger.debug(() => `Blocking resolution completed for: ${names}`);
 
-        // Map the result to BlockingResult
+        // Map the result to BlockingResult. Reaching here means the queue
+        // resolved without throwing, so clear any stale timeout cooldown for
+        // this key. (mapResultToBlockingResult only yields
+        // 'resolved'/'not-found'; queue timeouts throw and are handled below.)
         const mapped = this.mapResultToBlockingResult(result);
-        if (mapped !== 'timeout') {
-          EnhancedMissingArtifactResolutionService.recentBlockingTimeouts.delete(
-            key,
-          );
-        }
+        EnhancedMissingArtifactResolutionService.recentBlockingTimeouts.delete(
+          key,
+        );
         if (shouldObserve) {
           this.logger.debug(
             () =>
@@ -251,25 +300,8 @@ export class EnhancedMissingArtifactResolutionService implements MissingArtifact
     }
 
     try {
-      // Get LSP connection to send request to client
       // Sanitize params before sending via postMessage (structured clone).
-      // Symbol manager class instances (typeReference, parentContext.*) are not
-      // cloneable. Schema.decodeUnknownSync creates a new plain object containing
-      // only the declared wire-schema fields, stripping all class extras.
-      const decodeIdentifier = Schema.decodeUnknownSync(
-        WireIdentifierSpecSchema,
-      );
-      const safeParams = {
-        ...params,
-        identifiers: params.identifiers.map((id) => {
-          try {
-            return decodeIdentifier(id);
-          } catch {
-            // Fallback: name-only if the identifier deviates from the wire schema
-            return { name: id.name };
-          }
-        }),
-      };
+      const safeParams = this.sanitizeParams(params);
 
       const connection = this.getConnection();
       if (!connection) {
@@ -336,6 +368,52 @@ export class EnhancedMissingArtifactResolutionService implements MissingArtifact
       );
       // Don't throw - background resolution failures shouldn't block the main flow
     }
+  }
+
+  /**
+   * Sanitize params before sending via postMessage (structured clone).
+   * Symbol manager class instances (typeReference, parentContext.*) are not
+   * cloneable. Schema.decodeUnknownSync creates a new plain object containing
+   * only the declared wire-schema fields, stripping all class extras. Shared by
+   * every sink that forwards params across a worker boundary (proxy + queue).
+   */
+  private sanitizeParams(
+    params: FindMissingArtifactParams,
+  ): FindMissingArtifactParams {
+    const decodeIdentifier = Schema.decodeUnknownSync(WireIdentifierSpecSchema);
+    // Schema.decode yields deeply-readonly values; the runtime object is a
+    // plain structured-clone-safe payload, so cast back to the mutable param
+    // type for the sinks that consume it.
+    return {
+      ...params,
+      identifiers: params.identifiers.map((id) => {
+        try {
+          return decodeIdentifier(id);
+        } catch {
+          // Fallback: name-only if the identifier deviates from the wire schema
+          return { name: id.name };
+        }
+      }),
+    } as FindMissingArtifactParams;
+  }
+
+  /**
+   * Race a promise against a timeout. Rejects with a timeout Error (matched by
+   * the caller's `error.message.includes('timeout')` cooldown handling) if the
+   * budget elapses first.
+   */
+  private withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+    let timer: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(
+        () =>
+          reject(new Error(`Blocking resolution timeout after ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+    });
+    return Promise.race([promise, timeout]).finally(() =>
+      clearTimeout(timer),
+    ) as Promise<T>;
   }
 
   /**

--- a/packages/lsp-compliant-services/src/services/MissingArtifactResolutionService.ts
+++ b/packages/lsp-compliant-services/src/services/MissingArtifactResolutionService.ts
@@ -22,11 +22,7 @@ import type { Connection } from 'vscode-languageserver';
  * Result types for blocking resolution
  */
 export type BlockingResult =
-  | 'resolved'
-  | 'not-found'
-  | 'timeout'
-  | 'cancelled'
-  | 'unsupported';
+  'resolved' | 'not-found' | 'timeout' | 'cancelled' | 'unsupported';
 
 /**
  * Configuration for missing artifact resolution
@@ -67,8 +63,7 @@ export class EnhancedMissingArtifactResolutionService implements MissingArtifact
    * via setMissingArtifactAssistanceProxy().
    */
   private static assistanceProxy:
-    | ((params: unknown) => Promise<unknown>)
-    | null = null;
+    ((params: unknown) => Promise<unknown>) | null = null;
 
   static setAssistanceProxy(fn: (params: unknown) => Promise<unknown>): void {
     EnhancedMissingArtifactResolutionService.assistanceProxy = fn;
@@ -161,30 +156,79 @@ export class EnhancedMissingArtifactResolutionService implements MissingArtifact
       return 'unsupported';
     }
 
+    // Sanitize once and reuse for every sink (proxy + queue). Both terminate in
+    // a structured-clone postMessage, and symbol-manager class instances
+    // (typeReference, parentContext.*) are not cloneable — an unsanitized
+    // payload throws DataCloneError and silently fails resolution.
+    const safeParams = this.sanitizeParams(params);
+    const timeoutMs = params.timeoutMsHint || this.config.blockingWaitTimeoutMs;
+
     const requestPromise = (async (): Promise<BlockingResult> => {
       try {
+        // Worker context (enrichment/request pool): no LSP connection, so the
+        // local queue can't reach the client and would resolve nothing. Forward
+        // the blocking request through the coordinator assistance proxy and
+        // await it — the coordinator owns the connection, drives the client to
+        // open the artifact (which flows to the data-owner via didOpen), and
+        // returns the result. Awaiting here means the caller's re-query sees the
+        // freshly-loaded artifact.
+        const proxy = EnhancedMissingArtifactResolutionService.assistanceProxy;
+        if (!this.getConnection() && proxy) {
+          this.logger.debug(
+            () =>
+              `Forwarding blocking resolution via assistance proxy for: ${names}`,
+          );
+          // The proxy chain (requestCoordinatorAssistance) has no self-imposed
+          // rejection; without a bound, a lost/errored coordinator response
+          // would hang hover/definition on the hot path forever. Race against
+          // the same budget the queue path uses; a timeout throws and is
+          // handled by the shared catch below (records cooldown, returns
+          // 'timeout').
+          const proxyResult = await this.withTimeout(
+            proxy(safeParams),
+            timeoutMs,
+          );
+          // Reaching here means the proxy resolved without throwing, so any
+          // prior timeout cooldown for this key is stale — clear it.
+          // (mapResultToBlockingResult only yields 'resolved'/'not-found';
+          // timeouts surface as a thrown error handled by the catch below.)
+          const mappedProxy = this.mapResultToBlockingResult(proxyResult);
+          EnhancedMissingArtifactResolutionService.recentBlockingTimeouts.delete(
+            key,
+          );
+          if (shouldObserve) {
+            this.logger.debug(
+              () =>
+                `[REQ-HARDEN] missingArtifact blocking end (proxy) kind=${requestKind} ` +
+                `result=${mappedProxy} durationMs=${Date.now() - startedAt}`,
+            );
+          }
+          return mappedProxy;
+        }
+
         // Priority tuning: keep definition responsive, but avoid starving hover/startup
         // with high-priority artifact loads during workspace churn.
         const priority =
           requestKind === 'definition' ? Priority.High : Priority.Normal;
         const result = await this.getQueueManager().submitRequest(
           'findMissingArtifact',
-          params,
+          safeParams,
           {
             priority,
-            timeout: params.timeoutMsHint || this.config.blockingWaitTimeoutMs,
+            timeout: timeoutMs,
           },
         );
 
         this.logger.debug(() => `Blocking resolution completed for: ${names}`);
 
-        // Map the result to BlockingResult
+        // Map the result to BlockingResult. Reaching here means the queue
+        // resolved without throwing, so clear any stale timeout cooldown for
+        // this key. (mapResultToBlockingResult only yields
+        // 'resolved'/'not-found'; queue timeouts throw and are handled below.)
         const mapped = this.mapResultToBlockingResult(result);
-        if (mapped !== 'timeout') {
-          EnhancedMissingArtifactResolutionService.recentBlockingTimeouts.delete(
-            key,
-          );
-        }
+        EnhancedMissingArtifactResolutionService.recentBlockingTimeouts.delete(
+          key,
+        );
         if (shouldObserve) {
           this.logger.debug(
             () =>
@@ -256,25 +300,8 @@ export class EnhancedMissingArtifactResolutionService implements MissingArtifact
     }
 
     try {
-      // Get LSP connection to send request to client
       // Sanitize params before sending via postMessage (structured clone).
-      // Symbol manager class instances (typeReference, parentContext.*) are not
-      // cloneable. Schema.decodeUnknownSync creates a new plain object containing
-      // only the declared wire-schema fields, stripping all class extras.
-      const decodeIdentifier = Schema.decodeUnknownSync(
-        WireIdentifierSpecSchema,
-      );
-      const safeParams = {
-        ...params,
-        identifiers: params.identifiers.map((id) => {
-          try {
-            return decodeIdentifier(id);
-          } catch {
-            // Fallback: name-only if the identifier deviates from the wire schema
-            return { name: id.name };
-          }
-        }),
-      };
+      const safeParams = this.sanitizeParams(params);
 
       const connection = this.getConnection();
       if (!connection) {
@@ -341,6 +368,52 @@ export class EnhancedMissingArtifactResolutionService implements MissingArtifact
       );
       // Don't throw - background resolution failures shouldn't block the main flow
     }
+  }
+
+  /**
+   * Sanitize params before sending via postMessage (structured clone).
+   * Symbol manager class instances (typeReference, parentContext.*) are not
+   * cloneable. Schema.decodeUnknownSync creates a new plain object containing
+   * only the declared wire-schema fields, stripping all class extras. Shared by
+   * every sink that forwards params across a worker boundary (proxy + queue).
+   */
+  private sanitizeParams(
+    params: FindMissingArtifactParams,
+  ): FindMissingArtifactParams {
+    const decodeIdentifier = Schema.decodeUnknownSync(WireIdentifierSpecSchema);
+    // Schema.decode yields deeply-readonly values; the runtime object is a
+    // plain structured-clone-safe payload, so cast back to the mutable param
+    // type for the sinks that consume it.
+    return {
+      ...params,
+      identifiers: params.identifiers.map((id) => {
+        try {
+          return decodeIdentifier(id);
+        } catch {
+          // Fallback: name-only if the identifier deviates from the wire schema
+          return { name: id.name };
+        }
+      }),
+    } as FindMissingArtifactParams;
+  }
+
+  /**
+   * Race a promise against a timeout. Rejects with a timeout Error (matched by
+   * the caller's `error.message.includes('timeout')` cooldown handling) if the
+   * budget elapses first.
+   */
+  private withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+    let timer: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(
+        () =>
+          reject(new Error(`Blocking resolution timeout after ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+    });
+    return Promise.race([promise, timeout]).finally(() =>
+      clearTimeout(timer),
+    ) as Promise<T>;
   }
 
   /**

--- a/packages/lsp-compliant-services/src/utils/missingArtifactUtils.ts
+++ b/packages/lsp-compliant-services/src/utils/missingArtifactUtils.ts
@@ -40,8 +40,7 @@ export class MissingArtifactUtils {
    * Get or create the missing artifact resolution service on-demand
    */
   private getMissingArtifactService():
-    | MissingArtifactResolutionService
-    | undefined {
+    MissingArtifactResolutionService | undefined {
     if (!this.missingArtifactService) {
       try {
         // Create on-demand using the factory

--- a/packages/lsp-compliant-services/test/integration/DefinitionFieldParamDuplicate.integration.test.ts
+++ b/packages/lsp-compliant-services/test/integration/DefinitionFieldParamDuplicate.integration.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Regression: go-to-definition on a field must return a SINGLE location so VS
+ * Code jumps rather than opening a peek (W-23408848). Two distinct duplicate
+ * sources produced extra locations for a plain field:
+ *
+ *   1. Field vs. same-named constructor parameter. The parser derives a
+ *      symbol's unifiedId from its scope path, and a constructor's scope name
+ *      equals the enclosing class name, so a class field and a same-named
+ *      constructor parameter collapse onto one unifiedId
+ *      (`<file>#block.<Class>.<name>`). The duplicate grouping keyed only on
+ *      unifiedId returned both — a field AND a parameter. Fixed by also
+ *      matching on kind (a genuine duplicate declaration is always the same
+ *      kind; a field and a parameter never are).
+ *
+ *   2. Layered compilation artifacts. The pool worker loads the file at
+ *      public-api detail then recompiles it at full detail; the two passes can
+ *      leave two same-kind field entries on the SAME line — one anchored to the
+ *      identifier, one to the type token. Fixed by collapsing definition
+ *      locations that share a (uri, line): a real duplicate declaration lives
+ *      on its own line.
+ *
+ * Both broke the "navigate to field definition" e2e (multiple locations → peek
+ * → the harness escapes the peek → cursor never moves).
+ */
+
+import { DefinitionParams } from 'vscode-languageserver-protocol';
+
+import { DefinitionProcessingService } from '../../src/services/DefinitionProcessingService';
+import {
+  ApexSymbolManager,
+  CompilerService,
+  FullSymbolCollectorListener,
+  VisibilitySymbolListener,
+  SymbolTable,
+} from '@salesforce/apex-lsp-parser-ast';
+import {
+  enableConsoleLogging,
+  setLogLevel,
+  getLogger,
+} from '@salesforce/apex-lsp-shared';
+import { Effect } from 'effect';
+
+const URI = 'file:///ApexClassExample.cls';
+// A class field shadowed by a same-named constructor parameter — the exact
+// shape that collapses onto one unifiedId in the parser.
+const SRC = `public class ApexClassExample {
+    private String instanceId;
+
+    public ApexClassExample(String instanceId) {
+        if (String.isBlank(instanceId)) {
+            instanceId = 'default';
+        }
+        this.instanceId = instanceId;
+    }
+}`;
+
+// line index 1 (0-based): "    private String instanceId;"
+const FIELD_LINE = 1;
+
+describe('DefinitionProcessingService - field definition single location', () => {
+  const fieldDeclParams = (): DefinitionParams => {
+    const line = SRC.split('\n')[FIELD_LINE];
+    return {
+      textDocument: { uri: URI },
+      position: { line: FIELD_LINE, character: line.indexOf('instanceId') },
+    };
+  };
+
+  beforeAll(() => {
+    enableConsoleLogging();
+    setLogLevel('error');
+  });
+
+  it('returns a single location for a field shadowed by a same-named constructor parameter', async () => {
+    const symbolManager = new ApexSymbolManager();
+    const compilerService = new CompilerService();
+    const table = new SymbolTable();
+    const listener = new FullSymbolCollectorListener(table);
+    compilerService.compile(SRC, URI, listener, {});
+    await Effect.runPromise(symbolManager.addSymbolTable(table, URI));
+    const definitionService = new DefinitionProcessingService(
+      getLogger(),
+      symbolManager,
+    );
+
+    const result = await definitionService.processDefinition(fieldDeclParams());
+
+    expect(result).toBeDefined();
+    // Exactly one location — the field declaration — NOT the field plus the
+    // same-named constructor parameter.
+    expect(result!.length).toBe(1);
+    expect(result![0].range.start.line).toBe(FIELD_LINE);
+  });
+
+  it('returns a single location after a layered public-api + full recompile (same-line artifacts)', async () => {
+    // Mirror the pool worker: ingest the file at public-api detail, then
+    // recompile it at full detail. The two passes can leave two same-kind field
+    // entries on the field's line; the (uri, line) collapse must fold them.
+    const symbolManager = new ApexSymbolManager();
+    const compilerService = new CompilerService();
+
+    const publicApiTable = new SymbolTable();
+    compilerService.compile(
+      SRC,
+      URI,
+      new VisibilitySymbolListener('public-api', publicApiTable),
+      {},
+    );
+    await Effect.runPromise(symbolManager.addSymbolTable(publicApiTable, URI));
+
+    const fullTable = new SymbolTable();
+    compilerService.compile(
+      SRC,
+      URI,
+      new FullSymbolCollectorListener(fullTable),
+      { collectReferences: true, resolveReferences: true },
+    );
+    await Effect.runPromise(symbolManager.addSymbolTable(fullTable, URI));
+
+    const definitionService = new DefinitionProcessingService(
+      getLogger(),
+      symbolManager,
+    );
+
+    const result = await definitionService.processDefinition(fieldDeclParams());
+
+    expect(result).toBeDefined();
+    expect(result!.length).toBe(1);
+    expect(result![0].range.start.line).toBe(FIELD_LINE);
+  });
+});

--- a/packages/lsp-compliant-services/test/services/MissingArtifactResolutionService-blocking-proxy.test.ts
+++ b/packages/lsp-compliant-services/test/services/MissingArtifactResolutionService-blocking-proxy.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  LSPConfigurationManager,
+  getLogger,
+  ApexSettingsManager,
+} from '@salesforce/apex-lsp-shared';
+import { EnhancedMissingArtifactResolutionService } from '../../src/services/MissingArtifactResolutionService';
+
+/**
+ * Tests for the blocking assistance-proxy path (worker context, no LSP
+ * connection). Covers the two review-blocking fixes:
+ *   1. params forwarded to the proxy are sanitized (non-cloneable symbol
+ *      manager instances stripped) so structured-clone postMessage can't throw.
+ *   2. a proxy that never settles is bounded by a timeout instead of hanging
+ *      the hover/definition hot path forever.
+ */
+describe('MissingArtifactResolutionService — blocking assistance proxy', () => {
+  let service: EnhancedMissingArtifactResolutionService;
+
+  beforeEach(() => {
+    LSPConfigurationManager.resetInstance();
+    ApexSettingsManager.resetInstance();
+
+    const settingsManager = ApexSettingsManager.getInstance(
+      undefined,
+      'desktop',
+    );
+    settingsManager.updateSettings({
+      apex: {
+        findMissingArtifact: {
+          enabled: true,
+          maxCandidatesToOpen: 3,
+          timeoutMsHint: 2000,
+          blockingWaitTimeoutMs: 5000,
+          indexingBarrierPollMs: 100,
+          enablePerfMarks: false,
+        },
+      },
+    } as any);
+
+    // No connection set on the config manager → resolveBlocking takes the
+    // assistance-proxy branch.
+    LSPConfigurationManager.getInstance();
+
+    service = new EnhancedMissingArtifactResolutionService(getLogger(), {
+      blockingWaitTimeoutMs: 5000,
+      indexingBarrierPollMs: 100,
+    });
+  });
+
+  afterEach(() => {
+    EnhancedMissingArtifactResolutionService.setAssistanceProxy(
+      undefined as any,
+    );
+    LSPConfigurationManager.resetInstance();
+    ApexSettingsManager.resetInstance();
+  });
+
+  // A non-cloneable identifier: a class instance carrying a method. Passing
+  // this straight into structured clone (postMessage) throws DataCloneError.
+  class NonCloneableTypeReference {
+    name = 'MissingClass';
+    resolve() {
+      return this.name;
+    }
+  }
+
+  const makeParams = () => ({
+    identifiers: [
+      {
+        name: 'MissingClass',
+        typeReference: new NonCloneableTypeReference(),
+      } as any,
+    ],
+    mode: 'blocking' as const,
+    origin: {
+      uri: 'file:///test.cls',
+      requestKind: 'definition' as const,
+    },
+  });
+
+  it('sanitizes params before forwarding through the assistance proxy', async () => {
+    const proxy = jest
+      .fn()
+      .mockResolvedValue({ opened: ['file:///Found.cls'] });
+    EnhancedMissingArtifactResolutionService.setAssistanceProxy(proxy);
+
+    const result = await service.resolveBlocking(makeParams());
+
+    expect(result).toBe('resolved');
+    expect(proxy).toHaveBeenCalledTimes(1);
+
+    // The forwarded identifier must be a plain, structured-clone-safe object:
+    // no class prototype, no methods.
+    const forwarded = proxy.mock.calls[0][0];
+    const forwardedId = forwarded.identifiers[0];
+    expect(forwardedId.name).toBe('MissingClass');
+    expect(typeof (forwardedId.typeReference as any)?.resolve).not.toBe(
+      'function',
+    );
+    // structuredClone must not throw on the sanitized payload.
+    expect(() => structuredClone(forwarded)).not.toThrow();
+  });
+
+  it('returns timeout when the proxy never settles', async () => {
+    // A proxy that hangs forever.
+    const proxy = jest.fn().mockReturnValue(new Promise(() => {}));
+    EnhancedMissingArtifactResolutionService.setAssistanceProxy(proxy);
+
+    // Tight budget so the test is fast.
+    const fastService = new EnhancedMissingArtifactResolutionService(
+      getLogger(),
+      { blockingWaitTimeoutMs: 50, indexingBarrierPollMs: 100 },
+    );
+
+    const result = await fastService.resolveBlocking(makeParams());
+
+    expect(result).toBe('timeout');
+    expect(proxy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Merges the latest `main` into the PR #552 branch (`feature/W-23354947-workspace-load-profiling`) and resolves the resulting conflicts. Targets the #552 branch directly (not `main`) so #552 can absorb the merge and go green.

`main` advanced past #552's base with two merges — **#549** (`fix(apex-lsp-web): revive web worker topology + pool member/cross-file resolution`) and **#551** (typed apex/* client surface). #549 overlaps #552 on the enrichment path, producing the conflicts resolved here.

## Conflicts resolved (2 files)

**`packages/apex-lsp-shared/src/workerWireSchemas.ts`** — `DispatchDefinition` payload: kept **both** #552's `traceContext` field and #549's `content` field (the latter is required by #549's full-detail recompile fix).

**`packages/apex-ls/src/worker.platform.shared.ts`** — three regions, all resolved by keeping #552's Effect/span structure and grafting in #549's resolution fixes:
- `loadSymbolDataForEnrichment`: kept #552's `Effect.fn` spans (`querySymbolSubset`, `addSymbolTable`, `resolveDepUris`, `resolveCrossFileReferences`) **and** added #549's supertype-ref collection (`isSupertypeRef` for `INHERITANCE` / `INTERFACE_IMPLEMENTATION`, fetched even when already resolved).
- `DispatchHover` + `DispatchDefinition`: kept #552's `Effect.gen` handler bodies **and** added #549's `recompileCursorFileAtFullDetail` call (wrapped as `yield* Effect.promise(...)` to fit the Effect idiom).

## Also included

Repo-wide `prettier --write` / `eslint --fix`. The #552 branch head was **already failing** the pre-commit lint hook (108 auto-fixable prettier errors, ~65 files, pre-existing — not introduced by this merge). Fixed so the hook passes; changes are formatting-only.

## Verification

- `npm run lint` — clean (prettier + eslint across all packages).
- `npm test` (full suite via pre-commit hook) — **4650 passed, 0 failed**, 489 pending.
- Targeted: `EnrichmentRoundTrip.node.test.ts` (7/7), `DefinitionFieldParamDuplicate.integration.test.ts` (2/2, #549's test), `TraceContextPropagation.node.test.ts` (3/3).
- `tsc` on `packages/apex-ls` src — clean.

Both PRs' fixes verified present in the merged tree: #552's 6 enrichment spans + Effect handlers, and #549's supertype fetch + full-detail recompile + wire-schema `content`.

## Note

This does **not** address the review findings on #552 itself (the web-worker `__require` bundling crash, the `Effect.promise` error-channel regression, etc.) — it only brings the branch up to date with `main`. Those remain for the #552 author.

@W-23354947@
