### PR TITLE
fix(apex-lsp-parser-ast): exclude FORMULA from generated Apex keywords

### DIFF
--- a/packages/apex-parser-ast/scripts/generate-keywords.mjs
+++ b/packages/apex-parser-ast/scripts/generate-keywords.mjs
@@ -14,7 +14,12 @@ const EXCLUDE_ID_TOKENS = new Set(['Identifier', 'IntegralCurrencyLiteral']);
 
 // Grammar erroneously treats system.runas as single token; runAsStatement is System.runAs.
 // Exclude until grammar owners fix. See runAsStatement rule.
-const EXCLUDE_LEXER_KEYWORDS = new Set(['SYSTEMRUNAS']);
+//
+// FORMULA is a SOQL date-function token in the apex-parser grammar, not an Apex
+// language keyword. Emitting it in APEX_KEYWORDS caused `formula` to be treated
+// as a reserved word (and drift the keyword snapshot). Exclude it so the
+// generated keyword list matches the maintained snapshot.
+const EXCLUDE_LEXER_KEYWORDS = new Set(['SYSTEMRUNAS', 'FORMULA']);
 
 /**
  * Read @apexdevtools/apex-parser version. Prefer package-lock.json (exact resolved);


### PR DESCRIPTION
### What does this PR do?

Fixes a deterministic CI failure in `ApexKeywords.test.ts` (Keyword List Snapshot) that fails on every Linux Test matrix cell.

**Root cause:** the apex-parser-ast keyword generator (`scripts/generate-keywords.mjs`) emits `formula` into `APEX_KEYWORDS` because `FORMULA` is a token in the `@apexdevtools/apex-parser` grammar — but it is a **SOQL date-function token, not an Apex language keyword**. A prior change (`7a6409d8`, "removed formula keyword from expected list") removed `formula` from the maintained `ApexKeywords.test.ts.snap` **without** adding a corresponding generator exclusion. `apexKeywords.ts` is git-ignored and regenerated in CI, so a fresh `generate-keywords` run reintroduces `formula` and the snapshot test fails.

### How is it implemented?

Add `FORMULA` to `EXCLUDE_LEXER_KEYWORDS` in `generate-keywords.mjs` (alongside the existing `SYSTEMRUNAS` exclusion), with a comment explaining why. This makes the generated keyword list match the maintained snapshot.

### Testing

- `generate-keywords` fresh run no longer emits `formula`.
- `ApexKeywords.test.ts`: **66/66 pass**.
- Full `apex-parser-ast` suite: green.

### Notes

Discovered while rebasing PR #576 onto `main` — this failure reproduces on a clean `origin/main` checkout (fresh keyword generation), so it is a pre-existing infrastructure bug, independent of #576. Merging this first unblocks #576's CI.

[skip-validate-pr]
