### PR TITLE
feat(apex-lsp-parser-ast): infer expression types for Extract code actions - W-23389334

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -35,6 +35,8 @@ jobs:
         test_file:
           - apex-capability-gating.spec.ts
           - apex-extension-core.spec.ts
+          - apex-extract-constant.spec.ts
+          - apex-extract-variable.spec.ts
           - apex-goto-definition.spec.ts
           - apex-hover.spec.ts
           - apex-hover-stdlib.spec.ts
@@ -275,6 +277,8 @@ jobs:
           EXPECTED_SPECS=(
             "apex-capability-gating.spec.ts"
             "apex-extension-core.spec.ts"
+            "apex-extract-constant.spec.ts"
+            "apex-extract-variable.spec.ts"
             "apex-goto-definition.spec.ts"
             "apex-hover.spec.ts"
             "apex-hover-stdlib.spec.ts"

--- a/e2e-tests/test-data/apex-samples/ExtractConstantSample.cls
+++ b/e2e-tests/test-data/apex-samples/ExtractConstantSample.cls
@@ -1,0 +1,10 @@
+public with sharing class ExtractConstantSample {
+    // A method with a string-literal sub-expression. Extract Constant is gated
+    // (Jorje parity) to literal expressions, and `'greeting'` is a literal, so
+    // the "Extract constant" action is offered here and the extracted constant
+    // infers to String.
+    public String greet() {
+        String message = 'greeting';
+        return message;
+    }
+}

--- a/e2e-tests/test-data/apex-samples/ExtractVariableSample.cls
+++ b/e2e-tests/test-data/apex-samples/ExtractVariableSample.cls
@@ -2,8 +2,24 @@ public with sharing class ExtractVariableSample {
     // A method with a clearly extractable sub-expression. The literal
     // `2 * 3` is a single, well-formed expression inside a method body,
     // which is exactly what the Extract Local Variable refactoring targets.
+    // It infers to Integer (Integer * Integer).
     public Integer computeValue() {
         Integer result = 1 + 2 * 3;
         return result;
+    }
+
+    // A string literal sub-expression: `'value'` infers to String. (Being a
+    // literal it is also eligible for Extract Constant; see ExtractConstantSample.)
+    public String describe() {
+        String label = 'value';
+        return label;
+    }
+
+    // A constructor expression: `new Account()` infers to the constructed type
+    // `Account` (a non-literal, resolved from the expression alone), exercising
+    // that user-defined type casing is preserved.
+    public Account makeAccount() {
+        Account acct = new Account();
+        return acct;
     }
 }

--- a/e2e-tests/tests/apex-extract-constant.spec.ts
+++ b/e2e-tests/tests/apex-extract-constant.spec.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { test, expect } from '../fixtures/apexFixtures';
+
+/**
+ * E2E test for the Extract Constant code action (W-23389338 / 05.3) with
+ * expression type inference (W-23389334 / 01.1).
+ *
+ * Exercises the LSP `textDocument/codeAction` path end-to-end through the
+ * editor: open a .cls fixture, select a literal sub-expression, invoke the
+ * Refactor UI, assert the "Extract constant" action is offered, apply it, and
+ * confirm a class-body `private static final <Type> <name> = <literal>;`
+ * constant is inserted with the selection replaced by `<name>`.
+ *
+ * Extract Constant is gated (Jorje parity) to literal expressions, so the
+ * fixture selection is a string literal (`'greeting'`), which the constant
+ * finder accepts and type inference resolves to `String`.
+ *
+ * Capability profile / development-mode notes: see apex-extract-variable.spec.ts.
+ *
+ * @group code-action
+ */
+
+test.describe('Apex Extract Constant Code Action', () => {
+  test('offers and applies "Extract constant" for a string literal, inferring String', async ({
+    apexEditor,
+  }) => {
+    await test.step('Open the extract-constant fixture', async () => {
+      await apexEditor.openFile('ExtractConstantSample.cls');
+      await apexEditor.waitForLanguageServerReady();
+    });
+
+    await test.step("Select the `'greeting'` string literal", async () => {
+      // Fixture line 7 (1-based): `        String message = 'greeting';`
+      // `'greeting'` begins at column 26 and is 10 characters wide (quotes
+      // included).
+      await apexEditor.selectRange(7, 26, 10);
+    });
+
+    await test.step('Invoke Refactor and assert Extract constant is offered', async () => {
+      const titles = await apexEditor.openCodeActions();
+      expect(
+        titles.some((t) => t.includes('Extract constant')),
+        `Expected an "Extract constant" action but got: ${titles.join(', ')}`,
+      ).toBe(true);
+    });
+
+    await test.step('Apply the action and assert the String constant appears', async () => {
+      await apexEditor.applyCodeAction('Extract constant');
+
+      // A top-level class constant uses `private static final`; the string
+      // literal infers to `String`. Match on structure rather than exact
+      // whitespace/name.
+      await apexEditor.waitForContentToInclude(
+        "private static final String v1 = 'greeting';",
+      );
+
+      const content = await apexEditor.getContent();
+      // Monaco renders indentation with non-breaking spaces ( ); normalize
+      // to regular spaces so the structural regex assertions match reliably.
+      const normalized = content.replace(/ /g, ' ');
+
+      expect(normalized).toMatch(
+        /private\s+static\s+final\s+String\s+v\d+\s*=\s*'greeting'\s*;/,
+      );
+      expect(normalized).not.toContain('// TODO');
+
+      // The original literal is now replaced by the generated name.
+      expect(normalized).toMatch(/String\s+message\s*=\s*v\d+\s*;/);
+    });
+  });
+});

--- a/e2e-tests/tests/apex-extract-constant.spec.ts
+++ b/e2e-tests/tests/apex-extract-constant.spec.ts
@@ -62,14 +62,28 @@ test.describe('Apex Extract Constant Code Action', () => {
       );
 
       const content = await apexEditor.getContent();
-      // Monaco renders indentation with non-breaking spaces ( ); normalize
-      // to regular spaces so the structural regex assertions match reliably.
-      const normalized = content.replace(/ /g, ' ');
+      // Monaco renders indentation with non-breaking spaces ( ); normalize
+      // to regular spaces so the structural regex assertions (including the
+      // exact leading-space count below) match reliably.
+      const normalized = content.replace(/ /g, ' ');
 
       expect(normalized).toMatch(
         /private\s+static\s+final\s+String\s+v\d+\s*=\s*'greeting'\s*;/,
       );
       expect(normalized).not.toContain('// TODO');
+
+      // The constant must line up with the existing four-space members
+      // (regression: the indent was previously a fixed two-space unit, leaving
+      // the inserted line under-indented by two spaces). Assert the inserted
+      // line's leading whitespace is exactly four spaces — matching the
+      // fixture's members. Split on the constant line and measure its indent
+      // directly so a wrong count surfaces the actual value.
+      const constantLine = normalized
+        .split('\n')
+        .find((line) => line.includes('private static final String'));
+      expect(constantLine).toBeDefined();
+      const leadingSpaces = constantLine!.match(/^\s*/)?.[0] ?? '';
+      expect(leadingSpaces).toBe('    ');
 
       // The original literal is now replaced by the generated name.
       expect(normalized).toMatch(/String\s+message\s*=\s*v\d+\s*;/);

--- a/e2e-tests/tests/apex-extract-variable.spec.ts
+++ b/e2e-tests/tests/apex-extract-variable.spec.ts
@@ -9,12 +9,13 @@
 import { test, expect } from '../fixtures/apexFixtures';
 
 /**
- * E2E test for the Extract Variable code action (W-23389338 / 05.3).
+ * E2E tests for the Extract Variable code action (W-23389338 / 05.3) with
+ * expression type inference (W-23389334 / 01.1).
  *
  * Exercises the LSP `textDocument/codeAction` path end-to-end through the
  * editor: open a .cls fixture, select a single sub-expression, invoke the
  * Refactor UI, assert the "Extract local variable" action is offered, apply
- * it, and confirm the document now contains the inserted `Object <name> = ...`
+ * it, and confirm the document now contains the inserted `<Type> <name> = ...`
  * declaration with the selection replaced by `<name>`.
  *
  * Capability profile: the code action provider (kinds quickfix +
@@ -24,17 +25,21 @@ import { test, expect } from '../fixtures/apexFixtures';
  * `.vscode/settings.json` (test-server.js / utils/setup.ts), and desktop via
  * the extension being launched from its `extensionDevelopmentPath`
  * (ExtensionMode.Development). So the provider IS advertised e2e; capability
- * gating (story 05.4) does NOT block this test.
+ * gating (story 05.4) does NOT block these tests.
  *
- * The inferred type is a placeholder (`Object`) with a trailing TODO comment
- * until type inference lands (a separate story), and the generated name is
- * `v1`/`v2`/… so assertions match on structure, not an exact type or name.
+ * Type inference (W-23389334): the extracted declaration now carries the
+ * inferred Apex type rather than the former `Object` placeholder. These cases
+ * cover the three inference kinds that resolve from the expression / same-file
+ * symbol table alone (no cross-file resolution, so no reliance on symbol-index
+ * warm-up): numeric promotion (`Integer`), a string literal (`String`), and a
+ * constructor expression (`Account`, casing preserved). The generated name is
+ * `v1`/`v2`/… so assertions match on structure, not an exact name.
  *
  * @group code-action
  */
 
 test.describe('Apex Extract Variable Code Action', () => {
-  test('offers and applies "Extract local variable" for a selected sub-expression', async ({
+  test('infers Integer for a numeric sub-expression', async ({
     apexEditor,
   }) => {
     await test.step('Open the extract-variable fixture', async () => {
@@ -43,10 +48,10 @@ test.describe('Apex Extract Variable Code Action', () => {
     });
 
     await test.step('Select the `2 * 3` sub-expression', async () => {
-      // Fixture line 6 (1-based): `        Integer result = 1 + 2 * 3;`
+      // Fixture line 7 (1-based): `        Integer result = 1 + 2 * 3;`
       // Columns are 1-based; the `2` of `2 * 3` begins at column 30 and the
       // sub-expression `2 * 3` is 5 characters wide.
-      await apexEditor.selectRange(6, 30, 5);
+      await apexEditor.selectRange(7, 30, 5);
     });
 
     await test.step('Invoke Refactor and assert Extract local variable is offered', async () => {
@@ -57,26 +62,101 @@ test.describe('Apex Extract Variable Code Action', () => {
       ).toBe(true);
     });
 
-    await test.step('Apply the action and assert the extracted declaration appears', async () => {
+    await test.step('Apply the action and assert the Integer declaration appears', async () => {
       await apexEditor.applyCodeAction('Extract local variable');
 
-      // The refactoring inserts `Object v1 = 2 * 3; // TODO...` above the
-      // statement and replaces the selection with the generated name. Match on
-      // structure (Object <name> = <expr>) rather than exact whitespace/name.
-      await apexEditor.waitForContentToInclude('Object v1 = 2 * 3;');
+      // The refactoring infers `Integer` (Integer * Integer) and inserts
+      // `Integer v1 = 2 * 3;` above the statement, replacing the selection with
+      // the generated name. Match on structure rather than exact whitespace.
+      await apexEditor.waitForContentToInclude('Integer v1 = 2 * 3;');
 
       const content = await apexEditor.getContent();
-      // Monaco renders indentation with non-breaking spaces ( ); normalize
+      // Monaco renders indentation with non-breaking spaces ( ); normalize
       // to regular spaces so the structural regex assertions match reliably.
-      const normalized = content.replace(/ /g, ' ');
+      const normalized = content.replace(/ /g, ' ');
 
-      // The inserted declaration: `Object <name> = 2 * 3;` (type is the Object
-      // placeholder until inference lands).
-      expect(normalized).toMatch(/Object\s+v\d+\s*=\s*2\s*\*\s*3\s*;/);
+      // The inserted declaration carries the inferred type (no `Object`
+      // placeholder, no `// TODO`).
+      expect(normalized).toMatch(/Integer\s+v\d+\s*=\s*2\s*\*\s*3\s*;/);
+      expect(normalized).not.toContain('// TODO');
 
       // The original expression is now replaced by the generated name, so the
       // enclosing statement reads `Integer result = 1 + v1;`.
       expect(normalized).toMatch(/Integer\s+result\s*=\s*1\s*\+\s*v\d+\s*;/);
+    });
+  });
+
+  test('infers String for a string-literal sub-expression', async ({
+    apexEditor,
+  }) => {
+    await test.step('Open the extract-variable fixture', async () => {
+      await apexEditor.openFile('ExtractVariableSample.cls');
+      await apexEditor.waitForLanguageServerReady();
+    });
+
+    await test.step("Select the `'value'` string literal", async () => {
+      // Fixture line 14 (1-based): `        String label = 'value';`
+      // `'value'` begins at column 24 and is 7 characters wide (quotes
+      // included).
+      await apexEditor.selectRange(14, 24, 7);
+    });
+
+    await test.step('Invoke Refactor and assert Extract local variable is offered', async () => {
+      const titles = await apexEditor.openCodeActions();
+      expect(
+        titles.some((t) => t.includes('Extract local variable')),
+        `Expected an "Extract local variable" action but got: ${titles.join(', ')}`,
+      ).toBe(true);
+    });
+
+    await test.step('Apply the action and assert the String declaration appears', async () => {
+      await apexEditor.applyCodeAction('Extract local variable');
+
+      // A string literal infers to `String`.
+      await apexEditor.waitForContentToInclude("String v1 = 'value';");
+
+      const content = await apexEditor.getContent();
+      const normalized = content.replace(/ /g, ' ');
+
+      expect(normalized).toMatch(/String\s+v\d+\s*=\s*'value'\s*;/);
+      expect(normalized).not.toContain('// TODO');
+    });
+  });
+
+  test('infers the constructed type for a `new` expression, casing preserved', async ({
+    apexEditor,
+  }) => {
+    await test.step('Open the extract-variable fixture', async () => {
+      await apexEditor.openFile('ExtractVariableSample.cls');
+      await apexEditor.waitForLanguageServerReady();
+    });
+
+    await test.step('Select the `new Account()` expression', async () => {
+      // Fixture line 22 (1-based): `        Account acct = new Account();`
+      // `new Account()` begins at column 24 and is 13 characters wide.
+      await apexEditor.selectRange(22, 24, 13);
+    });
+
+    await test.step('Invoke Refactor and assert Extract local variable is offered', async () => {
+      const titles = await apexEditor.openCodeActions();
+      expect(
+        titles.some((t) => t.includes('Extract local variable')),
+        `Expected an "Extract local variable" action but got: ${titles.join(', ')}`,
+      ).toBe(true);
+    });
+
+    await test.step('Apply the action and assert the Account declaration appears', async () => {
+      await apexEditor.applyCodeAction('Extract local variable');
+
+      // A `new T(...)` expression infers to the constructed type `T`, with
+      // user-defined casing preserved (`Account`, not `account`).
+      await apexEditor.waitForContentToInclude('Account v1 = new Account();');
+
+      const content = await apexEditor.getContent();
+      const normalized = content.replace(/ /g, ' ');
+
+      expect(normalized).toMatch(/Account\s+v\d+\s*=\s*new\s+Account\(\)\s*;/);
+      expect(normalized).not.toContain('// TODO');
     });
   });
 });

--- a/packages/apex-parser-ast/src/index.ts
+++ b/packages/apex-parser-ast/src/index.ts
@@ -74,6 +74,7 @@ export * from './utils/effectUtils';
 export * from './utils/UnifiedCache';
 export * from './utils/expressionRangeFinder';
 export * from './utils/methodCallAtRange';
+export * from './utils/expressionTypeInference';
 export * from './utils/codeActionParse';
 
 // Export cross-file symbol management

--- a/packages/apex-parser-ast/src/types/symbol.ts
+++ b/packages/apex-parser-ast/src/types/symbol.ts
@@ -1796,6 +1796,84 @@ export class SymbolTable {
   }
 
   /**
+   * Resolve a variable/parameter/field/property by name AS SEEN AT a source
+   * position (1-based line, 0-based column), honoring lexical scope.
+   *
+   * The block scopes whose `symbolRange` contains the position are the lexical
+   * ancestors of that point; visiting them innermost-first and returning the
+   * first name match models real Apex resolution — an inner block's local
+   * shadows an enclosing declaration, and a class-body field is found only when
+   * no closer local exists. Crucially this NEVER matches a same-named local in
+   * a sibling method/block (whose range does not contain the position), which a
+   * flat file-wide scan does — emitting a wrong, non-compiling declared type.
+   *
+   * Falls back to a file-scope (root) declaration when no enclosing block
+   * declares the name. Returns `undefined` when nothing matches.
+   *
+   * Unlike {@link lookupInScopeChain}, this seeds from a raw position (no
+   * pre-located `ScopeSymbol` needed) and walks the physical block ranges, so it
+   * also reaches class-body fields whose parent is the class block rather than a
+   * method block.
+   *
+   * @param name The identifier to resolve (case-insensitive, matching Apex).
+   * @param line 1-based source line of the reference.
+   * @param column 0-based source column of the reference.
+   */
+  resolveVariableAtPosition(
+    name: string,
+    line: number,
+    column: number,
+  ): ApexSymbol | undefined {
+    const isVariableLike = (symbol: ApexSymbol): boolean =>
+      symbol.kind === SymbolKind.Variable ||
+      symbol.kind === SymbolKind.Parameter ||
+      symbol.kind === SymbolKind.Field ||
+      symbol.kind === SymbolKind.Property;
+
+    const nameMatches = (symbol: ApexSymbol): boolean =>
+      symbol.name?.toLowerCase() === name.toLowerCase() &&
+      isVariableLike(symbol);
+
+    const containsPosition = (range: Range): boolean => {
+      const afterStart =
+        range.startLine < line ||
+        (range.startLine === line && range.startColumn <= column);
+      const beforeEnd =
+        range.endLine > line ||
+        (range.endLine === line && range.endColumn >= column);
+      return afterStart && beforeEnd;
+    };
+
+    // Enclosing block scopes, innermost (latest-starting) first: this is the
+    // lexical ancestor chain for `position`.
+    const enclosingScopes = this.symbolArray
+      .filter(
+        (symbol): symbol is ScopeSymbol =>
+          symbol.kind === SymbolKind.Block &&
+          !!symbol.location?.symbolRange &&
+          containsPosition(symbol.location.symbolRange),
+      )
+      .sort((a, b) => {
+        const rangeA = a.location.symbolRange;
+        const rangeB = b.location.symbolRange;
+        return (
+          rangeB.startLine - rangeA.startLine ||
+          rangeB.startColumn - rangeA.startColumn
+        );
+      });
+
+    for (const scope of enclosingScopes) {
+      const match = this.getSymbolsInScope(scope.id).find(nameMatches);
+      if (match) {
+        return match;
+      }
+    }
+
+    // Fall back to a file-scope (root) declaration.
+    return this.getSymbolsInScope(null).find(nameMatches);
+  }
+
+  /**
    * Lookup a symbol by key
    * @param key The key of the symbol to find
    * @returns The symbol if found, undefined otherwise

--- a/packages/apex-parser-ast/src/utils/codeActionParse.ts
+++ b/packages/apex-parser-ast/src/utils/codeActionParse.ts
@@ -7,7 +7,8 @@
  */
 
 import { CompilerService, RawParseTree } from '../parser/compilerService';
-import { ApexFoldingRangeListener } from '../parser/listeners/ApexFoldingRangeListener';
+import { ApexSymbolCollectorListener } from '../parser/listeners/ApexSymbolCollectorListener';
+import { SymbolTable } from '../types/symbol';
 import {
   ConstantExtraction,
   ExpressionAtRange,
@@ -15,28 +16,42 @@ import {
   findExpressionAtRange,
   LspRange,
 } from './expressionRangeFinder';
+import {
+  inferExpressionType,
+  InferExpressionTypeOptions,
+} from './expressionTypeInference';
 import { findMethodCallAtRange, MethodCallAtRange } from './methodCallAtRange';
 
 /**
  * Opaque, parsed-once handle for the code-action finders.
  *
  * Produced by {@link parseForCodeActions} and passed back into the range-based
- * accessors ({@link findExpressionForCodeAction}, etc.). The parse tree is held
- * privately so the language-server layer never sees an ANTLR type nor decides
- * which listener / compile options to use — that orchestration lives here, next
- * to the finders that consume it.
+ * accessors ({@link findExpressionForCodeAction}, etc.). The parse tree and
+ * symbol table are held privately so the language-server layer never sees an
+ * ANTLR type nor decides which listener / compile options to use — that
+ * orchestration lives here, next to the finders that consume it.
  */
 export interface CodeActionParseContext {
   /** @internal Cached CST; not for consumption outside this module's accessors. */
   readonly parseTree: RawParseTree | undefined;
+  /**
+   * @internal Same-file symbol table from the single parse; consumed by
+   * {@link inferTypeForCodeAction} for expression type inference. Not for
+   * consumption outside this module's accessors.
+   */
+  readonly symbolTable: SymbolTable | undefined;
 }
 
 /**
- * Parse `text` (Apex source for `uri`) into the CST the code-action finders
- * need, exactly once. Owns the {@link CompilerService} construction, the
- * throwaway {@link ApexFoldingRangeListener} (used purely to obtain
- * `CompilationResult.parseTree`), and the compile options — knowledge that used
- * to leak into the LS layer.
+ * Parse `text` (Apex source for `uri`) into the CST and same-file symbol table
+ * the code-action finders need, exactly once. Owns the {@link CompilerService}
+ * construction, the {@link ApexSymbolCollectorListener} (which yields both the
+ * `parseTree` and a `SymbolTable` in one walk), and the compile options —
+ * knowledge that used to leak into the LS layer.
+ *
+ * The symbol table powers expression type inference (story 01.1); same-file
+ * references are resolved so variable/parameter/field declarations carry their
+ * declared types.
  *
  * Returns `null` (never throws) on parse failure so callers simply degrade to
  * "no code actions offered". The returned handle is opaque: pass it to the
@@ -53,10 +68,16 @@ export const parseForCodeActions = (
     const result = new CompilerService().compile(
       text,
       uri,
-      new ApexFoldingRangeListener(),
-      { includeComments: false },
+      new ApexSymbolCollectorListener(),
+      {
+        includeComments: false,
+        collectReferences: true,
+        resolveReferences: true,
+      },
     );
-    return { parseTree: result.parseTree };
+    const symbolTable =
+      result.result instanceof SymbolTable ? result.result : undefined;
+    return { parseTree: result.parseTree, symbolTable };
   } catch {
     // Resilient: a broken parse yields no code actions, never an exception.
     return null;
@@ -119,3 +140,24 @@ export const findMethodCallForCodeAction = (
   range: LspRange,
 ): MethodCallAtRange | null =>
   context ? findMethodCallAtRange(context.parseTree, range) : null;
+
+/**
+ * Infer the Apex type of an expression already located via
+ * {@link findExpressionForCodeAction}, using the single parse's same-file symbol
+ * table. Returns the correctly-cased type name (e.g. `Integer`, `String`,
+ * `Account`) for the Extract Variable / Extract Constant declaration, or `null`
+ * when the type cannot be resolved (the caller falls back to `Object`).
+ *
+ * The `ExpressionAtRange` handle stays opaque to the caller — only this module
+ * reads its private `expression`. Cross-file resolution enters through the
+ * optional {@link InferExpressionTypeOptions.lookupCrossFileType} seam; when
+ * omitted, resolution is same-file only.
+ */
+export const inferTypeForCodeAction = (
+  context: CodeActionParseContext | null | undefined,
+  found: ExpressionAtRange | null | undefined,
+  options: InferExpressionTypeOptions = {},
+): string | null =>
+  context && found
+    ? inferExpressionType(found.expression, context.symbolTable, options)
+    : null;

--- a/packages/apex-parser-ast/src/utils/expressionRangeFinder.ts
+++ b/packages/apex-parser-ast/src/utils/expressionRangeFinder.ts
@@ -9,6 +9,7 @@
 import { ParserRuleContext } from 'antlr4';
 import {
   BlockContext,
+  ClassBodyDeclarationContext,
   ClassDeclarationContext,
   ExpressionContext,
   LiteralPrimaryContext,
@@ -19,9 +20,9 @@ import {
 } from '@apexdevtools/apex-parser';
 
 /**
- * One level of member indentation for generated declarations. The Extract
- * family emits two-space indent units (matching the Extract Variable path); do
- * not introduce tabs here.
+ * One level of member indentation, used only as a fallback when the enclosing
+ * class has no sibling member to measure. The Extract family emits two-space
+ * indent units; do not introduce tabs here.
  */
 const INDENT_UNIT = '  ';
 
@@ -442,6 +443,25 @@ const isInnerClass = (classDecl: ClassDeclarationContext): boolean =>
   findEnclosingClass(classDecl) !== null;
 
 /**
+ * Walk up from `ctx` to the nearest enclosing member declaration (a
+ * `ClassBodyDeclarationContext` — method, field, property, inner type, ...), or
+ * null. The extracted constant is inserted as a sibling of this member, so its
+ * physical line indent is exactly the target member indentation.
+ */
+const findEnclosingMember = (
+  ctx: ParserRuleContext,
+): ClassBodyDeclarationContext | null => {
+  let current: ParserRuleContext | undefined = ctx.parentCtx;
+  while (current) {
+    if (current instanceof ClassBodyDeclarationContext) {
+      return current;
+    }
+    current = current.parentCtx;
+  }
+  return null;
+};
+
+/**
  * Given an expression (from {@link findExpressionAtRange}), compute the neutral
  * insertion descriptor for extracting it to a class-body constant: the offset
  * just after the enclosing class body's opening `{`, the physical member
@@ -476,13 +496,23 @@ export const findConstantExtraction = (
     // Insert immediately after the class body's opening brace.
     const insertOffset = openBrace.symbol.stop + 1;
 
-    // Physical indent of the class declaration's line + one member level.
-    // `classDecl.start` points at the `class` keyword (modifiers live in a
-    // parent context), so we measure the line's actual indentation from the
-    // char stream rather than the keyword's column — the latter shifts with
+    // Match the existing member indentation by measuring a real sibling: the
+    // member declaration that encloses the expression sits at exactly the
+    // target member level, so its physical line indent is what we want. This
+    // reflects the file's actual indent width (2 spaces, 4 spaces, tabs, ...)
+    // rather than assuming a fixed unit — the same "derive from real code"
+    // approach the Extract Variable path uses for statement indentation.
+    //
+    // Fallback (no enclosing member, e.g. a class-level field initializer):
+    // the class declaration's own line indent + one nominal unit. `classDecl
+    // .start` points at the `class` keyword (modifiers live in a parent
+    // context), so we measure the line's physical indentation from the char
+    // stream rather than the keyword's column — the latter shifts with
     // visibility/sharing modifiers (e.g. `public with sharing class`).
-    const indent =
-      physicalLineIndentAt(classDecl, classDecl.start.start) + INDENT_UNIT;
+    const enclosingMember = findEnclosingMember(expression);
+    const indent = enclosingMember
+      ? physicalLineIndentAt(enclosingMember, enclosingMember.start.start)
+      : physicalLineIndentAt(classDecl, classDecl.start.start) + INDENT_UNIT;
 
     return {
       insertOffset,

--- a/packages/apex-parser-ast/src/utils/expressionTypeInference.ts
+++ b/packages/apex-parser-ast/src/utils/expressionTypeInference.ts
@@ -80,6 +80,53 @@ const CANONICAL_PRIMITIVE_CASING: ReadonlyMap<string, string> = new Map([
 const canonicalizeTypeName = (typeName: string): string =>
   CANONICAL_PRIMITIVE_CASING.get(typeName.toLowerCase()) ?? typeName;
 
+/**
+ * Recover the author's casing for a (possibly-lowercased) type name using the
+ * same-file symbol table. The shared recursive resolver lowercases user-defined
+ * type names (`Account` → `account`), so composite results over custom types
+ * would otherwise be emitted lowercased. Primitives resolve through the fixed
+ * canonical map; for everything else we search the file's declared type spellings
+ * — type declarations (class/interface/enum names) and the declared types of
+ * variables/parameters/fields/properties — and return the first spelling whose
+ * lowercase matches. Falls back to the input verbatim when no declaration is
+ * found (Apex type names are case-insensitive, so the result still compiles).
+ */
+const recoverTypeCasing = (
+  typeName: string,
+  symbolTable: SymbolTable,
+): string => {
+  const primitive = CANONICAL_PRIMITIVE_CASING.get(typeName.toLowerCase());
+  if (primitive) {
+    return primitive;
+  }
+
+  const lower = typeName.toLowerCase();
+  for (const symbol of symbolTable.getAllSymbols()) {
+    // A type declaration's own name carries the canonical spelling.
+    if (
+      (symbol.kind === SymbolKind.Class ||
+        symbol.kind === SymbolKind.Interface ||
+        symbol.kind === SymbolKind.Enum) &&
+      symbol.name?.toLowerCase() === lower
+    ) {
+      return symbol.name;
+    }
+    // A declared variable/field/parameter type carries the author's spelling.
+    if (
+      symbol.kind === SymbolKind.Variable ||
+      symbol.kind === SymbolKind.Parameter ||
+      symbol.kind === SymbolKind.Field ||
+      symbol.kind === SymbolKind.Property
+    ) {
+      const declaredName = (symbol as VariableSymbol).type?.name;
+      if (declaredName && declaredName.toLowerCase() === lower) {
+        return declaredName;
+      }
+    }
+  }
+  return typeName;
+};
+
 /** Unwrap parentheses so `(expr)` resolves as `expr`. */
 const unwrapSubExpression = (expr: ExpressionContext): ExpressionContext => {
   let current = expr;
@@ -122,25 +169,26 @@ const inferLiteralType = (literal: LiteralPrimaryContext): string | null => {
 };
 
 /**
- * Look up a same-file variable/parameter/field by name and return its declared
- * type name verbatim (casing preserved), or `null` when not found or untyped.
+ * Look up a same-file variable/parameter/field AS SEEN AT the reference's source
+ * position and return its declared type name verbatim (casing preserved), or
+ * `null` when not found or untyped.
+ *
+ * Resolution is scope-aware: it walks the lexical block scopes enclosing the
+ * reference (innermost first, then file root) via
+ * {@link SymbolTable.resolveVariableAtPosition}. This is essential — a flat,
+ * file-wide first-match-by-name scan can bind to a same-named local in an
+ * unrelated sibling method (e.g. `Integer x` in one method vs `String x` in
+ * another), yielding a wrong, non-compiling declared type for the extracted
+ * declaration. The position comes from the reference's own token, so no scope
+ * context need cross the package boundary.
  */
 const sameFileVariableType = (
   name: string,
+  line: number,
+  column: number,
   symbolTable: SymbolTable,
 ): string | null => {
-  const symbol =
-    symbolTable.lookup(name, null) ??
-    symbolTable
-      .getAllSymbols()
-      .find(
-        (candidate) =>
-          candidate.name?.toLowerCase() === name.toLowerCase() &&
-          (candidate.kind === SymbolKind.Variable ||
-            candidate.kind === SymbolKind.Parameter ||
-            candidate.kind === SymbolKind.Field ||
-            candidate.kind === SymbolKind.Property),
-      );
+  const symbol = symbolTable.resolveVariableAtPosition(name, line, column);
 
   if (
     symbol &&
@@ -156,24 +204,50 @@ const sameFileVariableType = (
 };
 
 /**
- * Look up a same-file method by name and return its declared return type name
- * verbatim (casing preserved), or `null` when not found or untyped.
+ * Look up a same-file method by name and argument count and return its declared
+ * return type name verbatim (casing preserved), or `null` when it cannot be
+ * resolved unambiguously.
+ *
+ * Overloads are disambiguated by ARITY: among same-named methods, only those
+ * whose declared parameter count matches `argCount` are considered. A flat
+ * first-match-by-name scan (ignoring arguments) picks the first-declared
+ * overload regardless of the call — e.g. resolving `describe(5)` to a zero-arg
+ * `String describe()` when an `Integer describe(Integer)` is the real target —
+ * emitting a wrong declared type. When arity still leaves more than one
+ * candidate (or none matches), we bail to `null` rather than guess, so the
+ * caller falls back to the safe `Object` placeholder.
  */
 const sameFileMethodReturnType = (
   name: string,
+  argCount: number,
   symbolTable: SymbolTable,
 ): string | null => {
-  const method = symbolTable
+  const methods = symbolTable
     .getAllSymbols()
-    .find(
-      (candidate) =>
+    .filter(
+      (candidate): candidate is MethodSymbol =>
         candidate.name?.toLowerCase() === name.toLowerCase() &&
         candidate.kind === SymbolKind.Method,
     );
-  if (method) {
-    return (method as MethodSymbol).returnType?.name ?? null;
+
+  if (methods.length === 0) {
+    return null;
   }
-  return null;
+
+  // Single same-named method: no overloading, resolve directly.
+  if (methods.length === 1) {
+    return methods[0].returnType?.name ?? null;
+  }
+
+  // Overloaded: keep only arity-compatible candidates. Bail on ambiguity so we
+  // never emit a confidently-wrong return type.
+  const byArity = methods.filter(
+    (method) => (method.parameters?.length ?? 0) === argCount,
+  );
+  if (byArity.length !== 1) {
+    return null;
+  }
+  return byArity[0].returnType?.name ?? null;
 };
 
 /**
@@ -211,11 +285,18 @@ const inferLeafType = (
       return inferLiteralType(primary);
     }
     if (primary instanceof IdPrimaryContext) {
-      const name = primary.id()?.getText();
+      const idNode = primary.id();
+      const name = idNode?.getText();
       if (!name) {
         return null;
       }
-      const localType = sameFileVariableType(name, symbolTable);
+      // Resolve the reference at its own source position so a same-named local
+      // in a sibling scope can't be picked. ANTLR lines are 1-based, columns
+      // 0-based — the shape `resolveVariableAtPosition` expects.
+      const token = idNode.start;
+      const localType = token
+        ? sameFileVariableType(name, token.line, token.column, symbolTable)
+        : null;
       if (localType) {
         return canonicalizeTypeName(localType);
       }
@@ -224,13 +305,17 @@ const inferLeafType = (
     }
   }
 
-  // Unqualified method call `foo(...)` — resolve the declared return type.
+  // Unqualified method call `foo(...)` — resolve the declared return type,
+  // disambiguating overloads by argument count.
   if (expr instanceof MethodCallExpressionContext) {
-    const name = expr.methodCall()?.id()?.getText();
+    const methodCall = expr.methodCall();
+    const name = methodCall?.id()?.getText();
     if (!name) {
       return null;
     }
-    const localReturn = sameFileMethodReturnType(name, symbolTable);
+    const argCount =
+      methodCall?.expressionList()?.expression_list()?.length ?? 0;
+    const localReturn = sameFileMethodReturnType(name, argCount, symbolTable);
     if (localReturn) {
       return canonicalizeTypeName(localReturn);
     }
@@ -322,6 +407,65 @@ const collectLiteralTypes = (
 };
 
 /**
+ * Pre-seed the recursive resolver's `resolvedTypes` cache with SCOPE-CORRECT
+ * variable types, keyed by each bare-identifier {@link PrimaryExpressionContext}
+ * in the subtree rooted at `expr`.
+ *
+ * The recursive resolver consults this cache before its own resolution, and its
+ * built-in variable lookup ({@code resolveExpressionTypeTier1}) is a flat,
+ * file-wide first-match-by-name scan — the same scope-unaware bug fixed on the
+ * leaf path, but reachable here for COMPOSITE expressions (e.g. `x + 1`, where a
+ * same-named local in a sibling method would otherwise be picked). Seeding each
+ * variable reference with its position-resolved declared type forecloses that:
+ * the resolver finds our correct entry and never runs its flat scan for these
+ * nodes. Types are stored verbatim (the resolver's combination logic is
+ * case-insensitive; final casing is recovered by {@link recoverTypeCasing}).
+ */
+const collectVariableTypes = (
+  expr: ExpressionContext,
+  symbolTable: SymbolTable,
+): WeakMap<ExpressionContext, ExpressionTypeInfo> => {
+  const resolvedTypes = new WeakMap<ExpressionContext, ExpressionTypeInfo>();
+
+  const visit = (node: any): void => {
+    if (
+      node instanceof PrimaryExpressionContext &&
+      node.primary() instanceof IdPrimaryContext
+    ) {
+      const idNode = (node.primary() as IdPrimaryContext).id();
+      const name = idNode?.getText();
+      const token = idNode?.start;
+      if (name && token) {
+        const declaredType = sameFileVariableType(
+          name,
+          token.line,
+          token.column,
+          symbolTable,
+        );
+        if (declaredType) {
+          resolvedTypes.set(node, {
+            resolvedType: declaredType,
+            source: 'variable',
+          });
+        }
+      }
+    }
+
+    const childCount =
+      typeof node?.getChildCount === 'function' ? node.getChildCount() : 0;
+    for (let i = 0; i < childCount; i++) {
+      const child = node.getChild(i);
+      if (child && typeof child.getChildCount === 'function') {
+        visit(child);
+      }
+    }
+  };
+
+  visit(expr);
+  return resolvedTypes;
+};
+
+/**
  * Infer the Apex type of `expression`, returning the correctly-cased type name
  * (e.g. `Integer`, `String`, `Account`) or `null` when it cannot be resolved.
  *
@@ -358,17 +502,26 @@ export const inferExpressionType = (
     // Composite expressions: delegate to the shared recursive resolver, which
     // computes numeric promotion / string concat / comparison-to-Boolean, etc.
     // Its result is always a primitive (lowercased); normalize the casing.
+    //
+    // Pre-seed the resolver's cache with scope-correct variable types so its own
+    // flat, scope-unaware variable lookup never runs for our identifiers — a
+    // same-named local in a sibling method must not leak into e.g. `x + 1`.
     const literalTypes = collectLiteralTypes(expr);
+    const resolvedTypes = collectVariableTypes(expr, symbolTable);
     const resolved: ExpressionTypeInfo | null = Effect.runSync(
       resolveExpressionTypeRecursive(
         expr,
-        new WeakMap<ExpressionContext, ExpressionTypeInfo>(),
+        resolvedTypes,
         literalTypes,
         symbolTable,
       ),
     );
     if (resolved?.resolvedType) {
-      return canonicalizeTypeName(resolved.resolvedType);
+      // The recursive resolver lowercases everything. Primitives map through the
+      // fixed canonical table; user-defined types (e.g. a ternary/arithmetic
+      // over `Account`) have their author casing recovered from the same-file
+      // declarations so the emitted declaration reads `Account`, not `account`.
+      return recoverTypeCasing(resolved.resolvedType, symbolTable);
     }
     return null;
   } catch {

--- a/packages/apex-parser-ast/src/utils/expressionTypeInference.ts
+++ b/packages/apex-parser-ast/src/utils/expressionTypeInference.ts
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Effect } from 'effect';
+import {
+  CastExpressionContext,
+  ExpressionContext,
+  IdPrimaryContext,
+  LiteralPrimaryContext,
+  MethodCallExpressionContext,
+  NewExpressionContext,
+  PrimaryExpressionContext,
+  SubExpressionContext,
+} from '@apexdevtools/apex-parser';
+
+import { SymbolKind, SymbolTable } from '../types/symbol';
+import type { MethodSymbol, VariableSymbol } from '../types/symbol';
+import {
+  ExpressionTypeInfo,
+  resolveExpressionTypeRecursive,
+} from '../semantics/validation/validators/ExpressionValidator';
+
+/**
+ * Resolve a bare type name that cannot be determined from the local file's
+ * symbol table — e.g. the return type of a method declared in another file, or
+ * a field reached through a receiver whose declaring type lives elsewhere.
+ *
+ * This is the cross-file seam. In the first cut it is backed by same-file
+ * resolution (callers pass a lookup over the local {@link SymbolTable}); a later
+ * change routes it through `chainResolution.resolveMemberInContext` +
+ * `ISymbolManager` for true cross-file resolution without touching this module.
+ *
+ * Implementations return the correctly-cased Apex type name, or `null` when the
+ * name cannot be resolved.
+ */
+export type CrossFileTypeLookup = (typeName: string) => string | null;
+
+/** Options for {@link inferExpressionType}. */
+export interface InferExpressionTypeOptions {
+  /**
+   * Optional cross-file resolver. When omitted, resolution is same-file only
+   * (method-call return types and field access that cannot be resolved from the
+   * local symbol table yield `null`, and the caller falls back to `Object`).
+   */
+  readonly lookupCrossFileType?: CrossFileTypeLookup;
+}
+
+/**
+ * Canonical Apex casing for the primitive/lowercased type names that the shared
+ * recursive resolver (and cast/literal handling) emit. The recursive resolver
+ * lowercases everything, so composite results (`integer`, `boolean`, ...) are
+ * normalized back to their canonical Apex spelling here. Names not in this map
+ * (user-defined types) are returned verbatim from the leaf handlers, so they
+ * never reach normalization lowercased.
+ */
+const CANONICAL_PRIMITIVE_CASING: ReadonlyMap<string, string> = new Map([
+  ['blob', 'Blob'],
+  ['boolean', 'Boolean'],
+  ['date', 'Date'],
+  ['datetime', 'Datetime'],
+  ['decimal', 'Decimal'],
+  ['double', 'Double'],
+  ['id', 'Id'],
+  ['integer', 'Integer'],
+  ['long', 'Long'],
+  ['object', 'Object'],
+  ['string', 'String'],
+  ['time', 'Time'],
+]);
+
+/**
+ * Normalize a possibly-lowercased primitive type name to its canonical Apex
+ * spelling. User-defined type names (not primitives) pass through unchanged.
+ */
+const canonicalizeTypeName = (typeName: string): string =>
+  CANONICAL_PRIMITIVE_CASING.get(typeName.toLowerCase()) ?? typeName;
+
+/** Unwrap parentheses so `(expr)` resolves as `expr`. */
+const unwrapSubExpression = (expr: ExpressionContext): ExpressionContext => {
+  let current = expr;
+  while (current instanceof SubExpressionContext) {
+    const inner = current.expression();
+    if (!inner) {
+      break;
+    }
+    current = inner;
+  }
+  return current;
+};
+
+/**
+ * Resolve the type of a literal primary (e.g. `'x'`, `42`, `true`) with correct
+ * Apex casing, or `null` when the primary is not a typed literal (`null`).
+ */
+const inferLiteralType = (literal: LiteralPrimaryContext): string | null => {
+  const node = literal.literal();
+  if (!node) {
+    return null;
+  }
+  if (node.StringLiteral() || node.MultilineStringLiteral()) {
+    return 'String';
+  }
+  if (node.IntegerLiteral()) {
+    return 'Integer';
+  }
+  if (node.LongLiteral()) {
+    return 'Long';
+  }
+  if (node.NumberLiteral()) {
+    return 'Decimal';
+  }
+  if (node.BooleanLiteral()) {
+    return 'Boolean';
+  }
+  // NULL literal carries no type information.
+  return null;
+};
+
+/**
+ * Look up a same-file variable/parameter/field by name and return its declared
+ * type name verbatim (casing preserved), or `null` when not found or untyped.
+ */
+const sameFileVariableType = (
+  name: string,
+  symbolTable: SymbolTable,
+): string | null => {
+  const symbol =
+    symbolTable.lookup(name, null) ??
+    symbolTable
+      .getAllSymbols()
+      .find(
+        (candidate) =>
+          candidate.name?.toLowerCase() === name.toLowerCase() &&
+          (candidate.kind === SymbolKind.Variable ||
+            candidate.kind === SymbolKind.Parameter ||
+            candidate.kind === SymbolKind.Field ||
+            candidate.kind === SymbolKind.Property),
+      );
+
+  if (
+    symbol &&
+    (symbol.kind === SymbolKind.Variable ||
+      symbol.kind === SymbolKind.Parameter ||
+      symbol.kind === SymbolKind.Field ||
+      symbol.kind === SymbolKind.Property)
+  ) {
+    const variable = symbol as VariableSymbol;
+    return variable.type?.name ?? null;
+  }
+  return null;
+};
+
+/**
+ * Look up a same-file method by name and return its declared return type name
+ * verbatim (casing preserved), or `null` when not found or untyped.
+ */
+const sameFileMethodReturnType = (
+  name: string,
+  symbolTable: SymbolTable,
+): string | null => {
+  const method = symbolTable
+    .getAllSymbols()
+    .find(
+      (candidate) =>
+        candidate.name?.toLowerCase() === name.toLowerCase() &&
+        candidate.kind === SymbolKind.Method,
+    );
+  if (method) {
+    return (method as MethodSymbol).returnType?.name ?? null;
+  }
+  return null;
+};
+
+/**
+ * Resolve the type of a leaf expression — one whose type comes directly from a
+ * declaration or literal rather than from combining operand types. Returns the
+ * correctly-cased Apex type name, or `null` when it cannot be resolved from the
+ * available (same-file, plus optional cross-file seam) information.
+ *
+ * Handles: `new T(...)`, casts `(T) x`, literals, same-file variable/parameter/
+ * field references, and same-file (unqualified) method-call return types.
+ * Qualified/chained access (`a.b`, `a.b()`) is deferred to the cross-file seam
+ * and yields `null` today (caller falls back to `Object`).
+ */
+const inferLeafType = (
+  expr: ExpressionContext,
+  symbolTable: SymbolTable,
+  options: InferExpressionTypeOptions,
+): string | null => {
+  // `new T(...)` — the constructed type is the declared type.
+  if (expr instanceof NewExpressionContext) {
+    const createdName = expr.creator()?.createdName()?.getText();
+    return createdName ? canonicalizeTypeName(createdName) : null;
+  }
+
+  // `(T) x` — a cast's static type is the target type, verbatim.
+  if (expr instanceof CastExpressionContext) {
+    const typeName = expr.typeRef()?.getText();
+    return typeName ? canonicalizeTypeName(typeName) : null;
+  }
+
+  // Primary expressions: literals and bare identifiers.
+  if (expr instanceof PrimaryExpressionContext) {
+    const primary = expr.primary();
+    if (primary instanceof LiteralPrimaryContext) {
+      return inferLiteralType(primary);
+    }
+    if (primary instanceof IdPrimaryContext) {
+      const name = primary.id()?.getText();
+      if (!name) {
+        return null;
+      }
+      const localType = sameFileVariableType(name, symbolTable);
+      if (localType) {
+        return canonicalizeTypeName(localType);
+      }
+      // Unresolved locally — offer the cross-file seam (same-file-backed today).
+      return options.lookupCrossFileType?.(name) ?? null;
+    }
+  }
+
+  // Unqualified method call `foo(...)` — resolve the declared return type.
+  if (expr instanceof MethodCallExpressionContext) {
+    const name = expr.methodCall()?.id()?.getText();
+    if (!name) {
+      return null;
+    }
+    const localReturn = sameFileMethodReturnType(name, symbolTable);
+    if (localReturn) {
+      return canonicalizeTypeName(localReturn);
+    }
+    return options.lookupCrossFileType?.(name) ?? null;
+  }
+
+  return null;
+};
+
+/**
+ * True when `expr` is a leaf whose type this module resolves directly (with
+ * casing preserved), rather than delegating to the shared recursive resolver.
+ */
+const isLeafExpression = (expr: ExpressionContext): boolean =>
+  expr instanceof NewExpressionContext ||
+  expr instanceof CastExpressionContext ||
+  expr instanceof MethodCallExpressionContext ||
+  (expr instanceof PrimaryExpressionContext &&
+    (expr.primary() instanceof LiteralPrimaryContext ||
+      expr.primary() instanceof IdPrimaryContext));
+
+/**
+ * Build the `literalTypes` map the shared recursive resolver needs, by walking
+ * the subtree rooted at `expr` and classifying each literal primary against its
+ * enclosing {@link ExpressionContext}. The resolver treats leaf literals as
+ * untyped unless they appear in this map, so composite expressions such as
+ * `1 + 2 * 3` cannot resolve without it.
+ */
+const collectLiteralTypes = (
+  expr: ExpressionContext,
+): Map<
+  ExpressionContext,
+  'integer' | 'long' | 'decimal' | 'string' | 'boolean' | 'null'
+> => {
+  const literalTypes = new Map<
+    ExpressionContext,
+    'integer' | 'long' | 'decimal' | 'string' | 'boolean' | 'null'
+  >();
+
+  const visit = (node: any): void => {
+    if (node instanceof LiteralPrimaryContext) {
+      const literal = node.literal();
+      let type:
+        'integer' | 'long' | 'decimal' | 'string' | 'boolean' | 'null' | null =
+        null;
+      if (literal) {
+        if (literal.IntegerLiteral()) {
+          type = 'integer';
+        } else if (literal.LongLiteral()) {
+          type = 'long';
+        } else if (literal.NumberLiteral()) {
+          type = 'decimal';
+        } else if (
+          literal.StringLiteral() ||
+          literal.MultilineStringLiteral()
+        ) {
+          type = 'string';
+        } else if (literal.BooleanLiteral()) {
+          type = 'boolean';
+        } else if (literal.NULL?.()) {
+          type = 'null';
+        }
+      }
+      if (type) {
+        // Key by the nearest enclosing ExpressionContext, matching the
+        // convention the validators use to populate this map.
+        let parent: any = node.parentCtx;
+        while (parent && !(parent instanceof ExpressionContext)) {
+          parent = parent.parentCtx;
+        }
+        if (parent instanceof ExpressionContext) {
+          literalTypes.set(parent, type);
+        }
+      }
+    }
+
+    const childCount =
+      typeof node?.getChildCount === 'function' ? node.getChildCount() : 0;
+    for (let i = 0; i < childCount; i++) {
+      const child = node.getChild(i);
+      if (child && typeof child.getChildCount === 'function') {
+        visit(child);
+      }
+    }
+  };
+
+  visit(expr);
+  return literalTypes;
+};
+
+/**
+ * Infer the Apex type of `expression`, returning the correctly-cased type name
+ * (e.g. `Integer`, `String`, `Account`) or `null` when it cannot be resolved.
+ *
+ * Leaf cases (literals, `new T`, casts, same-file variable/parameter/field
+ * references, unqualified same-file method-call return types) are resolved
+ * directly here so their casing is preserved. Composite cases (arithmetic,
+ * comparison, logical, ternary, unary, `instanceof`) are delegated to the
+ * shared {@link resolveExpressionTypeRecursive}, whose lowercased primitive
+ * result is normalized back to canonical Apex casing.
+ *
+ * Same-file only in the first cut; cross-file resolution enters through the
+ * optional {@link InferExpressionTypeOptions.lookupCrossFileType} seam. Never
+ * throws — resolution failures degrade to `null` so the caller can fall back to
+ * `Object`.
+ */
+export const inferExpressionType = (
+  expression: ExpressionContext | null | undefined,
+  symbolTable: SymbolTable | null | undefined,
+  options: InferExpressionTypeOptions = {},
+): string | null => {
+  if (!expression || !symbolTable) {
+    return null;
+  }
+
+  try {
+    const expr = unwrapSubExpression(expression);
+
+    // Leaf types are resolved directly to preserve user-defined casing (the
+    // shared resolver would lowercase e.g. `Account` to `account`).
+    if (isLeafExpression(expr)) {
+      return inferLeafType(expr, symbolTable, options);
+    }
+
+    // Composite expressions: delegate to the shared recursive resolver, which
+    // computes numeric promotion / string concat / comparison-to-Boolean, etc.
+    // Its result is always a primitive (lowercased); normalize the casing.
+    const literalTypes = collectLiteralTypes(expr);
+    const resolved: ExpressionTypeInfo | null = Effect.runSync(
+      resolveExpressionTypeRecursive(
+        expr,
+        new WeakMap<ExpressionContext, ExpressionTypeInfo>(),
+        literalTypes,
+        symbolTable,
+      ),
+    );
+    if (resolved?.resolvedType) {
+      return canonicalizeTypeName(resolved.resolvedType);
+    }
+    return null;
+  } catch {
+    // Resilient: any resolution failure degrades to "unknown" (caller falls
+    // back to `Object`), never an exception.
+    return null;
+  }
+};

--- a/packages/apex-parser-ast/test/utils/expressionRangeFinder.test.ts
+++ b/packages/apex-parser-ast/test/utils/expressionRangeFinder.test.ts
@@ -291,7 +291,7 @@ describe('findConstantExtraction', () => {
     expect(extraction!.isInner).toBe(false);
   });
 
-  it('indents inner-class members relative to the inner class line', () => {
+  it('indents inner-class members to match the sibling member', () => {
     const source = [
       'public class Outer {',
       '  public class Inner {',
@@ -305,9 +305,30 @@ describe('findConstantExtraction', () => {
     const extraction = extractionFor(source, "'hi'");
 
     expect(extraction).not.toBeNull();
-    // Inner class line is indented two spaces; members add one more unit.
+    // The enclosing member (`    public void run()`) is indented four spaces,
+    // so the extracted constant matches at four spaces.
     expect(extraction!.indent).toBe('    ');
     expect(extraction!.isInner).toBe(true);
+    expect(extraction!.isLiteral).toBe(true);
+  });
+
+  it('matches four-space member indentation (not a fixed two-space unit)', () => {
+    // Real-world Apex commonly indents members four spaces. The extracted
+    // constant must line up with the existing members rather than assuming a
+    // two-space unit (the earlier off-by-two bug).
+    const source = [
+      'public with sharing class Const {',
+      '    public void run() {',
+      "        String greeting = 'hello';",
+      '    }',
+      '}',
+    ].join('\n');
+
+    const extraction = extractionFor(source, "'hello'");
+
+    expect(extraction).not.toBeNull();
+    expect(extraction!.indent).toBe('    ');
+    expect(extraction!.isInner).toBe(false);
     expect(extraction!.isLiteral).toBe(true);
   });
 

--- a/packages/apex-parser-ast/test/utils/expressionTypeInference.test.ts
+++ b/packages/apex-parser-ast/test/utils/expressionTypeInference.test.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  findExpressionForCodeAction,
+  inferTypeForCodeAction,
+  parseForCodeActions,
+} from '../../src/utils/codeActionParse';
+import { LspRange } from '../../src/utils/expressionRangeFinder';
+
+/**
+ * Range covering exactly the first occurrence of `needle` in `source`
+ * (0-based line/character).
+ */
+const rangeOf = (source: string, needle: string): LspRange => {
+  const lines = source.split('\n');
+  for (let line = 0; line < lines.length; line++) {
+    const character = lines[line].indexOf(needle);
+    if (character !== -1) {
+      return {
+        start: { line, character },
+        end: { line, character: character + needle.length },
+      };
+    }
+  }
+  throw new Error(`substring not found in source: ${needle}`);
+};
+
+/**
+ * Range covering the LAST occurrence of `needle` in `source` — used to target a
+ * variable/parameter *reference* rather than its earlier declaration, which
+ * shares the same identifier text.
+ */
+const lastRangeOf = (source: string, needle: string): LspRange => {
+  const idx = source.lastIndexOf(needle);
+  if (idx === -1) {
+    throw new Error(`substring not found in source: ${needle}`);
+  }
+  const before = source.substring(0, idx);
+  const line = before.split('\n').length - 1;
+  const character = idx - (before.lastIndexOf('\n') + 1);
+  return {
+    start: { line, character },
+    end: { line, character: character + needle.length },
+  };
+};
+
+/**
+ * Parse `source`, locate the expression at `needle`, and infer its type — the
+ * exact path the Extract code actions take. Targets the first occurrence of
+ * `needle`; pass `range` explicitly for reference-vs-declaration disambiguation.
+ */
+const inferAt = (
+  source: string,
+  needle: string,
+  range: LspRange = rangeOf(source, needle),
+): string | null => {
+  const uri = 'file:///test/ExprTypeInfer.cls';
+  const context = parseForCodeActions(source, uri);
+  const found = findExpressionForCodeAction(context, range);
+  return inferTypeForCodeAction(context, found);
+};
+
+const inMethod = (body: string): string =>
+  [
+    'public class Sample {',
+    '  public void run() {',
+    `    ${body}`,
+    '  }',
+    '}',
+  ].join('\n');
+
+describe('inferTypeForCodeAction — literals', () => {
+  it('infers String for a string literal', () => {
+    expect(inferAt(inMethod("String s = 'hello';"), "'hello'")).toBe('String');
+  });
+
+  it('infers Integer for an integer literal', () => {
+    expect(inferAt(inMethod('Integer i = 42;'), '42')).toBe('Integer');
+  });
+
+  it('infers Long for a long literal', () => {
+    expect(inferAt(inMethod('Long n = 42L;'), '42L')).toBe('Long');
+  });
+
+  it('infers Decimal for a number literal', () => {
+    expect(inferAt(inMethod('Decimal d = 3.14;'), '3.14')).toBe('Decimal');
+  });
+
+  it('infers Boolean for a boolean literal', () => {
+    expect(inferAt(inMethod('Boolean b = true;'), 'true')).toBe('Boolean');
+  });
+});
+
+describe('inferTypeForCodeAction — composite expressions', () => {
+  it('promotes Integer * Integer to Integer', () => {
+    expect(inferAt(inMethod('Integer x = 2 * 3;'), '2 * 3')).toBe('Integer');
+  });
+
+  it('promotes Integer + Decimal to Decimal', () => {
+    expect(inferAt(inMethod('Decimal x = 1 + 2.0;'), '1 + 2.0')).toBe(
+      'Decimal',
+    );
+  });
+
+  it('treats String + Integer as String concatenation', () => {
+    expect(inferAt(inMethod("String x = 'n=' + 1;"), "'n=' + 1")).toBe(
+      'String',
+    );
+  });
+
+  it('resolves a comparison to Boolean', () => {
+    expect(inferAt(inMethod('Boolean b = 1 < 2;'), '1 < 2')).toBe('Boolean');
+  });
+
+  it('preserves the numeric type through parentheses', () => {
+    expect(inferAt(inMethod('Integer x = (2 + 3);'), '(2 + 3)')).toBe(
+      'Integer',
+    );
+  });
+});
+
+describe('inferTypeForCodeAction — new and cast', () => {
+  it('infers the constructed type for a new expression, casing preserved', () => {
+    expect(
+      inferAt(inMethod('Account a = new Account();'), 'new Account()'),
+    ).toBe('Account');
+  });
+
+  it('infers the target type for a cast, casing preserved', () => {
+    expect(
+      inferAt(
+        inMethod('Object raw = null; String s = (String) raw;'),
+        '(String) raw',
+      ),
+    ).toBe('String');
+  });
+});
+
+describe('inferTypeForCodeAction — same-file variable references', () => {
+  it('infers a local variable declared type, casing preserved', () => {
+    const source = inMethod(
+      'String greeting = null;\n    String other = greeting;',
+    );
+    // Target the reference (last `greeting`), not the earlier declaration.
+    expect(inferAt(source, 'greeting', lastRangeOf(source, 'greeting'))).toBe(
+      'String',
+    );
+  });
+
+  it('infers a parameter declared type', () => {
+    const source = [
+      'public class Sample {',
+      '  public void run(Account input) {',
+      '    Account local = input;',
+      '  }',
+      '}',
+    ].join('\n');
+    // Target the reference (last `input`), not the parameter declaration.
+    expect(inferAt(source, 'input', lastRangeOf(source, 'input'))).toBe(
+      'Account',
+    );
+  });
+});
+
+describe('inferTypeForCodeAction — same-file method-call return types', () => {
+  it('infers an unqualified method-call return type, casing preserved', () => {
+    const source = [
+      'public class Sample {',
+      '  public void run() {',
+      '    Account a = makeAccount();',
+      '  }',
+      '  private Account makeAccount() {',
+      '    return new Account();',
+      '  }',
+      '}',
+    ].join('\n');
+    expect(inferAt(source, 'makeAccount()')).toBe('Account');
+  });
+});
+
+describe('inferTypeForCodeAction — graceful degradation', () => {
+  it('returns null for a null context', () => {
+    expect(inferTypeForCodeAction(null, null)).toBeNull();
+  });
+
+  it('returns null when the type cannot be resolved (falls back to Object at the caller)', () => {
+    // A qualified/chained access is deferred to the cross-file seam (absent
+    // here) and yields null.
+    const source = inMethod('Object x = a.b.c;');
+    expect(inferAt(source, 'a.b.c')).toBeNull();
+  });
+
+  it('never throws on garbage input', () => {
+    const source = 'public class @@@ { void ( { %%% }';
+    expect(() => parseForCodeActions(source, 'file:///g.cls')).not.toThrow();
+  });
+});
+
+describe('inferTypeForCodeAction — cross-file seam', () => {
+  it('routes unresolved method names through the injected lookup', () => {
+    const uri = 'file:///test/Seam.cls';
+    const source = inMethod('Object x = external();');
+    const context = parseForCodeActions(source, uri);
+    const found = findExpressionForCodeAction(
+      context,
+      rangeOf(source, 'external()'),
+    );
+    const inferred = inferTypeForCodeAction(context, found, {
+      lookupCrossFileType: (name) => (name === 'external' ? 'MyResult' : null),
+    });
+    expect(inferred).toBe('MyResult');
+  });
+});

--- a/packages/apex-parser-ast/test/utils/expressionTypeInference.test.ts
+++ b/packages/apex-parser-ast/test/utils/expressionTypeInference.test.ts
@@ -184,6 +184,140 @@ describe('inferTypeForCodeAction — same-file method-call return types', () => 
   });
 });
 
+describe('inferTypeForCodeAction — scope-aware variable resolution', () => {
+  // Regression: a same-named local in a sibling method must NOT be picked. A
+  // flat file-wide first-match scan bound `x` in method `b` to the `Integer x`
+  // declared first in method `a`, emitting a wrong, non-compiling declaration.
+  it('resolves a shadowed local to the declaration in its own method', () => {
+    const source = [
+      'public class Sample {',
+      '  public void a() {',
+      '    Integer x = 1;',
+      '    Integer y = x;',
+      '  }',
+      '  public void b() {',
+      '    String x = null;',
+      '    String z = x;',
+      '  }',
+      '}',
+    ].join('\n');
+    // Target the reference on `String z = x;` (the last `x`), which lives in
+    // method b — it must resolve to String, not the Integer x in method a.
+    expect(inferAt(source, 'x', lastRangeOf(source, 'x'))).toBe('String');
+  });
+
+  it('resolves a class field when no local shadows it', () => {
+    const source = [
+      'public class Sample {',
+      '  private Account acct;',
+      '  public void run() {',
+      '    Account z = acct;',
+      '  }',
+      '}',
+    ].join('\n');
+    expect(inferAt(source, 'acct', lastRangeOf(source, 'acct'))).toBe(
+      'Account',
+    );
+  });
+
+  it('resolves a shadowed local inside a composite expression', () => {
+    // The composite path (arithmetic/ternary/...) delegates to the shared
+    // recursive resolver, whose own variable lookup is scope-unaware. Extracting
+    // `x + 1` in method `b` (where `x` is Integer) must not pick up the `String
+    // x` declared in method `a` and mis-infer String concatenation.
+    const source = [
+      'public class Sample {',
+      '  public void a() {',
+      '    String x = null;',
+      '  }',
+      '  public void b() {',
+      '    Integer x = 1;',
+      '    Integer y = x + 1;',
+      '  }',
+      '}',
+    ].join('\n');
+    expect(inferAt(source, 'x + 1')).toBe('Integer');
+  });
+
+  it('prefers an inner-block local over a same-named field', () => {
+    const source = [
+      'public class Sample {',
+      '  private Account value;',
+      '  public void run() {',
+      '    if (true) {',
+      '      String value = null;',
+      '      String captured = value;',
+      '    }',
+      '  }',
+      '}',
+    ].join('\n');
+    // The reference inside the if-block sees the local String `value`, not the
+    // Account field of the same name.
+    expect(inferAt(source, 'value', lastRangeOf(source, 'value'))).toBe(
+      'String',
+    );
+  });
+});
+
+describe('inferTypeForCodeAction — method overload disambiguation', () => {
+  // Regression: overloads were resolved by first-match-on-name, ignoring
+  // arguments — `describe(5)` bound to the zero-arg `String describe()`.
+  it('picks the overload matching the call arity', () => {
+    const source = [
+      'public class Sample {',
+      '  public String describe() {',
+      "    return 'hi';",
+      '  }',
+      '  public Integer describe(Integer n) {',
+      '    return n;',
+      '  }',
+      '  public void run() {',
+      '    Integer result = describe(5);',
+      '  }',
+      '}',
+    ].join('\n');
+    expect(inferAt(source, 'describe(5)')).toBe('Integer');
+  });
+
+  it('bails to null (safe Object fallback) when overloads are ambiguous by arity', () => {
+    // Two single-arg overloads with different return types — arity cannot
+    // disambiguate, so we must not guess.
+    const source = [
+      'public class Sample {',
+      '  public String f(Integer a) {',
+      "    return 'x';",
+      '  }',
+      '  public Integer f(String a) {',
+      '    return 1;',
+      '  }',
+      '  public void run() {',
+      '    Object o = f(5);',
+      '  }',
+      '}',
+    ].join('\n');
+    expect(inferAt(source, 'f(5)')).toBeNull();
+  });
+});
+
+describe('inferTypeForCodeAction — composite over user-defined type', () => {
+  // Regression: the composite path (ternary/arithmetic/comparison) delegated to
+  // the shared resolver, which lowercases user types — `Account` came back as
+  // `account`. Casing must be recovered from the same-file declarations.
+  it('preserves user-type casing through a ternary', () => {
+    const source = [
+      'public class Sample {',
+      '  public void run() {',
+      '    Boolean cond = true;',
+      '    Account left = new Account();',
+      '    Account right = new Account();',
+      '    Account picked = cond ? left : right;',
+      '  }',
+      '}',
+    ].join('\n');
+    expect(inferAt(source, 'cond ? left : right')).toBe('Account');
+  });
+});
+
 describe('inferTypeForCodeAction — graceful degradation', () => {
   it('returns null for a null context', () => {
     expect(inferTypeForCodeAction(null, null)).toBeNull();

--- a/packages/lsp-compliant-services/src/services/CodeActionProcessingService.ts
+++ b/packages/lsp-compliant-services/src/services/CodeActionProcessingService.ts
@@ -27,6 +27,7 @@ import {
   findExpressionForCodeAction,
   findConstantExtractionFromExpression,
   findMethodCallForCodeAction,
+  inferTypeForCodeAction,
   CodeActionParseContext,
   ConstantExtraction,
   ApexSymbol,
@@ -319,6 +320,17 @@ export class CodeActionProcessingService implements ICodeActionProcessor {
 
     const variableName = this.generateExtractName(text);
 
+    // Infer the declared type over the single parse's same-file symbol table
+    // (story 01.1). Falls back to `Object` when the type cannot be resolved
+    // (e.g. cross-file member access, which the cross-file seam handles later).
+    let inferredType: string | null = null;
+    try {
+      inferredType = inferTypeForCodeAction(context.parseContext, found);
+    } catch (error) {
+      this.logger.debug(() => `Extract type inference error: ${error}`);
+    }
+    const declaredType = inferredType ?? FALLBACK_TYPE;
+
     const variableAction = this.buildExtractVariableAction(
       context,
       text,
@@ -327,6 +339,7 @@ export class CodeActionProcessingService implements ICodeActionProcessor {
       exprText,
       variableName,
       exprRange,
+      declaredType,
     );
     if (variableAction) {
       actions.push(variableAction);
@@ -345,6 +358,7 @@ export class CodeActionProcessingService implements ICodeActionProcessor {
         exprText,
         variableName,
         exprRange,
+        declaredType,
       );
       if (constantAction) {
         actions.push(constantAction);
@@ -362,8 +376,8 @@ export class CodeActionProcessingService implements ICodeActionProcessor {
    *      the enclosing statement's line, and
    *   2. a replacement of the selected range with `<name>`.
    *
-   * Type inference is a separate story (01.1); until then the declared type
-   * falls back to `Object` and a trailing comment documents the limitation.
+   * `declaredType` is the inferred Apex type (story 01.1); it is `Object` when
+   * the type could not be resolved from same-file information.
    */
   private buildExtractVariableAction(
     context: CodeActionContext,
@@ -373,6 +387,7 @@ export class CodeActionProcessingService implements ICodeActionProcessor {
     exprText: string,
     variableName: string,
     exprRange: Range,
+    declaredType: string,
   ): CodeAction | null {
     const insertPosition = context.document.positionAt(statementStart);
     // Anchor the insertion at the very start of the statement's line so the new
@@ -382,7 +397,7 @@ export class CodeActionProcessingService implements ICodeActionProcessor {
       character: 0,
     };
 
-    const declaration = `${indent}Object ${variableName} = ${exprText}; // TODO: infer type (was Object)\n`;
+    const declaration = `${indent}${declaredType} ${variableName} = ${exprText};\n`;
 
     const insertEdit: TextEdit = {
       range: { start: lineStart, end: lineStart },
@@ -407,11 +422,13 @@ export class CodeActionProcessingService implements ICodeActionProcessor {
   /**
    * Build the Extract Constant WorkspaceEdit.
    *
-   * Inserts `<modifiers> Object <name> = <exprText>;` at class-body level,
-   * directly under the enclosing class declaration's opening brace, and replaces
-   * the selection with `<name>`. Top-level classes use `private static final`;
-   * inner classes use `private final` (Apex/Jorje disallows `static` on inner
-   * members). Returns `null` when the enclosing class body cannot be located.
+   * Inserts `<modifiers> <declaredType> <name> = <exprText>;` at class-body
+   * level, directly under the enclosing class declaration's opening brace, and
+   * replaces the selection with `<name>`. Top-level classes use `private static
+   * final`; inner classes use `private final` (Apex/Jorje disallows `static` on
+   * inner members). `declaredType` is the inferred Apex type (story 01.1),
+   * `Object` when it could not be resolved. Returns `null` when the enclosing
+   * class body cannot be located.
    */
   private buildExtractConstantAction(
     context: CodeActionContext,
@@ -419,14 +436,15 @@ export class CodeActionProcessingService implements ICodeActionProcessor {
     exprText: string,
     variableName: string,
     exprRange: Range,
+    declaredType: string,
   ): CodeAction | null {
     const modifiers = insertion.isInner
       ? 'private final'
       : 'private static final';
     const insertPosition = context.document.positionAt(insertion.insertOffset);
     const declaration =
-      `\n${insertion.indent}${modifiers} Object ${variableName} = ` +
-      `${exprText}; // TODO: infer type (was Object)`;
+      `\n${insertion.indent}${modifiers} ${declaredType} ${variableName} = ` +
+      `${exprText};`;
 
     const insertEdit: TextEdit = {
       range: { start: insertPosition, end: insertPosition },

--- a/packages/lsp-compliant-services/test/services/CodeActionProcessingService.test.ts
+++ b/packages/lsp-compliant-services/test/services/CodeActionProcessingService.test.ts
@@ -443,10 +443,52 @@ describe('CodeActionProcessingService', () => {
       const edits = action?.edit?.changes?.[uri];
       expect(edits).toHaveLength(2);
       // First edit inserts a declaration; second replaces the selection.
-      expect(edits?.[0].newText).toMatch(/Object v1 = 1 \+ 2;/);
+      // Type is inferred (story 01.1): `1 + 2` promotes to Integer.
+      expect(edits?.[0].newText).toMatch(/Integer v1 = 1 \+ 2;/);
       expect(edits?.[0].newText.endsWith('\n')).toBe(true);
       expect(edits?.[1].newText).toBe('v1');
       expect(edits?.[1].range).toEqual(params.range);
+    });
+
+    it('infers a constructed (new) type for Extract local variable', async () => {
+      // Story 01.1: `new Account()` -> Account, replacing the Object placeholder.
+      const source = [
+        'public class Extract {',
+        '  public void doWork() {',
+        '    Account a = new Account();',
+        '  }',
+        '}',
+      ].join('\n');
+      const { params } = setupDocument(source, 'new Account()');
+
+      const result = await service.processCodeAction(params);
+      const action = findAction(result, 'Extract local variable');
+
+      const edits = action?.edit?.changes?.[uri];
+      expect(edits?.[0].newText).toMatch(/Account v1 = new Account\(\);/);
+      // The old Object placeholder / TODO comment is gone.
+      expect(edits?.[0].newText).not.toMatch(/Object/);
+      expect(edits?.[0].newText).not.toMatch(/TODO/);
+    });
+
+    it('falls back to Object when the type cannot be inferred', async () => {
+      // Story 01.1: a chained/qualified access is deferred to the cross-file
+      // seam (absent in this same-file test) -> Object fallback, no TODO noise.
+      const source = [
+        'public class Extract {',
+        '  public void doWork() {',
+        '    Object x = foo.bar.baz;',
+        '  }',
+        '}',
+      ].join('\n');
+      const { params } = setupDocument(source, 'foo.bar.baz');
+
+      const result = await service.processCodeAction(params);
+      const action = findAction(result, 'Extract local variable');
+
+      const edits = action?.edit?.changes?.[uri];
+      expect(edits?.[0].newText).toMatch(/Object v1 = foo\.bar\.baz;/);
+      expect(edits?.[0].newText).not.toMatch(/TODO/);
     });
 
     /**
@@ -462,9 +504,9 @@ describe('CodeActionProcessingService', () => {
       const edits = action?.edit?.changes?.[uri];
       expect(edits).toHaveLength(2);
       const declaration = edits![0].newText;
-      const captured = declaration.match(
-        /Object v\d+ = ([\s\S]+?); \/\/ TODO/,
-      )?.[1];
+      // Declaration is `<indent><Type> v<n> = <expr>;\n`; capture <expr>.
+      // <Type> is the inferred Apex type (story 01.1), no longer always Object.
+      const captured = declaration.match(/^\s*\S+ v\d+ = ([\s\S]+?);\s*$/)?.[1];
       expect(captured).toBeDefined();
       expect(edits![1].newText).toBe('v1');
       const doc = TextDocument.create(uri, 'apex', 1, source);
@@ -565,8 +607,9 @@ describe('CodeActionProcessingService', () => {
       expect(constant?.kind).toBe(CodeActionKind.RefactorExtract);
       const edits = constant?.edit?.changes?.[uri];
       expect(edits).toHaveLength(2);
+      // Type is inferred (story 01.1): a string literal -> String.
       expect(edits?.[0].newText).toMatch(
-        /private static final Object v1 = 'hello';/,
+        /private static final String v1 = 'hello';/,
       );
       expect(edits?.[1].newText).toBe('v1');
     });
@@ -585,8 +628,9 @@ describe('CodeActionProcessingService', () => {
       const constant = findAction(result, 'Extract constant');
 
       expect(constant).toBeDefined();
+      // `-5` is a prefix-of-literal integer -> Integer (story 01.1).
       expect(constant?.edit?.changes?.[uri]?.[0].newText).toMatch(
-        /private static final Object v1 = -5;/,
+        /private static final Integer v1 = -5;/,
       );
     });
 
@@ -695,7 +739,8 @@ describe('CodeActionProcessingService', () => {
 
       expect(constant).toBeDefined();
       const newText = constant?.edit?.changes?.[uri]?.[0].newText ?? '';
-      expect(newText).toMatch(/private final Object v1 = 'hi';/);
+      // Type is inferred (story 01.1): a string literal -> String.
+      expect(newText).toMatch(/private final String v1 = 'hi';/);
       expect(newText).not.toMatch(/static/);
     });
 

--- a/packages/lsp-compliant-services/test/services/CodeActionProcessingService.test.ts
+++ b/packages/lsp-compliant-services/test/services/CodeActionProcessingService.test.ts
@@ -653,10 +653,12 @@ describe('CodeActionProcessingService', () => {
 
     /**
      * The extracted constant's leading indentation (the whitespace before the
-     * `private ... final` modifiers on the inserted line) must equal the class
-     * declaration's physical line indent plus one indent unit — NOT a value
-     * derived from the `class` keyword's column (which shifts with
-     * visibility/sharing modifiers). Returns that leading indent.
+     * `private ... final` modifiers on the inserted line) must match the
+     * existing member indentation — measured from the enclosing member's
+     * physical line indent, so it reflects the file's actual indent width
+     * (two spaces, four spaces, tabs, ...) rather than a fixed unit or the
+     * `class` keyword's column (which shifts with visibility/sharing
+     * modifiers). Returns that leading indent.
      */
     const constantIndentOf = (action: CodeAction | undefined): string => {
       expect(action).toBeDefined();
@@ -680,14 +682,15 @@ describe('CodeActionProcessingService', () => {
       const result = await service.processCodeAction(params);
       const constant = findAction(result, 'Extract constant');
 
-      // Top-level class at column 0 -> members indent exactly one unit.
+      // Members here are indented two spaces, so the constant matches at two.
       expect(constantIndentOf(constant)).toBe('  ');
     });
 
     it('indents the constant one level despite sharing/visibility modifiers', async () => {
       // Regression (W-23544057): indent was derived from the `class` keyword's
       // column, so `public with sharing class` produced ~18+ spaces of leading
-      // whitespace. The physical class-line indent is 0, so one unit is correct.
+      // whitespace. Measuring the sibling member's physical line indent (two
+      // spaces here) is correct regardless of the modifiers before `class`.
       const source = [
         'public with sharing class Extract {',
         '  public void doWork() {',
@@ -718,7 +721,26 @@ describe('CodeActionProcessingService', () => {
       const result = await service.processCodeAction(params);
       const constant = findAction(result, 'Extract constant');
 
-      // Inner class line is indented two spaces; member adds one more unit.
+      // The inner member (`    public void doWork()`) is indented four spaces,
+      // so the constant matches at four.
+      expect(constantIndentOf(constant)).toBe('    ');
+    });
+
+    it('matches four-space member indentation under a top-level class', async () => {
+      // Real-world Apex commonly indents members four spaces; the constant must
+      // line up with the members rather than assume a two-space unit.
+      const source = [
+        'public with sharing class Extract {',
+        '    public void doWork() {',
+        "        String greeting = 'hello';",
+        '    }',
+        '}',
+      ].join('\n');
+      const { params } = setupDocument(source, "'hello'");
+
+      const result = await service.processCodeAction(params);
+      const constant = findAction(result, 'Extract constant');
+
       expect(constantIndentOf(constant)).toBe('    ');
     });
 


### PR DESCRIPTION
### What does this PR do?

Replaces the `Object` placeholder in the Extract Variable / Extract Constant code actions with the **inferred Apex type** of the extracted expression (Jorje-parity story 01.1).

**Type inference** — new `inferExpressionType` in `apex-parser-ast`:
- Leaf cases resolved directly (casing preserved): literals (`String`/`Integer`/`Long`/`Decimal`/`Boolean`), `new T(...)` → `T`, casts `(T) x` → `T`, same-file variable/parameter/field references, and unqualified same-file method-call return types.
- Composite cases (arithmetic promotion, string concat, comparison → `Boolean`, ternary, unary, `instanceof`) delegate to the shared recursive resolver, normalized back to canonical Apex casing.
- Same-file only in this cut; cross-file resolution enters through an injected `lookupCrossFileType` seam. Never throws — resolution failures degrade to `null`, and the caller falls back to `Object` (no more `// TODO`).

**Wiring** — `CodeActionProcessingService` computes the inferred type and emits it in both the Extract Variable and Extract Constant declarations. Parse failures now log at `debug` in the LS caller (apex-parser-ast stays logger-free).

**Extract Constant indent fix** — the inserted constant now matches the file's actual member indentation (measured from the enclosing member's physical line indent) instead of a hardcoded two-space unit, which had under-indented it by two spaces in four-space files.

**Tests** — unit coverage for inference and indentation; e2e specs (`apex-extract-variable`, new `apex-extract-constant`) assert the inferred types (`Integer`, `String`, `Account`) and the four-space constant indent end-to-end through the editor. 4/4 e2e pass locally in web mode.

### What issues does this PR fix or reference?

@W-23389334@
