### PR TITLE
fix: pass custom JS heap to data owner worker via resourceLimits - W-23610333

### DIFF
--- a/packages/apex-ls/src/server/LCSAdapter.ts
+++ b/packages/apex-ls/src/server/LCSAdapter.ts
@@ -2650,16 +2650,26 @@ export class LCSAdapter {
         this.logger.alwaysLog(
           () => `[WorkerCoordinator] Worker script (node): ${workerScript}`,
         );
-        const workerLayerFactory = (role: string) =>
-          makeNodeWorkerLayer(workerScript, {
+        const workerLayerFactory = (role: string) => {
+          const { execArgv, maxOldGenerationSizeMb } = buildWorkerExecArgv({
+            role,
+          });
+          return makeNodeWorkerLayer(workerScript, {
             name: `apex-worker-${role}`,
-            execArgv: buildWorkerExecArgv({ role }).execArgv,
+            execArgv,
+            // `--max-old-space-size` is illegal as a worker execArgv flag, so
+            // the builder surfaces the heap limit here instead. Only roles in
+            // HEAP_LIMITED_ROLES (the data owner) receive a value.
+            ...(maxOldGenerationSizeMb !== undefined && {
+              resourceLimits: { maxOldGenerationSizeMb },
+            }),
             workerData: {
               role,
               compilationPoolSize,
               compilationConcurrency,
             },
           });
+        };
 
         topology = yield* Effect.provideService(
           initializeTopology({ ...config, workerLayerFactory }),

--- a/packages/apex-ls/src/server/WorkerCoordinator.ts
+++ b/packages/apex-ls/src/server/WorkerCoordinator.ts
@@ -87,6 +87,7 @@ export const makeNodeWorkerLayer = (
   workerOptions?: {
     name?: string;
     execArgv?: string[];
+    resourceLimits?: { maxOldGenerationSizeMb?: number };
     workerData?: unknown;
     transferList?: any[];
     stdout?: boolean;

--- a/packages/apex-ls/src/server/WorkerExecArgvBuilder.ts
+++ b/packages/apex-ls/src/server/WorkerExecArgvBuilder.ts
@@ -23,19 +23,37 @@ function isPassthroughFlag(flag: string): boolean {
 }
 
 /**
+ * Roles whose heap should track the user's `jsHeapSizeGB` setting.
+ *
+ * Only the data owner holds state that scales with workspace size (the full
+ * symbol graph), so it is the sole worker that inherits the custom heap limit.
+ * Enrichment (lspRequest) workers hold bounded per-request symbol subsets, the
+ * resource loader holds the fixed-size stdlib, and compilation sub-workers
+ * process one file at a time — none of them benefit from a larger heap, and
+ * applying it to every worker would over-commit system memory.
+ */
+const HEAP_LIMITED_ROLES = new Set<string>(['dataOwner']);
+
+/**
  * Collects role-specific profile output directories that need to be
  * created before the worker starts. The caller is responsible for
  * creating them (the builder is pure — no fs side effects).
+ *
+ * `maxOldGenerationSizeMb`, when present, must be passed to the Worker
+ * constructor via `resourceLimits` — NOT as a `--max-old-space-size` execArgv
+ * flag, which `worker_threads` rejects as an "invalid execArgv flag".
  */
 export interface BuildResult {
   readonly execArgv: string[];
   readonly profileDirs: string[];
+  readonly maxOldGenerationSizeMb?: number;
 }
 
 export function buildWorkerExecArgv(opts: WorkerExecArgvOptions): BuildResult {
   const parentArgv = opts.parentExecArgv ?? process.execArgv;
   const execArgv: string[] = [];
   const profileDirs: string[] = [];
+  let maxOldGenerationSizeMb: number | undefined;
 
   for (const arg of parentArgv) {
     if (isPassthroughFlag(arg)) {
@@ -65,10 +83,19 @@ export function buildWorkerExecArgv(opts: WorkerExecArgvOptions): BuildResult {
     }
 
     if (arg.startsWith('--max-old-space-size=')) {
-      execArgv.push(arg);
+      // `--max-old-space-size` is rejected by the Worker constructor as an
+      // invalid execArgv flag, so it must NOT be forwarded. Translate it into
+      // a resourceLimits value, and only for roles whose heap should scale
+      // with the workspace (see HEAP_LIMITED_ROLES).
+      if (HEAP_LIMITED_ROLES.has(opts.role)) {
+        const mb = Number(arg.slice('--max-old-space-size='.length));
+        if (Number.isFinite(mb) && mb > 0) {
+          maxOldGenerationSizeMb = mb;
+        }
+      }
       continue;
     }
   }
 
-  return { execArgv, profileDirs };
+  return { execArgv, profileDirs, maxOldGenerationSizeMb };
 }

--- a/packages/apex-ls/test/server/WorkerExecArgvBuilder.test.ts
+++ b/packages/apex-ls/test/server/WorkerExecArgvBuilder.test.ts
@@ -80,12 +80,61 @@ describe('buildWorkerExecArgv', () => {
     expect(execArgv).toEqual(['--inspect=0']);
   });
 
-  it('passes through --max-old-space-size', () => {
-    const { execArgv } = buildWorkerExecArgv({
+  // --max-old-space-size is NOT a legal worker_threads execArgv flag; the
+  // Worker constructor throws "invalid execArgv flags" on it. It must be
+  // surfaced as a resourceLimits.maxOldGenerationSizeMb value instead, and
+  // only for the data owner (the worker whose heap actually scales with the
+  // workspace symbol graph).
+  it('never passes --max-old-space-size through to execArgv', () => {
+    for (const role of [
+      'dataOwner',
+      'lspRequest',
+      'resourceLoader',
+      'compiler',
+    ] as const) {
+      const { execArgv } = buildWorkerExecArgv({
+        role,
+        parentExecArgv: ['--max-old-space-size=4096'],
+      });
+      expect(execArgv).not.toContain('--max-old-space-size=4096');
+      expect(execArgv).toEqual([]);
+    }
+  });
+
+  it('surfaces --max-old-space-size as maxOldGenerationSizeMb for dataOwner', () => {
+    const result = buildWorkerExecArgv({
       role: 'dataOwner',
-      parentExecArgv: ['--max-old-space-size=4096'],
+      parentExecArgv: ['--max-old-space-size=12288'],
     });
-    expect(execArgv).toEqual(['--max-old-space-size=4096']);
+    expect(result.maxOldGenerationSizeMb).toBe(12288);
+    expect(result.execArgv).toEqual([]);
+  });
+
+  it('omits maxOldGenerationSizeMb for non-dataOwner roles', () => {
+    for (const role of ['lspRequest', 'resourceLoader', 'compiler'] as const) {
+      const result = buildWorkerExecArgv({
+        role,
+        parentExecArgv: ['--max-old-space-size=12288'],
+      });
+      expect(result.maxOldGenerationSizeMb).toBeUndefined();
+    }
+  });
+
+  it('leaves maxOldGenerationSizeMb undefined when no heap flag is present', () => {
+    const result = buildWorkerExecArgv({
+      role: 'dataOwner',
+      parentExecArgv: ['--enable-source-maps'],
+    });
+    expect(result.maxOldGenerationSizeMb).toBeUndefined();
+  });
+
+  it('ignores a malformed --max-old-space-size value', () => {
+    const result = buildWorkerExecArgv({
+      role: 'dataOwner',
+      parentExecArgv: ['--max-old-space-size=not-a-number'],
+    });
+    expect(result.maxOldGenerationSizeMb).toBeUndefined();
+    expect(result.execArgv).toEqual([]);
   });
 
   it('passes through --enable-source-maps and --nolazy', () => {
@@ -98,7 +147,7 @@ describe('buildWorkerExecArgv', () => {
 
   it('handles a full combination of flags', () => {
     const result = buildWorkerExecArgv({
-      role: 'resourceLoader',
+      role: 'dataOwner',
       parentExecArgv: [
         '--nolazy',
         '--inspect=6009',
@@ -108,15 +157,17 @@ describe('buildWorkerExecArgv', () => {
         '--max-old-space-size=2048',
       ],
     });
+    // --max-old-space-size is stripped from execArgv (illegal for workers)
+    // and surfaced separately as a resourceLimits value.
     expect(result.execArgv).toEqual([
       '--nolazy',
       '--inspect=0',
       '--cpu-prof',
-      '--cpu-prof-dir=/tmp/p/resourceLoader',
+      '--cpu-prof-dir=/tmp/p/dataOwner',
       '--enable-source-maps',
-      '--max-old-space-size=2048',
     ]);
-    expect(result.profileDirs).toEqual(['/tmp/p/resourceLoader']);
+    expect(result.maxOldGenerationSizeMb).toBe(2048);
+    expect(result.profileDirs).toEqual(['/tmp/p/dataOwner']);
   });
 
   it('defaults to process.execArgv when parentExecArgv is not provided', () => {


### PR DESCRIPTION
### What does this PR do?

Fixes the Apex Language Server failing to start whenever a user sets a custom JS heap size (`apex.environment.jsHeapSizeGB`).

**Root cause:** the extension adds `--max-old-space-size=<MB>` to the main server process, and the worker exec-argv builder copied that flag into every worker's `execArgv`. But `--max-old-space-size` is **not** a legal `worker_threads` execArgv flag — `new Worker()` throws `Error: Initiated Worker with invalid execArgv flags`. The first worker spawn aborted topology initialization, taking down the entire worker pool and the server.

**Fix:** stop forwarding `--max-old-space-size` into worker `execArgv`. Parse the MB value and pass it through the Worker constructor's `resourceLimits.maxOldGenerationSizeMb` instead — the correct mechanism for a worker's heap. The heap limit is scoped to the **data owner worker only** (`HEAP_LIMITED_ROLES`), the sole worker whose heap scales with workspace size (it holds the full symbol graph). Enrichment, resource loader, and compilation workers keep the default heap, avoiding a multi-worker memory over-commit.

Verified locally that `execArgv: ['--max-old-space-size=N']` is rejected by the Worker constructor while `resourceLimits: { maxOldGenerationSizeMb: N }` is accepted (data owner comes up at ~12 GB with the reported `12288` value; other roles stay at the ~4 GB default).

### What issues does this PR fix or reference?

#7910, @W-23610333@

### Functionality Before

Setting `apex.environment.jsHeapSizeGB` to any non-zero value crashed the language server on startup:

```
cause="Error: Initiated Worker with invalid execArgv flags: --max-old-space-size=12288
    at new Worker (node:internal/worker:225:13)"
```

### Functionality After

The language server starts normally with a custom heap size. The data owner worker receives the configured heap; other workers keep the default.
