### PR TITLE
ci: point nightly at github-workflows fix branch to test release fix - W-23628608

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,9 @@ permissions:
 
 jobs:
   nightly-release:
-    uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-extensions.yml@main
+    # TEMP: point at fix branch to test resolve-changed-extensions fix (salesforcecli/github-workflows#165).
+    # Revert to @main once that PR merges.
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-extensions.yml@fix/vscode-publish-resolve-changed-extensions
     with:
       branch: ${{ github.event.inputs.branch || 'main' }}
       # Use 'changed' to automatically detect extensions with changes since last release


### PR DESCRIPTION
## What does this PR do?

Temporarily points the **Nightly Release** job at the shared-workflows fix branch so we can verify the fix that restores GitHub release creation for nightly builds.

- [nightly.yml](.github/workflows/nightly.yml): `vscode-publish-extensions.yml@main` → `@fix/vscode-publish-resolve-changed-extensions`

### Background

Nightly builds have created git tags daily but produced **no GitHub release** since `v0.9.19-nightly.20260714` — the first nightly after this repo switched its nightly job to `extensions: 'changed'`. Root cause is in the shared reusable workflow: `create-github-releases` (and the two `slack-notify` jobs) consumed the raw `inputs.extensions` value (`"changed"`) instead of the resolved `determine-changes.outputs.selected-extensions`, so it looked for `packages/changed/package.json`, skipped, and still reported success. Fix: salesforcecli/github-workflows#165.

### How to test

Because `nightly.yml` runs only on `schedule` / `workflow_dispatch` (not on PRs), the reusable-workflow ref on this branch is exercised by dispatching the workflow **from this branch**:

```
gh workflow run nightly.yml --repo forcedotcom/apex-language-support --ref chore/test-nightly-publish-fix -f dry-run=true
```

- `dry-run=true` first to confirm the release job now resolves `changed` → `apex-lsp-vscode-extension` and would create the release (no tag/release side effects).
- Then a live dispatch (`dry-run=false`) to confirm an actual GitHub release is produced.

### ⚠️ Temporary — do not merge as-is

The reusable-workflow ref must be reverted to `@main` once salesforcecli/github-workflows#165 merges. This PR exists to validate the fix from a consuming repo.

### What issues does this PR fix or reference?

@W-23628608@