### PR TITLE
test: restore VS Code Web hover locator - W-21360368

### DIFF
--- a/e2e-tests/pages/HoverPage.ts
+++ b/e2e-tests/pages/HoverPage.ts
@@ -33,15 +33,25 @@ export class HoverPage extends BasePage {
 
   constructor(page: Page) {
     super(page);
-    // Monaco retains hidden hover widgets for inactive editors. Scope all
-    // reads to the visible editor in the active group so first() cannot bind to
-    // a stale diagnostic or semantic hover from another editor instance.
-    this.hoverWidget = page.locator(
-      '.editor-group-container.active .monaco-editor:visible .monaco-hover:visible',
-    );
-    this.hoverContent = this.hoverWidget.locator(
-      '.monaco-hover-content, .hover-contents',
-    );
+    // VS Code Web renders hover as a role="tooltip" overlay that lives OUTSIDE
+    // the .monaco-editor element, while desktop Monaco renders it as an in-editor
+    // .monaco-hover. Match both. getByRole('tooltip') excludes hidden nodes by
+    // default, and :visible scopes the Monaco path, so a stale hidden hover from
+    // an inactive editor cannot bind first.
+    this.hoverWidget = page
+      .getByRole('tooltip')
+      .or(
+        page.locator(
+          '.editor-group-container.active .monaco-editor .monaco-hover:visible',
+        ),
+      );
+    this.hoverContent = page
+      .getByRole('tooltip')
+      .or(
+        page.locator(
+          '.monaco-hover:visible .monaco-hover-content, .monaco-hover:visible .hover-contents',
+        ),
+      );
     this.defaultTimeout = this.isDesktopMode ? 10000 : 5000;
   }
 
@@ -137,17 +147,22 @@ export class HoverPage extends BasePage {
       // Fallback: use page.evaluate to find tooltip in DOM (handles shadow DOM, etc.)
       content =
         (await this.page.evaluate(() => {
-          const editors = Array.from(
+          const isVisible = (node: Element) =>
+            (node as HTMLElement).offsetParent !== null;
+          // VS Code Web hover overlay: role="tooltip", rendered outside the editor.
+          const tooltip = Array.from(
+            document.querySelectorAll('[role="tooltip"]'),
+          ).find(isVisible);
+          if (tooltip) return (tooltip as HTMLElement).innerText;
+          // Desktop Monaco: in-editor .monaco-hover on the active editor.
+          const activeEditor = Array.from(
             document.querySelectorAll(
               '.editor-group-container.active .monaco-editor',
             ),
-          );
-          const activeEditor = editors.find(
-            (editor) => (editor as HTMLElement).offsetParent !== null,
-          );
+          ).find(isVisible);
           const el = Array.from(
             activeEditor?.querySelectorAll('.monaco-hover') ?? [],
-          ).find((hover) => (hover as HTMLElement).offsetParent !== null);
+          ).find(isVisible);
           return el ? (el as HTMLElement).innerText : '';
         })) || '';
       return content;

--- a/e2e-tests/tests/apex-hover.spec.ts
+++ b/e2e-tests/tests/apex-hover.spec.ts
@@ -196,18 +196,17 @@ test.describe('Apex Hover Functionality', () => {
    * Test: Multiple hovers can be triggered sequentially.
    */
   test('should handle multiple sequential hovers', async ({ hoverHelper }) => {
-    await hoverHelper.hoverOnWord('ApexClassExample');
-    const content1 = await hoverHelper.getHoverContent();
+    // Re-issue each hover until it resolves: a single request can fire before
+    // the web worker pool is warm and return null, which never self-recovers.
+    const content1 = await hoverHelper.hoverOnWordWithRetry('ApexClassExample');
     expect(content1).toContain('ApexClassExample');
 
     await hoverHelper.dismissHover();
-    await hoverHelper.hoverOnWord('Configuration');
-    const content2 = await hoverHelper.getHoverContent();
+    const content2 = await hoverHelper.hoverOnWordWithRetry('Configuration');
     expect(content2).toContain('Configuration');
 
     await hoverHelper.dismissHover();
-    await hoverHelper.hoverOnWord('StatusType');
-    const content3 = await hoverHelper.getHoverContent();
+    const content3 = await hoverHelper.hoverOnWordWithRetry('StatusType');
     expect(content3).toContain('StatusType');
   });
 
@@ -230,8 +229,7 @@ test.describe('Apex Hover Functionality', () => {
    * Test: Hover provides content (not empty).
    */
   test('should provide non-empty hover content', async ({ hoverHelper }) => {
-    await hoverHelper.hoverOnWord('ApexClassExample');
-    const content = await hoverHelper.getHoverContent();
+    const content = await hoverHelper.hoverOnWordWithRetry('ApexClassExample');
     expect(content.length).toBeGreaterThan(0);
     expect(content.trim()).not.toBe('');
     expect(content).toContain('ApexClassExample');
@@ -241,8 +239,10 @@ test.describe('Apex Hover Functionality', () => {
    * Test: Hover on private method shows method information.
    */
   test('should show hover for private method', async ({ hoverHelper }) => {
-    await hoverHelper.hoverOnWord('validateAccounts');
-    const content = await hoverHelper.getHoverContent();
+    const content = await hoverHelper.hoverOnWordWithRetry(
+      'validateAccounts',
+      'validateAccounts',
+    );
     expect(content).toContain('void');
     expect(content).toContain('validateAccounts');
   });


### PR DESCRIPTION
### What does this PR do?

Fixes the `apex-hover.spec.ts (Web)` E2E job on the #616 branch, which fails on every run (empty hover content → retries → 20-min timeout → cancelled), while goto-definition passes.

**Root cause:** the hover page-object locator refactor scoped all hover reads to `.monaco-editor .monaco-hover`, which only exists in **desktop** Monaco. VS Code **Web** renders hover as a `role="tooltip"` overlay that lives *outside* the editor element, so `getHoverContent()` read back empty for every web hover. The LSP itself is healthy — goto-definition (which reads the editor, not a tooltip) passes on the same runs.

**Fix:** restore the `getByRole('tooltip')` web path (as on `main`) alongside the active-editor `.monaco-hover:visible` desktop path, and mirror the same dual lookup in the `page.evaluate` DOM fallback. The branch's anti-stale-widget intent is preserved: `getByRole('tooltip')` excludes hidden nodes and `:visible` scopes the Monaco path.

This targets the `feature/W-21360368-sobject-discovery` branch (PR #616), not `main`.

### What issues does this PR fix or reference?

@W-21360368@