### PR TITLE
fix: pin runtimePlatform in settings merge + guard blob-URL worker resolution - W-23851445

### DIFF
--- a/packages/apex-ls/src/server/LCSAdapter.ts
+++ b/packages/apex-ls/src/server/LCSAdapter.ts
@@ -2646,11 +2646,13 @@ export class LCSAdapter {
         mediatorModule,
         resourceLoaderModule,
         execArgvModule,
+        workerUrlModule,
       ] = yield* Effect.all([
         Effect.promise(() => import('./WorkerCoordinator')),
         Effect.promise(() => import('./CoordinatorAssistanceMediator')),
         Effect.promise(() => import('./ResourceLoaderProxy')),
         Effect.promise(() => import('./WorkerExecArgvBuilder')),
+        Effect.promise(() => import('./WebWorkerUrlResolver')),
       ]);
 
       const {
@@ -2667,6 +2669,7 @@ export class LCSAdapter {
       const { CoordinatorAssistanceMediator } = mediatorModule;
       const { ResourceLoaderProxy } = resourceLoaderModule;
       const { buildWorkerExecArgv } = execArgvModule;
+      const { resolveWebWorkerUrl } = workerUrlModule;
 
       const { Scope } = yield* Effect.promise(() => import('effect'));
 
@@ -2811,19 +2814,12 @@ export class LCSAdapter {
         // the client-injected absolute worker URL, then a file:// placeholder.
         // The browser layer factory re-wraps fetched scripts in SAME-ORIGIN
         // blob regardless, so the sub-worker always shares the parent's origin.
-        const resolveWorkerUrl = (fileName: string, base: string) =>
-          new URL(`./${fileName}`, base).href;
-        const rawHref = (globalThis as any).location?.href;
-        const workerUrl =
-          typeof rawHref === 'string' && !rawHref.startsWith('blob:')
-            ? resolveWorkerUrl('worker.platform.web.js', rawHref)
-            : // `||` (not `??`): an empty string is as unusable a base as
-              // undefined, so fall through to the placeholder in both cases.
-              this.workerPlatformWebUrl ||
-              resolveWorkerUrl(
-                'worker.platform.web.js',
-                'file:///server.web.js',
-              );
+        // Logic lives in `resolveWebWorkerUrl` (pure, unit-tested for the
+        // blob-URL regression).
+        const workerUrl = resolveWebWorkerUrl({
+          locationHref: (globalThis as any).location?.href,
+          injectedWorkerUrl: this.workerPlatformWebUrl,
+        });
         this.logger.alwaysLog(
           () => `[WorkerCoordinator] Worker script (browser): ${workerUrl}`,
         );

--- a/packages/apex-ls/src/server/WebWorkerUrlResolver.ts
+++ b/packages/apex-ls/src/server/WebWorkerUrlResolver.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Default placeholder base used when neither the parent bundle origin nor a
+ * client-injected worker URL is usable. It is a syntactically valid absolute
+ * URL so `new URL(relative, base)` never throws; the browser layer factory
+ * re-wraps the fetched script in a same-origin blob anyway, so the concrete
+ * host here does not matter for correctness.
+ */
+export const PLACEHOLDER_WORKER_BASE = 'file:///server.web.js';
+
+/** Name of the web worker entry script bundled alongside the server. */
+export const WEB_WORKER_SCRIPT = 'worker.platform.web.js';
+
+export interface ResolveWebWorkerUrlInput {
+  /**
+   * `globalThis.location?.href` of the parent server bundle. Used as the base
+   * for same-origin worker resolution when it is a usable base.
+   */
+  readonly locationHref?: unknown;
+  /**
+   * Absolute worker URL injected by the client (VS Code Web passes the
+   * extension-relative URI). Preferred fallback when `locationHref` is unusable.
+   */
+  readonly injectedWorkerUrl?: string;
+  /** Worker script file name. Defaults to {@link WEB_WORKER_SCRIPT}. */
+  readonly fileName?: string;
+}
+
+/**
+ * Resolve the absolute URL of the web worker entry script.
+ *
+ * Resolution order:
+ *  1. `locationHref` as the base — same-origin, no CORS — but ONLY when it is a
+ *     usable base. VS Code Web serves the server bundle from a `blob:` URL,
+ *     which is NOT a valid base for `new URL(relative, base)` and would throw,
+ *     aborting worker-topology init and silently dropping the whole pool
+ *     (hover/definition fall back to the coordinator-local path; references —
+ *     an empty stub there — return nothing). A `blob:` (or non-string/empty)
+ *     href is therefore treated as unusable.
+ *  2. The client-injected absolute worker URL.
+ *  3. A `file://` placeholder base — always a valid base, so this function
+ *     never throws.
+ *
+ * This is the pure core of the browser branch of
+ * `LCSAdapter.startWorkerTopologyIfEnabled`, extracted so the blob-URL
+ * regression can be unit-tested without standing up an Effect pipeline.
+ */
+export function resolveWebWorkerUrl(input: ResolveWebWorkerUrlInput): string {
+  const fileName = input.fileName ?? WEB_WORKER_SCRIPT;
+  const build = (base: string) => new URL(`./${fileName}`, base).href;
+
+  const href = input.locationHref;
+  if (
+    typeof href === 'string' &&
+    href.length > 0 &&
+    !href.startsWith('blob:')
+  ) {
+    return build(href);
+  }
+
+  // `||` (not `??`): an empty string is as unusable a base as undefined, so
+  // fall through to the placeholder in both cases.
+  return input.injectedWorkerUrl || build(PLACEHOLDER_WORKER_BASE);
+}

--- a/packages/apex-ls/test/server/WebWorkerUrlResolver.test.ts
+++ b/packages/apex-ls/test/server/WebWorkerUrlResolver.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  PLACEHOLDER_WORKER_BASE,
+  resolveWebWorkerUrl,
+  WEB_WORKER_SCRIPT,
+} from '../../src/server/WebWorkerUrlResolver';
+
+describe('resolveWebWorkerUrl', () => {
+  const INJECTED =
+    'https://cdn.example.com/ext/apex/dist/worker.platform.web.js';
+  const BLOB_UNUSABLE = 'blob:https://cdn.example.com/deadbeef';
+
+  describe('usable location.href base', () => {
+    it('resolves same-origin relative to an https bundle href', () => {
+      const url = resolveWebWorkerUrl({
+        locationHref: 'https://cdn.example.com/ext/apex/dist/server.web.js',
+        injectedWorkerUrl: INJECTED,
+      });
+      expect(url).toBe(
+        `https://cdn.example.com/ext/apex/dist/${WEB_WORKER_SCRIPT}`,
+      );
+    });
+
+    it('prefers the bundle origin over the injected URL when href is usable', () => {
+      const url = resolveWebWorkerUrl({
+        locationHref: 'https://a.example.com/dist/server.web.js',
+        injectedWorkerUrl: 'https://b.example.com/other/worker.platform.web.js',
+      });
+      expect(url).toBe(`https://a.example.com/dist/${WEB_WORKER_SCRIPT}`);
+    });
+  });
+
+  describe('blob: base regression (VS Code Web)', () => {
+    // The original defect: VS Code Web serves the server bundle from a `blob:`
+    // URL. `new URL('./worker.platform.web.js', blobHref)` throws
+    // "Failed to construct 'URL': Invalid URL", which aborted worker-topology
+    // init and dropped the entire pool. These guard that the resolver never
+    // throws on a blob base and falls back correctly.
+    const BLOB_HREF =
+      'blob:https://cdn.web-ide-qa.platform.salesforce.com/8f0a-abcd';
+
+    it('does NOT throw on a blob: href', () => {
+      expect(() =>
+        resolveWebWorkerUrl({
+          locationHref: BLOB_HREF,
+          injectedWorkerUrl: INJECTED,
+        }),
+      ).not.toThrow();
+    });
+
+    it('falls back to the injected worker URL when href is a blob: URL', () => {
+      const url = resolveWebWorkerUrl({
+        locationHref: BLOB_HREF,
+        injectedWorkerUrl: INJECTED,
+      });
+      expect(url).toBe(INJECTED);
+    });
+
+    it('documents that the pre-fix expression threw on a blob: base', () => {
+      // Proves the regression is real: building directly off the blob base is
+      // exactly what the old inline code did and what the resolver now avoids.
+      expect(() => new URL(`./${WEB_WORKER_SCRIPT}`, BLOB_HREF).href).toThrow();
+    });
+  });
+
+  describe('placeholder fallback', () => {
+    it('uses the file:// placeholder when href is a blob and no URL is injected', () => {
+      const url = resolveWebWorkerUrl({ locationHref: BLOB_UNUSABLE });
+      expect(url).toBe(`file:///${WEB_WORKER_SCRIPT}`);
+      expect(url.startsWith('file://')).toBe(true);
+    });
+
+    it('treats an empty-string href as unusable and falls back to injected URL', () => {
+      const url = resolveWebWorkerUrl({
+        locationHref: '',
+        injectedWorkerUrl: INJECTED,
+      });
+      expect(url).toBe(INJECTED);
+    });
+
+    it('treats a non-string href as unusable and falls back to injected URL', () => {
+      const url = resolveWebWorkerUrl({
+        locationHref: undefined,
+        injectedWorkerUrl: INJECTED,
+      });
+      expect(url).toBe(INJECTED);
+    });
+
+    it('treats an empty-string injected URL as unusable and falls back to placeholder', () => {
+      // `||` (not `??`) semantics: empty string must fall through.
+      const url = resolveWebWorkerUrl({
+        locationHref: undefined,
+        injectedWorkerUrl: '',
+      });
+      expect(url).toBe(`file:///${WEB_WORKER_SCRIPT}`);
+    });
+
+    it('never throws even with no inputs at all', () => {
+      expect(() => resolveWebWorkerUrl({})).not.toThrow();
+      expect(resolveWebWorkerUrl({})).toBe(`file:///${WEB_WORKER_SCRIPT}`);
+    });
+
+    it('exposes a syntactically valid placeholder base', () => {
+      expect(() => new URL(PLACEHOLDER_WORKER_BASE)).not.toThrow();
+    });
+  });
+
+  describe('custom fileName', () => {
+    it('honors a custom worker script file name', () => {
+      const url = resolveWebWorkerUrl({
+        locationHref: 'https://cdn.example.com/dist/server.web.js',
+        fileName: 'other.worker.js',
+      });
+      expect(url).toBe('https://cdn.example.com/dist/other.worker.js');
+    });
+  });
+});

--- a/packages/apex-ls/tsconfig.node.json
+++ b/packages/apex-ls/tsconfig.node.json
@@ -17,6 +17,7 @@
     "src/server/CoordinatorPrimaryAssistanceHandler.ts",
     "src/server/ResourceLoaderProxy.ts",
     "src/server/WorkerExecArgvBuilder.ts",
+    "src/server/WebWorkerUrlResolver.ts",
     "src/server/WorkspaceBatchHandler.ts",
     "src/server/traceContextInjection.ts",
     "src/server/coordinatorTracing.ts",

--- a/packages/apex-lsp-shared/src/settings/ApexSettingsUtilities.ts
+++ b/packages/apex-lsp-shared/src/settings/ApexSettingsUtilities.ts
@@ -353,8 +353,14 @@ export function mergeWithDefaults(
       environment: (() => {
         const env = {
           ...baseApex.environment,
-          runtimePlatform: environment,
           ...userSettings.apex?.environment,
+          // `runtimePlatform` is derived from where the server physically runs,
+          // not a user preference. It MUST win over any value carried in the
+          // incoming settings — otherwise a client that mis-detects its host
+          // (e.g. a web bundle sending `desktop`) silently downgrades the
+          // server's own correct detection. Assigned AFTER the spread so the
+          // authoritative value cannot be clobbered.
+          runtimePlatform: environment,
         };
         // VSCode returns 0 for an unset numeric field with no schema default.
         // Treat 0 (and null) as "not configured" — keep jsHeapSizeGB undefined.
@@ -486,6 +492,11 @@ export function mergeWithExisting(
         const env = {
           ...existingSettings.apex.environment,
           ...partialSettings.apex?.environment,
+          // Preserve the already-detected `runtimePlatform`. It reflects where
+          // the server actually runs and is fixed for the process lifetime, so
+          // an incoming config sync (which may carry the client's own, possibly
+          // wrong, detection) must never flip it. Re-assigned AFTER the spread.
+          runtimePlatform: existingSettings.apex.environment.runtimePlatform,
         };
         if (!env.jsHeapSizeGB) {
           env.jsHeapSizeGB = undefined;

--- a/packages/apex-lsp-shared/test/settings/ApexLanguageServerSettings.test.ts
+++ b/packages/apex-lsp-shared/test/settings/ApexLanguageServerSettings.test.ts
@@ -374,6 +374,54 @@ describe('ApexLanguageServerSettings Validation', () => {
         true,
       );
     });
+
+    // Regression: a client that mis-detects its host (e.g. a web bundle that
+    // sends `runtimePlatform: 'desktop'`) must not override the server's own
+    // authoritative environment detection. The `environment` argument is
+    // derived from where the server physically runs and always wins.
+    it('should NOT let user-supplied runtimePlatform override the environment arg (web)', () => {
+      const partialConfig = {
+        apex: {
+          environment: {
+            runtimePlatform: 'desktop',
+          },
+        },
+      } as unknown as Partial<ApexLanguageServerSettings>;
+
+      const result = mergeWithDefaults(partialConfig, 'web');
+
+      expect(result.apex.environment.runtimePlatform).toBe('web');
+    });
+
+    it('should NOT let user-supplied runtimePlatform override the environment arg (desktop)', () => {
+      const partialConfig = {
+        apex: {
+          environment: {
+            runtimePlatform: 'web',
+          },
+        },
+      } as unknown as Partial<ApexLanguageServerSettings>;
+
+      const result = mergeWithDefaults(partialConfig, 'desktop');
+
+      expect(result.apex.environment.runtimePlatform).toBe('desktop');
+    });
+
+    it('should still apply other user-supplied environment fields while pinning runtimePlatform', () => {
+      const partialConfig = {
+        apex: {
+          environment: {
+            runtimePlatform: 'desktop',
+            serverMode: 'development',
+          },
+        },
+      } as unknown as Partial<ApexLanguageServerSettings>;
+
+      const result = mergeWithDefaults(partialConfig, 'web');
+
+      expect(result.apex.environment.runtimePlatform).toBe('web');
+      expect(result.apex.environment.serverMode).toBe('development');
+    });
   });
 
   describe('mergeWithExisting', () => {
@@ -529,6 +577,63 @@ describe('ApexLanguageServerSettings Validation', () => {
       const result = mergeWithExisting(existingSettings, partialUpdate);
 
       expect(result.apex.environment.jsHeapSizeGB).toBe(8); // Updated
+    });
+
+    // Regression: a `didChangeConfiguration` sync from the client can carry the
+    // client's own `runtimePlatform`. On web, the client may report `desktop`,
+    // which previously clobbered the server's already-detected `web` platform
+    // (the "Platform: web → desktop" log line). The existing platform reflects
+    // where the server actually runs and is fixed for the process lifetime, so
+    // an incoming sync must never flip it.
+    it('should NOT let a config sync flip the existing runtimePlatform (web → desktop)', () => {
+      const existingSettings = mergeWithDefaults({}, 'web');
+      expect(existingSettings.apex.environment.runtimePlatform).toBe('web');
+
+      const partialUpdate = {
+        apex: {
+          environment: {
+            runtimePlatform: 'desktop',
+          },
+        },
+      } as unknown as Partial<ApexLanguageServerSettings>;
+
+      const result = mergeWithExisting(existingSettings, partialUpdate);
+
+      expect(result.apex.environment.runtimePlatform).toBe('web');
+    });
+
+    it('should NOT let a config sync flip the existing runtimePlatform (desktop → web)', () => {
+      const existingSettings = mergeWithDefaults({}, 'desktop');
+
+      const partialUpdate = {
+        apex: {
+          environment: {
+            runtimePlatform: 'web',
+          },
+        },
+      } as unknown as Partial<ApexLanguageServerSettings>;
+
+      const result = mergeWithExisting(existingSettings, partialUpdate);
+
+      expect(result.apex.environment.runtimePlatform).toBe('desktop');
+    });
+
+    it('should apply other synced environment fields while pinning runtimePlatform', () => {
+      const existingSettings = mergeWithDefaults({}, 'web');
+
+      const partialUpdate = {
+        apex: {
+          environment: {
+            runtimePlatform: 'desktop',
+            serverMode: 'development',
+          },
+        },
+      } as unknown as Partial<ApexLanguageServerSettings>;
+
+      const result = mergeWithExisting(existingSettings, partialUpdate);
+
+      expect(result.apex.environment.runtimePlatform).toBe('web');
+      expect(result.apex.environment.serverMode).toBe('development');
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

Two web-platform correctness fixes surfaced by 0.7.0 cbweb (VS Code Web) startup logs.

**1. Merge-order bug (`Platform: web → desktop`)**

In `ApexSettingsUtilities.ts`, both `mergeWithDefaults` and `mergeWithExisting` spread the incoming settings *after* the authoritative `runtimePlatform`, so a client that mis-detects its host (a web bundle sending `runtimePlatform: 'desktop'`) clobbered the server's own correct `web` detection on every config sync. `runtimePlatform` reflects where the server physically runs and is fixed for the process lifetime, so it is now re-assigned *after* the spread and can no longer be flipped.

**2. Blob-URL worker resolution + regression coverage**

Extracted the browser worker-URL resolution out of `LCSAdapter` into a pure, unit-tested `resolveWebWorkerUrl` helper (`WebWorkerUrlResolver.ts`). VS Code Web serves the server bundle from a `blob:` URL, which is not a valid base for `new URL(relative, base)` and threw `Failed to construct 'URL': Invalid URL` — aborting worker-topology init and silently dropping the whole pool (the 0.7.0 crash). The guard itself landed in #553; this adds the regression coverage that was missing and makes the logic testable without standing up an Effect pipeline. Refactor is behavior-preserving.

**Verification**
- Web `apex-goto-definition` E2E: 20/20 (topology comes up through the extracted helper)
- 12 `resolveWebWorkerUrl` unit tests (blob base never throws, fallback order, `file://` placeholder)
- 6 new settings merge-order tests (platform cannot be flipped by a config sync)
- Full pre-commit suite: 5323 passed, 0 failed

### What issues does this PR fix or reference?

@W-23851445@
