### PR TITLE
fix(ci): use shared publish workflow branch - W-23832274

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -102,6 +102,6 @@ jobs:
       exclude-web-vsix: 'true'
       extensions-root: 'packages'
       vsix-artifact-name: 'vsix-packages'
-      required-ci-checks: 'CI Complete, Package / Package, Test Quality (ubuntu-latest, lts/*)'
+      required-ci-checks: '["CI Complete","Package / Package","Test Quality (ubuntu-latest, lts/*)"]'
       dry-run: ${{ inputs.dry-run }}
     secrets: inherit

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -88,8 +88,7 @@ permissions:
 
 jobs:
   manual-publish:
-    # TODO: Change to @main once feat/add-vscode-extension-ci is merged
-    uses: salesforcecli/github-workflows/.github/workflows/vscode-manual-publish.yml@main
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-manual-publish.yml@ph/W-23832274-pnpm-stable-promotion
     with:
       extension-name: ${{ inputs.extension }}
       vsix-name-pattern: 'apex-language-server-extension-*.vsix'

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -24,8 +24,7 @@ permissions:
 
 jobs:
   promote:
-    # TODO: Change to @main once feat/add-vscode-extension-ci is merged
-    uses: salesforcecli/github-workflows/.github/workflows/vscode-promote-stable.yml@main
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-promote-stable.yml@ph/W-23832274-pnpm-stable-promotion
     with:
       extension-name: 'apex-lsp-vscode-extension'
       vsix-name-pattern: 'apex-language-server-extension-*.vsix'


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23832274@

### Summary
- Resolve Manual Publish and stable promotion workflows from the active shared-workflows development branch.
- Exercise shared action implementations instead of the removed caller-local composite actions.

### Testing
- `npm run lint`
- `npm test`