### PR TITLE
build(deps): combine pending dependabot updates

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -219,8 +219,8 @@
     }
   },
   "devDependencies": {
-    "@playwright/test": "^1.61.1",
-    "playwright": "^1.61.0",
+    "@playwright/test": "^1.62.1",
+    "playwright": "^1.62.1",
     "@types/node": "^20.19.43",
     "@vscode/test-electron": "3.1.0",
     "typescript": "^5.8.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@commitlint/cli": "^20.5.3",
         "@commitlint/config-conventional": "^20.5.3",
-        "@effect/language-service": "^0.87.0",
+        "@effect/language-service": "^0.87.2",
         "@salesforce/apex-lsp-compliant-services": "1.0.0",
         "@salesforce/apex-lsp-parser-ast": "1.0.0",
         "@semantic-release/changelog": "^6.0.3",
@@ -56,12 +56,12 @@
         "knip": "^6.31.0",
         "prettier": "^3.9.6",
         "rimraf": "^5.0.5",
-        "semantic-release": "^25.0.8",
+        "semantic-release": "^25.0.9",
         "semver": "^7.8.5",
         "shelljs": "^0.10.0",
         "simple-git": "^3.36.0",
         "ts-jest": "^29.4.12",
-        "tsx": "^4.23.9",
+        "tsx": "^4.23.11",
         "typescript": "^5.8.2",
         "wireit": "^0.14.13",
         "zod": "^4.4.3"
@@ -71,18 +71,34 @@
         "npm": ">=10.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "^4.62.4",
         "@rollup/rollup-linux-x64-musl": "^4.62.4"
       }
     },
     "e2e-tests": {
       "version": "1.0.0",
       "devDependencies": {
-        "@playwright/test": "^1.61.1",
+        "@playwright/test": "^1.62.1",
         "@types/node": "^20.19.43",
         "@vscode/test-electron": "3.1.0",
-        "playwright": "^1.61.0",
+        "playwright": "^1.62.1",
         "typescript": "^5.8.2"
+      }
+    },
+    "e2e-tests/node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@actions/core": {
@@ -1395,9 +1411,9 @@
       }
     },
     "node_modules/@effect/language-service": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@effect/language-service/-/language-service-0.87.0.tgz",
-      "integrity": "sha512-GwZtEwBaOMyKea6YAtN0T0OGBtzJ8/y0KUIfyg29u3hnMRiXKlR2BRDqJmi+SbgaODJNNB3YOd6KuRB/vsxnWw==",
+      "version": "0.87.2",
+      "resolved": "https://registry.npmjs.org/@effect/language-service/-/language-service-0.87.2.tgz",
+      "integrity": "sha512-CfiSoaVQO8pZgaMZGw5VvMvRGybsJ2LaSDoLYaqiVGvo/YYPYVR2GzUKY0h1NtIweq/+SQ5XLrvtzPIttWQ0GQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1435,19 +1451,6 @@
       },
       "peerDependencies": {
         "effect": "^3.22.1"
-      }
-    },
-    "node_modules/@effect/platform-browser": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@effect/platform-browser/-/platform-browser-0.77.0.tgz",
-      "integrity": "sha512-PdkwdN8n0arIn/UCGbToX+h8ISISKDyLzeFW4tuoxTLVg2tV7yT6I+oPTPV+eiZ/aDnDlZcMG1xss6UCU1BFNA==",
-      "license": "MIT",
-      "dependencies": {
-        "multipasta": "^0.2.7"
-      },
-      "peerDependencies": {
-        "@effect/platform": "^0.97.0",
-        "effect": "^3.22.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3371,283 +3374,6 @@
         "tslib": "2"
       }
     },
-    "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.67.0.tgz",
-      "integrity": "sha512-+QOYAGujzm86pKcX4N0JQ1YcLEjypr/I+wmQRxwI8W7K0QXKSi8vQVC2oKQGjcfbHq02JvCQijypfvyhcTz7uw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.67.0",
-        "@jsonjoy.com/fs-node-utils": "4.67.0",
-        "thingies": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.67.0.tgz",
-      "integrity": "sha512-2jCnH5ofKXb+6vcl8dQArO1Gb4FT7vLbMGVnNim0ekXkY78DPVXZvJ8DQp9WLbqP/G/gxiPVz/DOMoOCD4BqqQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-core": "4.67.0",
-        "@jsonjoy.com/fs-node-builtins": "4.67.0",
-        "@jsonjoy.com/fs-node-utils": "4.67.0",
-        "thingies": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.67.0.tgz",
-      "integrity": "sha512-EZ/mSrxRYphDbyll1VuDW0mvj/USoe2M5sxT2nYqyYyvdxsIsijhJOiygBHAaj86Eqd/Kb9ukkwXjBisRTk1tg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-core": "4.67.0",
-        "@jsonjoy.com/fs-node-builtins": "4.67.0",
-        "@jsonjoy.com/fs-node-utils": "4.67.0",
-        "@jsonjoy.com/fs-print": "4.67.0",
-        "@jsonjoy.com/fs-snapshot": "4.67.0",
-        "glob-to-regex.js": "^1.0.0",
-        "thingies": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.67.0.tgz",
-      "integrity": "sha512-os7Cft1EudH0xZs5Kh5/qHI72jk8DMQ1561elyHkHd9c9xaa4wOfK1iMh4JB9y+kXtpXjEnT4cjHqqc7A3X3lA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.67.0.tgz",
-      "integrity": "sha512-5e6WTnLhw0Q5mPEACOsA7h2BA++N1FCSmhXRX5gone8Le4fsqcpgpukqW5hWneLfzIr5AOEliu0PyokdYx3Bwg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.67.0",
-        "@jsonjoy.com/fs-node-builtins": "4.67.0",
-        "@jsonjoy.com/fs-node-utils": "4.67.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.67.0.tgz",
-      "integrity": "sha512-ZcCPh4jvUqYxAgu4lLe+6eQbijxEkZIrCq0Jhh669o3v3zrCn8N4YAFod3zllZtSHhwb+YbER29LUW/SdNrP7Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.67.0",
-        "glob-to-regex.js": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.67.0.tgz",
-      "integrity": "sha512-xBhay3ayVlFeScafZy+7jyH0+I6MLomaL+2nn/KWirgjwh58w8+u44j7oSvE8EQ2NLF63B1eVc65awmbs/39Iw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.67.0",
-        "tree-dump": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.67.0.tgz",
-      "integrity": "sha512-wn5c6Qx0iVX1dV74l5WOCIPH9lz3xU6A0QG45n0c53athmmr7Z+XTg0YOndME88g/5LjcqwiSSYD9aSr9+goYg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.67.0",
-        "@jsonjoy.com/json-pack": "^17.65.0",
-        "@jsonjoy.com/util": "^17.65.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
-      "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
-      "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
-      "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/base64": "17.67.0",
-        "@jsonjoy.com/buffers": "17.67.0",
-        "@jsonjoy.com/codegen": "17.67.0",
-        "@jsonjoy.com/json-pointer": "17.67.0",
-        "@jsonjoy.com/util": "17.67.0",
-        "hyperdyperid": "^1.2.0",
-        "thingies": "^2.5.0",
-        "tree-dump": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
-      "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/util": "17.67.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
-      "version": "17.67.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
-      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/buffers": "17.67.0",
-        "@jsonjoy.com/codegen": "17.67.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
     "node_modules/@jsonjoy.com/json-pack": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
@@ -5414,33 +5140,17 @@
       }
     },
     "node_modules/@playwright/browser-chromium": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.61.0.tgz",
-      "integrity": "sha512-bBGzN+jow5uQtYRDCnFv5cpyMjUYTF6WnsfRRrDXIwbaGDtdh0JdOPmlKdJH4OK7TbkrZ35cV7jhQ1zELoX5ew==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.62.1.tgz",
+      "integrity": "sha512-DU/t4TSqHvAc+uFMt972forQYqBTh/ul7lZ8U81HYGyxnf6vSPPz9NzuE0OR3x/elqvvGm+n4gcny+QSKT+FDw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0"
+        "playwright-core": "1.62.1"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.61.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -5548,9 +5258,9 @@
       }
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
-      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
       "cpu": [
         "x64"
       ],
@@ -18274,33 +17984,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/memfs": {
-      "version": "4.67.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.67.0.tgz",
-      "integrity": "sha512-yuwPWDAs2kfwpQFuFNQI2OkiJ4ZqkGvSFq2jbgC9pFPfgh1N1lPxJaBj5rHp9R1wfJlSzUQkFnSw6WYGPwBbRg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-core": "4.67.0",
-        "@jsonjoy.com/fs-fsa": "4.67.0",
-        "@jsonjoy.com/fs-node": "4.67.0",
-        "@jsonjoy.com/fs-node-builtins": "4.67.0",
-        "@jsonjoy.com/fs-node-to-fsa": "4.67.0",
-        "@jsonjoy.com/fs-node-utils": "4.67.0",
-        "@jsonjoy.com/fs-print": "4.67.0",
-        "@jsonjoy.com/fs-snapshot": "4.67.0",
-        "@jsonjoy.com/json-pack": "^1.11.0",
-        "@jsonjoy.com/util": "^1.9.0",
-        "glob-to-regex.js": "^1.0.1",
-        "thingies": "^2.5.0",
-        "tree-dump": "^1.0.3",
-        "tslib": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      }
-    },
     "node_modules/memfs-browser": {
       "version": "3.5.10302",
       "resolved": "https://registry.npmjs.org/memfs-browser/-/memfs-browser-3.5.10302.tgz",
@@ -22294,35 +21977,35 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {
@@ -23843,9 +23526,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semantic-release": {
-      "version": "25.0.8",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.8.tgz",
-      "integrity": "sha512-w/iZ0bur36rKffXZYmIUmy068eoBY3Ij1DCCddx2JwWEM5Tg+eU9ld/E9qSInVvPASyyR2Ln/XGfQ9OZrMlhtw==",
+      "version": "25.0.9",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.9.tgz",
+      "integrity": "sha512-bxve7csK0/Txr++CkfrmV+X1r4jqiSOw2WsSad9E2S68R+ZfLBwDn8IceM8WfiOmKQIHgsQc1cNA8Dzg7U75pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26431,9 +26114,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.23.9",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.9.tgz",
-      "integrity": "sha512-6q8uTORRGauQVjqMQnKUucLFoeXZAfw6zKvG35GLbdKWbLdeOtZ3H4mhyA5mxuUd2o2cRTskhj59nLLQseUvUw==",
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -27737,7 +27420,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@effect/platform": "^0.97.1",
-        "@effect/platform-browser": "^0.77.0",
+        "@effect/platform-browser": "^0.77.1",
         "@effect/platform-node": "^0.108.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/context-async-hooks": "^2.10.0",
@@ -27764,7 +27447,7 @@
         "buffer": "^6.0.3",
         "events": "^3.3.0",
         "jest-environment-jsdom": "^30.4.1",
-        "memfs": "^4.67.0",
+        "memfs": "^4.68.0",
         "memfs-browser": "^3.5.10302",
         "node-dir": "^0.1.17",
         "npm-run-all": "^4.1.5",
@@ -27773,6 +27456,19 @@
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0",
         "util": "^0.12.5"
+      }
+    },
+    "packages/apex-ls/node_modules/@effect/platform-browser": {
+      "version": "0.77.1",
+      "resolved": "https://registry.npmjs.org/@effect/platform-browser/-/platform-browser-0.77.1.tgz",
+      "integrity": "sha512-QnncLCTIynGUatlMQY3CNK08tVKTbPLGPIzR9I1HThOHIVV4RIqicV94/zTzbyV/dQaaw6JpgXZALaTM1jJEFw==",
+      "license": "MIT",
+      "dependencies": {
+        "multipasta": "^0.2.8"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.97.1",
+        "effect": "^3.22.1"
       }
     },
     "packages/apex-ls/node_modules/@effect/platform-node": {
@@ -27810,6 +27506,304 @@
         "@effect/rpc": "^0.76.1",
         "@effect/sql": "^0.52.1",
         "effect": "^3.22.1"
+      }
+    },
+    "packages/apex-ls/node_modules/@jsonjoy.com/base64": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+      "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "packages/apex-ls/node_modules/@jsonjoy.com/codegen": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+      "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "packages/apex-ls/node_modules/@jsonjoy.com/fs-core": {
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.68.1.tgz",
+      "integrity": "sha512-V5oZ4Gt9WJKyQef0n9cAd0N9qjSkIBm3E4MYsgNIWBk5aINCDPKxMPo1i29rBxqiT4Ixf1epklqV9VJMKIxwlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "packages/apex-ls/node_modules/@jsonjoy.com/fs-fsa": {
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.68.1.tgz",
+      "integrity": "sha512-HCG72UioncuO7Gw09XNVG+S85e3cq2hrUC/mexBrsWsa3mI7eePkkqWie3uVYbtsb64OR9YGQs5SqaufDRYBcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "packages/apex-ls/node_modules/@jsonjoy.com/fs-node": {
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.68.1.tgz",
+      "integrity": "sha512-R5D9mWtqdURzcOWj1vdXr3APCwX0xchtFT+kmW7fXLNDifWdDrnh26jSID8pdnUfFBxTyfHtFtTL/NWKzIH7kQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "@jsonjoy.com/fs-print": "4.68.1",
+        "@jsonjoy.com/fs-snapshot": "4.68.1",
+        "glob-to-regex.js": "^1.0.0",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "packages/apex-ls/node_modules/@jsonjoy.com/fs-node-builtins": {
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.68.1.tgz",
+      "integrity": "sha512-HK1BTksysokNZxNspqDH0yPaqN9YgR/AYIlYiIaU2Ys4BOk5CdybI7r6BgiZuiiPiV8n4sK/kZdice7Znpy2Kw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "packages/apex-ls/node_modules/@jsonjoy.com/fs-node-to-fsa": {
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.68.1.tgz",
+      "integrity": "sha512-lpKmU4X9e/oh8GIuAI7EXaS5QiLNM3KD15CkdhfS6PYmrGvoJqKQcyEfnLgnnaGslh/PFUMYSIZBCf2ejJGw8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "packages/apex-ls/node_modules/@jsonjoy.com/fs-node-utils": {
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.68.1.tgz",
+      "integrity": "sha512-/GxfW1DWm9SCdkfbvqevLO/P5duobQfmKkHXxdMIDbcZMQeAgooAstIfZhkXpATzq9QbCQsnoWFM/dGHdZfndw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "glob-to-regex.js": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "packages/apex-ls/node_modules/@jsonjoy.com/fs-print": {
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.68.1.tgz",
+      "integrity": "sha512-oGeZOGPYKK9v1CgeVeEDsLomH1lCnslSpqUN5GmPzrmAVGQlsmsdcXNA2O4lV8Y4xkuSuynx2ITBkUHJVaTbow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "packages/apex-ls/node_modules/@jsonjoy.com/fs-snapshot": {
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.68.1.tgz",
+      "integrity": "sha512-XZfP0FDZN32bbc4t2bZN2qRrYHg5AktJnzk22HRoKGK4BprrbNRH2k5ceSNS/kupKYcofCs+O841+xaAbjnxwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^17.65.0",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "@jsonjoy.com/json-pack": "^17.65.0",
+        "@jsonjoy.com/util": "^17.65.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "packages/apex-ls/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+      "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "17.67.0",
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0",
+        "@jsonjoy.com/json-pointer": "17.67.0",
+        "@jsonjoy.com/util": "17.67.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "packages/apex-ls/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "packages/apex-ls/node_modules/@jsonjoy.com/json-pointer": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+      "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/util": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "packages/apex-ls/node_modules/@jsonjoy.com/json-pointer/node_modules/@jsonjoy.com/util": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
       }
     },
     "packages/apex-ls/node_modules/@opentelemetry/api-logs": {
@@ -28006,6 +28000,33 @@
       "engines": {
         "node": ">=12.20.0",
         "npm": ">=6.14.0"
+      }
+    },
+    "packages/apex-ls/node_modules/memfs": {
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.68.1.tgz",
+      "integrity": "sha512-OD+IDRUvIxu3QHL+nFm9gdyugInD27FDJ+sl4B5QgomPHXMlbw+GP918P8VNKu2FkNlVeqBkpzkwROpamVifRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-to-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "@jsonjoy.com/fs-print": "4.68.1",
+        "@jsonjoy.com/fs-snapshot": "4.68.1",
+        "@jsonjoy.com/json-pack": "^1.11.0",
+        "@jsonjoy.com/util": "^1.9.0",
+        "glob-to-regex.js": "^1.0.1",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.0.3",
+        "tslib": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
       }
     },
     "packages/apex-ls/node_modules/mime": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.5.3",
     "@commitlint/config-conventional": "^20.5.3",
-    "@effect/language-service": "^0.87.0",
+    "@effect/language-service": "^0.87.2",
     "@salesforce/apex-lsp-compliant-services": "1.0.0",
     "@salesforce/apex-lsp-parser-ast": "1.0.0",
     "@semantic-release/changelog": "^6.0.3",
@@ -107,18 +107,18 @@
     "knip": "^6.31.0",
     "prettier": "^3.9.6",
     "rimraf": "^5.0.5",
-    "semantic-release": "^25.0.8",
+    "semantic-release": "^25.0.9",
     "semver": "^7.8.5",
     "shelljs": "^0.10.0",
     "simple-git": "^3.36.0",
     "ts-jest": "^29.4.12",
-    "tsx": "^4.23.9",
+    "tsx": "^4.23.11",
     "typescript": "^5.8.2",
     "wireit": "^0.14.13",
     "zod": "^4.4.3"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.62.3",
+    "@rollup/rollup-linux-x64-gnu": "^4.62.4",
     "@rollup/rollup-linux-x64-musl": "^4.62.4"
   },
   "dependencies": {
@@ -128,8 +128,8 @@
   },
   "overrides": {
     "vscode-jsonrpc": "8.2.1",
-    "playwright": "1.61.0",
-    "@playwright/browser-chromium": "1.61.0"
+    "playwright": "1.62.1",
+    "@playwright/browser-chromium": "1.62.1"
   },
   "workspaces": [
     "packages/*",

--- a/packages/apex-ls/package.json
+++ b/packages/apex-ls/package.json
@@ -179,7 +179,7 @@
   },
   "dependencies": {
     "@effect/platform": "^0.97.1",
-    "@effect/platform-browser": "^0.77.0",
+    "@effect/platform-browser": "^0.77.1",
     "@effect/platform-node": "^0.108.1",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/context-async-hooks": "^2.10.0",
@@ -206,7 +206,7 @@
     "buffer": "^6.0.3",
     "events": "^3.3.0",
     "jest-environment-jsdom": "^30.4.1",
-    "memfs": "^4.67.0",
+    "memfs": "^4.68.0",
     "memfs-browser": "^3.5.10302",
     "node-dir": "^0.1.17",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
### What does this PR do?

Combines the 8 open dependabot PRs into a single lockfile regeneration so they can all land together instead of each racing flaky/timed-out Web E2E runs.

**Dependency bumps** (applied to the `package.json` files, then a single in-place `npm install` regenerated the lockfile — which also picks up transitive updates):

| Package | From | To | Supersedes |
| --- | --- | --- | --- |
| `tsx` | 4.23.9 | 4.23.11 | #650 |
| `@effect/language-service` | 0.87.0 | 0.87.2 | #649 |
| `@effect/platform-browser` | 0.77.0 | 0.77.1 | #643 |
| `memfs` | 4.67.0 | 4.68.0 | #642 |
| `@playwright/test` | 1.61.1 | 1.62.1 | #641 |
| `playwright` | 1.61.0 | 1.62.1 | #639 |
| `@rollup/rollup-linux-x64-gnu` | 4.62.3 | 4.62.4 | #638 |
| `semantic-release` | 25.0.8 | 25.0.9 | #637 |

**Lockfile note:** regenerated in place (`npm install`, not a from-scratch install) to preserve the full cross-platform optional-dependency matrix — 26 `@esbuild/*` + 19 `@oxc-parser/*` platform packages — that a clean install on macOS prunes and that breaks `npm ci` on the Linux/Windows CI runners.

**Verification (local):** `npm run lint` and `npm test` (5323 passed, 0 failed, 484 pending) pass via the pre-commit hooks; `npm ci` lockfile in sync.

Once green, this supersedes #650, #649, #643, #642, #641, #639, #638, and #637.

### What issues does this PR fix or reference?

Supersedes #650, #649, #643, #642, #641, #639, #638, #637

[skip-validate-pr]
