### PR TITLE
ci: publish web VSIX to CBWeb marketplace - W-23832274

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -50,6 +50,15 @@ on:
           - all
           - vsce
           - ovsx
+          - none
+      publish-web-vsix:
+        description: 'Publish the web VSIX to the CBWeb internal marketplace (pre-release only)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
       target-stable-version:
         description: >
           Optional stable version override (e.g. 0.6.1 for a stable patch).
@@ -96,6 +105,7 @@ jobs:
       source-run-id: ${{ inputs.source-run-id }}
       slot: ${{ inputs.slot }}
       registries: ${{ inputs.registries }}
+      publish-web-vsix: ${{ inputs.publish-web-vsix }}
       target-stable-version: ${{ inputs.target-stable-version }}
       skip-quality-checks: ${{ inputs.skip-quality-checks }}
       confirm-bypass: ${{ inputs.confirm-bypass }}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -125,7 +125,8 @@ Run it from **Actions → Manual Publish → Run workflow**. Inputs:
 | `version-tag` | **Tag path (normal):** a nightly git tag, e.g. `v0.5.3-nightly.20260301`. Mutually exclusive with `source-run-id`. |
 | `source-run-id` | **Run path (bypass):** an Actions run ID whose VSIX artifact to publish. For branch builds with no GH release. Requires `skip-quality-checks=true` **and** `confirm-bypass=BYPASS`. |
 | `slot` | `pre-release` or `stable`. |
-| `registries` | `all` (default), `vsce`, or `ovsx`. |
+| `registries` | `all` (default), `vsce`, `ovsx`, or `none`. Use `none` with `publish-web-vsix: true` for an internal-only publish. |
+| `publish-web-vsix` | `false` (default) excludes the web VSIX. Set to `true` to publish it to the internal CBWeb marketplace; use only with `slot: pre-release`. |
 | `target-stable-version` | Optional stable override (valid semver, **even** minor). Required when using `source-run-id` with `slot: stable`. |
 | `skip-quality-checks` | Bypass the CI quality gate. Required for the `source-run-id` path. |
 | `confirm-bypass` | Must be exactly `BYPASS` when skipping the quality gate. |
@@ -250,6 +251,7 @@ Apex extension publishes.
 - [ ] Run **Manual Publish** with `dry-run: true`; review the preview.
 - [ ] Re-run with `dry-run: false`; approve the environment gate.
 - [ ] Verify the new version on both registries.
+- [ ] If `publish-web-vsix: true`, verify the web VSIX in the internal CBWeb marketplace.
 - [ ] Update `code-builder-web` pin and open a PR there.
 
 ---


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23832274@

### What changed?
- Expose `publish-web-vsix` in Manual Publish and forward it to the shared workflow.
- Support `registries: none` for CBWeb-only pre-release publication.
- Document the internal marketplace path and verification step.

### Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/manual-publish.yml'); puts 'YAML valid'"`\n- `git diff --check`\n- Commit hooks: formatting and `npm test`