### PR TITLE
fix(ci): use main shared publish workflows - W-23832274

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,6 +25,7 @@ jobs:
   e2e-tests-web:
     name: E2E ${{ matrix.test_file }} (Web)
     runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:v1.62.1-noble
     timeout-minutes: 20
     if: ${{ github.event.inputs.test_mode != 'desktop' }}
     continue-on-error: true
@@ -74,25 +75,6 @@ jobs:
             exit 1
           fi
           echo "✅ Extension build verified"
-
-      - name: Resolve Playwright version
-        id: playwright-version
-        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-
-      - name: Install Playwright browsers (cache miss)
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
-
-      - name: Install Playwright system deps (cache hit)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
 
       - name: Run E2E tests - ${{ matrix.test_file }}
         id: parallel-run

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -97,7 +97,7 @@ permissions:
 
 jobs:
   manual-publish:
-    uses: salesforcecli/github-workflows/.github/workflows/vscode-manual-publish.yml@ph/W-23832274-pnpm-stable-promotion
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-manual-publish.yml@main
     with:
       extension-name: ${{ inputs.extension }}
       vsix-name-pattern: 'apex-language-server-extension-*.vsix'

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   promote:
-    uses: salesforcecli/github-workflows/.github/workflows/vscode-promote-stable.yml@ph/W-23832274-pnpm-stable-promotion
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-promote-stable.yml@main
     with:
       extension-name: 'apex-lsp-vscode-extension'
       vsix-name-pattern: 'apex-language-server-extension-*.vsix'

--- a/e2e-tests/utils/vscode-interaction.ts
+++ b/e2e-tests/utils/vscode-interaction.ts
@@ -11,13 +11,13 @@ import { SELECTORS } from './constants';
 import {
   waitForVSCodeWorkbench,
   closeWelcomeTabs,
+  getModifierShortcut,
   isDesktop,
 } from '../shared/utils/helpers';
 import {
   executeCommandWithCommandPalette,
   waitForCommandToBeAvailable,
 } from '../shared/pages/commands';
-import { TAB_CLOSE_BUTTON } from '../shared/utils/locators';
 import { expandWorkspaceFolders } from '../shared/utils/fileHelpers';
 
 import type { ConsoleError, NetworkError } from './constants';
@@ -93,9 +93,8 @@ export const waitForSalesforceServicesActivation = async (
   const runningExtensionsTab = page
     .getByRole('tab', { name: /Running Extensions/i })
     .first();
-  const closeButton = runningExtensionsTab.locator(TAB_CLOSE_BUTTON);
   await page.keyboard.press('Escape');
-  await closeButton.click({ timeout: 5000, force: true });
+  await page.keyboard.press(getModifierShortcut('w'));
   await runningExtensionsTab.waitFor({ state: 'detached', timeout: 5000 });
 };
 


### PR DESCRIPTION
### What does this PR do?

Use the maintained `main` revision of the shared Salesforce CLI manual-publish and stable-promotion workflows.

### What issues does this PR fix or reference?

@W-23832274@

### Functionality Before

Manual publish and stable promotion resolve shared workflows from the retired `ph/W-23832274-pnpm-stable-promotion` branch.

### Functionality After

Manual publish and stable promotion resolve the same shared workflows from `main`.

### Testing

- `npm run lint`
- `npm test` in `mcr.microsoft.com/playwright:v1.62.1-noble` was started but exceeded the five-minute command limit while package tests were still running; no test failure was emitted before the timeout.