### PR TITLE
build: configure promotion gates

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -30,5 +30,6 @@ jobs:
       vsix-name-pattern: 'apex-language-server-extension-*.vsix'
       exclude-web-vsix: 'true'
       extensions-root: 'packages'
+      required-ci-checks: '["CI Complete"]'
       dry-run: ${{ inputs.dry-run || 'false' }}
     secrets: inherit


### PR DESCRIPTION
### What does this PR do?

Configures stable promotions to require the `CI Complete` aggregate check exposed by the shared VS Code promotion workflow.

### What issues does this PR fix or reference?

[skip-validate-pr]
