### PR TITLE
refactor: implement gate-check before promotion W-23900552

### DIFF
--- a/.github/workflows/promote-prerelease.yml
+++ b/.github/workflows/promote-prerelease.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   # Step 1: Find nightly candidate (THIS REPO CONTROLS CRITERIA)
   find-nightly:
-    uses: salesforcecli/github-workflows/.github/workflows/vscode-find-nightly-candidate.yml@ms/caller-call-ci-status-check
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-find-nightly-candidate.yml@main
     with:
       min-tag-age-days: ${{ inputs.min-tag-age-days || '7' }}
 
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check CI status
-        uses: salesforcecli/github-workflows/.github/actions/vscode/check-ci-status@ms/caller-call-ci-status-check
+        uses: salesforcecli/github-workflows/.github/actions/vscode/check-ci-status@main
         with:
           commit-sha: ${{ needs.find-nightly.outputs.commit-sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -50,7 +50,7 @@ jobs:
   # Step 3: Promote to marketplace (only runs if gate-check passed)
   promote:
     needs: [find-nightly, gate-check]
-    uses: salesforcecli/github-workflows/.github/workflows/vscode-promote-prerelease.yml@ms/caller-call-ci-status-check
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-promote-prerelease.yml@main
     with:
       release-tag: ${{ needs.find-nightly.outputs.nightly-tag }}
       vsix-name-pattern: 'apex-language-server-extension-*.vsix'

--- a/.github/workflows/promote-prerelease.yml
+++ b/.github/workflows/promote-prerelease.yml
@@ -26,11 +26,33 @@ permissions:
   actions: read
 
 jobs:
-  promote:
-    # TODO: Change to @main once feat/add-vscode-extension-ci is merged
-    uses: salesforcecli/github-workflows/.github/workflows/vscode-promote-prerelease.yml@main
+  # Step 1: Find nightly candidate (THIS REPO CONTROLS CRITERIA)
+  find-nightly:
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-find-nightly-candidate.yml@ms/caller-call-ci-status-check
     with:
       min-tag-age-days: ${{ inputs.min-tag-age-days || '7' }}
+
+  # Step 2: Gate-check CI status (THIS REPO CONTROLS CRITERIA)
+  gate-check:
+    needs: find-nightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check CI status
+        uses: salesforcecli/github-workflows/.github/actions/vscode/check-ci-status@ms/caller-call-ci-status-check
+        with:
+          commit-sha: ${{ needs.find-nightly.outputs.commit-sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          required-checks: '["CI Complete"]'
+
+  # Step 3: Promote to marketplace (only runs if gate-check passed)
+  promote:
+    needs: [find-nightly, gate-check]
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-promote-prerelease.yml@ms/caller-call-ci-status-check
+    with:
+      release-tag: ${{ needs.find-nightly.outputs.nightly-tag }}
       vsix-name-pattern: 'apex-language-server-extension-*.vsix'
       exclude-web-vsix: 'true'
       extension-name: 'apex-lsp-vscode-extension'


### PR DESCRIPTION
Prevent inversion of control by implementing gate-check in this repo before calling shared promotion workflow.

Changes:
- Add find-nightly job (uses shared vscode-find-nightly-candidate.yml)
- Add inline gate-check job (validates CI status before promoting)
  - Uses shared check-ci-status action
  - THIS REPO controls criteria: requires ["CI Complete"]
- Update promote job to receive nightly-tag from find-nightly

3-stage flow: find → gate-check → promote
- find-nightly: Reuses shared workflow to find eligible nightly tag
- gate-check: THIS REPO validates CI passed (inline, visible in Actions UI)
- promote: Delegates to shared workflow for publishing (only if gate passed)

Benefits:
- This repo controls promotion criteria (not shared workflow)
- Gate-check visible in this repo's Actions UI
- Easy to customize required checks without upstream changes

<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

### What issues does this PR fix or reference?

@W-23900552@

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
