### PR TITLE
feat(apex-lsp-extension): renameField prepareRename + e2e coverage - W-23631087

### DIFF
--- a/e2e-tests/pages/BasePage.ts
+++ b/e2e-tests/pages/BasePage.ts
@@ -30,10 +30,9 @@ export class BasePage {
   constructor(page: Page) {
     this.page = page;
     this.workbench = page.locator(SELECTORS.WORKBENCH);
-    // Exclude the Monaco rename widget (`.monaco-editor.rename-box`), which stays
-    // in the DOM after the first rename. Without this, `.monaco-editor` matches
-    // two elements post-rename and `editor.waitFor()` (openFile) hits a
-    // strict-mode violation when switching files. It's never the editor we want.
+    // Exclude the Monaco rename widget (`.monaco-editor.rename-box`), which lingers
+    // in the DOM after a rename — otherwise `.monaco-editor` matches two elements
+    // and editor.waitFor() (openFile) throws a strict-mode violation on file switch.
     this.editor = page.locator(`${SELECTORS.MONACO_EDITOR}:not(.rename-box)`);
     this.explorer = page.locator(SELECTORS.EXPLORER);
     this.sidebar = page.locator(SELECTORS.SIDEBAR);

--- a/e2e-tests/pages/BasePage.ts
+++ b/e2e-tests/pages/BasePage.ts
@@ -30,12 +30,10 @@ export class BasePage {
   constructor(page: Page) {
     this.page = page;
     this.workbench = page.locator(SELECTORS.WORKBENCH);
-    // Exclude the Monaco rename widget: it carries the `.monaco-editor` class
-    // (`.monaco-editor.rename-box`) and Monaco keeps it in the DOM after the
-    // first rename, so an unscoped `.monaco-editor` locator would resolve to TWO
-    // elements once any rename has run — breaking `editor.waitFor()` (e.g. in
-    // openFile) with a strict-mode violation when switching files post-rename.
-    // The rename-box is never the editor we want, so excluding it is always safe.
+    // Exclude the Monaco rename widget (`.monaco-editor.rename-box`), which stays
+    // in the DOM after the first rename. Without this, `.monaco-editor` matches
+    // two elements post-rename and `editor.waitFor()` (openFile) hits a
+    // strict-mode violation when switching files. It's never the editor we want.
     this.editor = page.locator(`${SELECTORS.MONACO_EDITOR}:not(.rename-box)`);
     this.explorer = page.locator(SELECTORS.EXPLORER);
     this.sidebar = page.locator(SELECTORS.SIDEBAR);

--- a/e2e-tests/pages/BasePage.ts
+++ b/e2e-tests/pages/BasePage.ts
@@ -30,7 +30,13 @@ export class BasePage {
   constructor(page: Page) {
     this.page = page;
     this.workbench = page.locator(SELECTORS.WORKBENCH);
-    this.editor = page.locator(SELECTORS.MONACO_EDITOR);
+    // Exclude the Monaco rename widget: it carries the `.monaco-editor` class
+    // (`.monaco-editor.rename-box`) and Monaco keeps it in the DOM after the
+    // first rename, so an unscoped `.monaco-editor` locator would resolve to TWO
+    // elements once any rename has run — breaking `editor.waitFor()` (e.g. in
+    // openFile) with a strict-mode violation when switching files post-rename.
+    // The rename-box is never the editor we want, so excluding it is always safe.
+    this.editor = page.locator(`${SELECTORS.MONACO_EDITOR}:not(.rename-box)`);
     this.explorer = page.locator(SELECTORS.EXPLORER);
     this.sidebar = page.locator(SELECTORS.SIDEBAR);
     this.statusbar = page.locator(SELECTORS.STATUSBAR);

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldClient.cls
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldClient.cls
@@ -1,6 +1,5 @@
-// Consumer for cross-file renameField e2e (W-23631087 / 4.3). Holds a
-// locally-typed RenameFieldModel instance and reads/writes its `quantity`
-// field, so a rename of RenameFieldModel.quantity must update these usages.
+// Consumer for the cross-file renameField e2e (W-23631087): reads/writes
+// RenameFieldModel.quantity through a local instance.
 public with sharing class RenameFieldClient {
     public Integer useModel() {
         RenameFieldModel model = new RenameFieldModel();

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldClient.cls
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldClient.cls
@@ -1,0 +1,10 @@
+// Consumer for cross-file renameField e2e (W-23631087 / 4.3). Holds a
+// locally-typed RenameFieldModel instance and reads/writes its `quantity`
+// field, so a rename of RenameFieldModel.quantity must update these usages.
+public with sharing class RenameFieldClient {
+    public Integer useModel() {
+        RenameFieldModel model = new RenameFieldModel();
+        model.quantity = 5;
+        return model.quantity;
+    }
+}

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldClient.cls-meta.xml
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldClient.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldModel.cls
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldModel.cls
@@ -1,7 +1,5 @@
-// Fixture for cross-file renameField e2e (W-23631087 / 4.3). `quantity` is a
-// public field consumed by RenameFieldClient.cls through a locally-typed
-// instance, so renaming it must edit BOTH this declaration and the caller's
-// field-access occurrences (a two-file WorkspaceEdit).
+// Cross-file renameField e2e fixture (W-23631087): `quantity` is consumed by
+// RenameFieldClient, so renaming it must edit both files.
 public with sharing class RenameFieldModel {
     public Integer quantity = 0;
 }

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldModel.cls
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldModel.cls
@@ -1,0 +1,7 @@
+// Fixture for cross-file renameField e2e (W-23631087 / 4.3). `quantity` is a
+// public field consumed by RenameFieldClient.cls through a locally-typed
+// instance, so renaming it must edit BOTH this declaration and the caller's
+// field-access occurrences (a two-file WorkspaceEdit).
+public with sharing class RenameFieldModel {
+    public Integer quantity = 0;
+}

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldModel.cls-meta.xml
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldModel.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldSample.cls
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldSample.cls
@@ -1,7 +1,5 @@
-// Fixture for renameField e2e (W-23631087 / 4.3). The instance field `counter`
-// is declared once and referenced via this.counter and bare (implicit-this)
-// counter, so renaming it exercises the declaration + this-qualified +
-// implicit-this occurrence classification end-to-end through F2.
+// renameField e2e fixture (W-23631087): field `counter` used via this.counter
+// and bare (implicit-this) counter — exercises the declaration + both forms.
 public with sharing class RenameFieldSample {
     public Integer counter = 0;
 

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldSample.cls
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldSample.cls
@@ -1,0 +1,15 @@
+// Fixture for renameField e2e (W-23631087 / 4.3). The instance field `counter`
+// is declared once and referenced via this.counter and bare (implicit-this)
+// counter, so renaming it exercises the declaration + this-qualified +
+// implicit-this occurrence classification end-to-end through F2.
+public with sharing class RenameFieldSample {
+    public Integer counter = 0;
+
+    public void increment() {
+        this.counter = this.counter + 1;
+    }
+
+    public Integer readCounter() {
+        return counter;
+    }
+}

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldSample.cls-meta.xml
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameFieldSample.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/e2e-tests/tests/apex-rename-symbol.spec.ts
+++ b/e2e-tests/tests/apex-rename-symbol.spec.ts
@@ -373,7 +373,9 @@ test.describe('Apex Rename Symbol - Field', () => {
 
     await test.step('Assert the cross-file usages are renamed in RenameFieldClient', async () => {
       // The WorkspaceEdit spans both files. Switch to the consumer tab and wait
-      // for the applied edit to surface, then assert both field accesses.
+      // for the applied edit to surface, then assert both field accesses. (The
+      // editor locator excludes the lingering Monaco rename widget — see
+      // BasePage — so switching files after a rename is safe.)
       await apexEditor.openFile('RenameFieldClient.cls');
       await apexEditor.waitForContentToInclude('model.amount');
 

--- a/e2e-tests/tests/apex-rename-symbol.spec.ts
+++ b/e2e-tests/tests/apex-rename-symbol.spec.ts
@@ -224,3 +224,173 @@ test.describe('Apex Rename Symbol', () => {
     });
   });
 });
+
+/**
+ * E2E tests for textDocument/rename of FIELDS (W-23631087 / 4.3) — renameField
+ * for instance fields, single-file and cross-file.
+ *
+ * Field rename is driven through the SAME editor path as renameLocal: position
+ * the cursor on a field, press F2, type a new name, confirm (Enter), and assert
+ * the applied WorkspaceEdit. It exercises more of the stack than renameLocal,
+ * though — the worker's `resolveFieldRename` runs the workspace-wide two-phase
+ * scan (data-owner candidate discovery + per-candidate standalone parse with
+ * receiver-type disambiguation), so the cross-file case proves the multi-file
+ * WorkspaceEdit end-to-end.
+ *
+ * prepareRename gates F2: because `renameProvider: { prepareProvider: true }` is
+ * advertised, VS Code fires `textDocument/prepareRename` FIRST and only opens
+ * the rename box if it returns a range containing the cursor. Field support was
+ * added to `DispatchPrepareRename` in this story (W-23631087) — before it, a
+ * field cursor returned null and F2 showed "The element can't be renamed". Like
+ * the renameLocal tests, each test warms the request pool with a documentSymbol
+ * probe (live-required, no graph fallback) so prepareRename can parse the live
+ * buffer before F2.
+ *
+ * @group rename
+ */
+test.describe('Apex Rename Symbol - Field', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('renames a field declaration and its this-qualified and implicit-this usages', async ({
+    apexEditor,
+    outlineView,
+  }) => {
+    await test.step('Open the field rename fixture', async () => {
+      await apexEditor.openFile('RenameFieldSample.cls');
+      await apexEditor.waitForLanguageServerReady();
+    });
+
+    await test.step('Warm the request pool for prepareRename', async () => {
+      // F2's prepareRename needs this file's live buffer threaded to the pool.
+      // documentSymbol (live-required, no graph fallback) populates only once the
+      // live content is threadable — exactly prepareRename's precondition. Gate on
+      // a symbol from THIS file before F2 (see the renameLocal tests for why a
+      // ready-gate or hover probe is the wrong signal).
+      await outlineView.open();
+      const mainClass = await outlineView.findSymbol(
+        'RenameFieldSample',
+        20000,
+      );
+      expect(
+        mainClass,
+        'Outline (documentSymbol) must resolve RenameFieldSample before F2',
+      ).not.toBeNull();
+    });
+
+    await test.step('Position on the `counter` field declaration', async () => {
+      // Line 6 is `    public Integer counter = 0;` — `counter` occupies columns
+      // 20-26. Position at column 22 (INSIDE the token) via Go-to-Line; an
+      // in-word column avoids prepareRename's half-open [start, end) boundary
+      // (a cursor one past the last character is NOT contained → "can't be
+      // renamed"), the same hazard the renameLocal tests document.
+      await apexEditor.goToPosition(6, 22);
+    });
+
+    await test.step('Rename `counter` to `tally`', async () => {
+      await apexEditor.rename('tally');
+    });
+
+    await test.step('Assert the declaration and all field usages are renamed', async () => {
+      await apexEditor.waitForContentToInclude('tally');
+
+      const content = await apexEditor.getContent();
+      // Monaco renders indentation with non-breaking spaces (U+00A0); normalize
+      // to regular spaces so the structural assertions match reliably.
+      const normalized = content.replace(/ /g, ' ');
+
+      // Declaration: `public Integer tally = 0;`
+      expect(normalized).toMatch(/public\s+Integer\s+tally\s*=\s*0\s*;/);
+      // this-qualified read+write: `this.tally = this.tally + 1;`
+      expect(normalized).toMatch(/this\.tally\s*=\s*this\.tally\s*\+\s*1\s*;/);
+      // implicit-this read: `return tally;`
+      expect(normalized).toMatch(/return\s+tally\s*;/);
+
+      // The old name must be gone from the CLASS BODY. The leading comment
+      // mentions `counter`, so slice from the class declaration to exclude it —
+      // asserting on whole content would false-positive on the comment prose.
+      const classBody = normalized.slice(
+        normalized.indexOf('public with sharing class'),
+      );
+      expect(classBody).not.toContain('counter');
+    });
+  });
+
+  test('renames a field across files (declaration + cross-file field access)', async ({
+    apexEditor,
+    outlineView,
+  }) => {
+    await test.step('Open the consumer and declaring files', async () => {
+      // Open the consumer first so the workspace ingests the cross-file usage,
+      // then the declaring file where we invoke the rename (mirrors the
+      // cross-file find-references test's open order).
+      await apexEditor.openFile('RenameFieldClient.cls');
+      await apexEditor.waitForLanguageServerReady();
+      await apexEditor.openFile('RenameFieldModel.cls');
+      await apexEditor.waitForLanguageServerReady();
+    });
+
+    await test.step('Wait for full workspace ingestion', async () => {
+      // Cross-file renameField discovers candidates through the data-owner's
+      // stored document set. During an active workspace-load session that set is
+      // only PARTIAL, and the rename correctly DECLINES rather than emit a
+      // partial edit (W-23631084 review). Gate on full ingestion so the consumer
+      // file is stored and the cross-file occurrence is found — the same gate the
+      // cross-file goto/find-references tests use before their first cross-file
+      // request.
+      await apexEditor.waitForWorkspaceReady();
+    });
+
+    await test.step('Warm the request pool for prepareRename on the declaring file', async () => {
+      await apexEditor.openFile('RenameFieldModel.cls');
+      await outlineView.open();
+      const mainClass = await outlineView.findSymbol('RenameFieldModel', 20000);
+      expect(
+        mainClass,
+        'Outline (documentSymbol) must resolve RenameFieldModel before F2',
+      ).not.toBeNull();
+    });
+
+    await test.step('Position on the `quantity` field declaration', async () => {
+      // Line 6 is `    public Integer quantity = 0;` — `quantity` occupies
+      // columns 20-27. Position at column 23 (INSIDE the token).
+      await apexEditor.goToPosition(6, 23);
+    });
+
+    await test.step('Rename `quantity` to `amount`', async () => {
+      await apexEditor.rename('amount');
+    });
+
+    await test.step('Assert the declaration is renamed in RenameFieldModel', async () => {
+      await apexEditor.waitForContentToInclude('amount');
+      const content = await apexEditor.getContent();
+      const normalized = content.replace(/ /g, ' ');
+      expect(normalized).toMatch(/public\s+Integer\s+amount\s*=\s*0\s*;/);
+      const classBody = normalized.slice(
+        normalized.indexOf('public with sharing class'),
+      );
+      expect(classBody).not.toContain('quantity');
+    });
+
+    await test.step('Assert the cross-file usages are renamed in RenameFieldClient', async () => {
+      // The WorkspaceEdit spans both files. Switch to the consumer tab and wait
+      // for the applied edit to surface, then assert both field accesses.
+      await apexEditor.openFile('RenameFieldClient.cls');
+      await apexEditor.waitForContentToInclude('model.amount');
+
+      const content = await apexEditor.getContent();
+      const normalized = content.replace(/ /g, ' ');
+
+      // Write: `model.amount = 5;`
+      expect(normalized).toMatch(/model\.amount\s*=\s*5\s*;/);
+      // Read: `return model.amount;`
+      expect(normalized).toMatch(/return\s+model\.amount\s*;/);
+
+      // The old field name must be gone from the class body (the leading comment
+      // mentions `quantity`, so slice from the class declaration to exclude it).
+      const classBody = normalized.slice(
+        normalized.indexOf('public with sharing class'),
+      );
+      expect(classBody).not.toContain('quantity');
+    });
+  });
+});

--- a/e2e-tests/tests/apex-rename-symbol.spec.ts
+++ b/e2e-tests/tests/apex-rename-symbol.spec.ts
@@ -226,25 +226,14 @@ test.describe('Apex Rename Symbol', () => {
 });
 
 /**
- * E2E tests for textDocument/rename of FIELDS (W-23631087 / 4.3) — renameField
- * for instance fields, single-file and cross-file.
+ * E2E tests for textDocument/rename of FIELDS (W-23631087) — single-file and
+ * cross-file, driven through F2 like the renameLocal tests. The cross-file case
+ * proves the multi-file WorkspaceEdit from `resolveFieldRename`'s workspace scan.
  *
- * Field rename is driven through the SAME editor path as renameLocal: position
- * the cursor on a field, press F2, type a new name, confirm (Enter), and assert
- * the applied WorkspaceEdit. It exercises more of the stack than renameLocal,
- * though — the worker's `resolveFieldRename` runs the workspace-wide two-phase
- * scan (data-owner candidate discovery + per-candidate standalone parse with
- * receiver-type disambiguation), so the cross-file case proves the multi-file
- * WorkspaceEdit end-to-end.
- *
- * prepareRename gates F2: because `renameProvider: { prepareProvider: true }` is
- * advertised, VS Code fires `textDocument/prepareRename` FIRST and only opens
- * the rename box if it returns a range containing the cursor. Field support was
- * added to `DispatchPrepareRename` in this story (W-23631087) — before it, a
- * field cursor returned null and F2 showed "The element can't be renamed". Like
- * the renameLocal tests, each test warms the request pool with a documentSymbol
- * probe (live-required, no graph fallback) so prepareRename can parse the live
- * buffer before F2.
+ * F2 fires prepareRename first (prepareProvider is advertised); field support
+ * was added to DispatchPrepareRename in this story (before it, F2 on a field
+ * showed "The element can't be renamed"). Each test warms the pool with a
+ * documentSymbol probe so prepareRename can parse the live buffer before F2.
  *
  * @group rename
  */
@@ -261,11 +250,8 @@ test.describe('Apex Rename Symbol - Field', () => {
     });
 
     await test.step('Warm the request pool for prepareRename', async () => {
-      // F2's prepareRename needs this file's live buffer threaded to the pool.
-      // documentSymbol (live-required, no graph fallback) populates only once the
-      // live content is threadable — exactly prepareRename's precondition. Gate on
-      // a symbol from THIS file before F2 (see the renameLocal tests for why a
-      // ready-gate or hover probe is the wrong signal).
+      // documentSymbol threads this file's live buffer to the pool — exactly
+      // prepareRename's precondition (see the renameLocal tests for the rationale).
       await outlineView.open();
       const mainClass = await outlineView.findSymbol(
         'RenameFieldSample',
@@ -278,12 +264,9 @@ test.describe('Apex Rename Symbol - Field', () => {
     });
 
     await test.step('Position on the `counter` field declaration', async () => {
-      // Line 6 is `    public Integer counter = 0;` — `counter` occupies columns
-      // 20-26. Position at column 22 (INSIDE the token) via Go-to-Line; an
-      // in-word column avoids prepareRename's half-open [start, end) boundary
-      // (a cursor one past the last character is NOT contained → "can't be
-      // renamed"), the same hazard the renameLocal tests document.
-      await apexEditor.goToPosition(6, 22);
+      // Line 4 `    public Integer counter = 0;` — column 22 is inside `counter`.
+      // An in-word column avoids prepareRename's half-open [start, end) boundary.
+      await apexEditor.goToPosition(4, 22);
     });
 
     await test.step('Rename `counter` to `tally`', async () => {
@@ -305,9 +288,8 @@ test.describe('Apex Rename Symbol - Field', () => {
       // implicit-this read: `return tally;`
       expect(normalized).toMatch(/return\s+tally\s*;/);
 
-      // The old name must be gone from the CLASS BODY. The leading comment
-      // mentions `counter`, so slice from the class declaration to exclude it —
-      // asserting on whole content would false-positive on the comment prose.
+      // Old name gone — slice from the class decl so the leading comment (which
+      // mentions `counter`) doesn't false-positive.
       const classBody = normalized.slice(
         normalized.indexOf('public with sharing class'),
       );
@@ -320,9 +302,8 @@ test.describe('Apex Rename Symbol - Field', () => {
     outlineView,
   }) => {
     await test.step('Open the consumer and declaring files', async () => {
-      // Open the consumer first so the workspace ingests the cross-file usage,
-      // then the declaring file where we invoke the rename (mirrors the
-      // cross-file find-references test's open order).
+      // Consumer first so its cross-file usage is ingested, then the declaring
+      // file where we invoke the rename (mirrors the cross-file find-refs test).
       await apexEditor.openFile('RenameFieldClient.cls');
       await apexEditor.waitForLanguageServerReady();
       await apexEditor.openFile('RenameFieldModel.cls');
@@ -330,13 +311,9 @@ test.describe('Apex Rename Symbol - Field', () => {
     });
 
     await test.step('Wait for full workspace ingestion', async () => {
-      // Cross-file renameField discovers candidates through the data-owner's
-      // stored document set. During an active workspace-load session that set is
-      // only PARTIAL, and the rename correctly DECLINES rather than emit a
-      // partial edit (W-23631084 review). Gate on full ingestion so the consumer
-      // file is stored and the cross-file occurrence is found — the same gate the
-      // cross-file goto/find-references tests use before their first cross-file
-      // request.
+      // renameField declines rather than emit a partial edit while the workspace
+      // is mid-load (W-23631084). Gate on full ingestion so the consumer file is
+      // stored and its cross-file occurrence is found.
       await apexEditor.waitForWorkspaceReady();
     });
 
@@ -351,9 +328,8 @@ test.describe('Apex Rename Symbol - Field', () => {
     });
 
     await test.step('Position on the `quantity` field declaration', async () => {
-      // Line 6 is `    public Integer quantity = 0;` — `quantity` occupies
-      // columns 20-27. Position at column 23 (INSIDE the token).
-      await apexEditor.goToPosition(6, 23);
+      // Line 4 `    public Integer quantity = 0;` — column 23 is inside `quantity`.
+      await apexEditor.goToPosition(4, 23);
     });
 
     await test.step('Rename `quantity` to `amount`', async () => {
@@ -372,10 +348,7 @@ test.describe('Apex Rename Symbol - Field', () => {
     });
 
     await test.step('Assert the cross-file usages are renamed in RenameFieldClient', async () => {
-      // The WorkspaceEdit spans both files. Switch to the consumer tab and wait
-      // for the applied edit to surface, then assert both field accesses. (The
-      // editor locator excludes the lingering Monaco rename widget — see
-      // BasePage — so switching files after a rename is safe.)
+      // Switch to the consumer tab and wait for the cross-file edit to surface.
       await apexEditor.openFile('RenameFieldClient.cls');
       await apexEditor.waitForContentToInclude('model.amount');
 
@@ -387,8 +360,7 @@ test.describe('Apex Rename Symbol - Field', () => {
       // Read: `return model.amount;`
       expect(normalized).toMatch(/return\s+model\.amount\s*;/);
 
-      // The old field name must be gone from the class body (the leading comment
-      // mentions `quantity`, so slice from the class declaration to exclude it).
+      // Old name gone (slice past the comment that mentions `quantity`).
       const classBody = normalized.slice(
         normalized.indexOf('public with sharing class'),
       );

--- a/e2e-tests/tests/apex-rename-symbol.spec.ts
+++ b/e2e-tests/tests/apex-rename-symbol.spec.ts
@@ -107,8 +107,7 @@ test.describe('Apex Rename Symbol', () => {
       await apexEditor.waitForContentToInclude('renamed');
 
       const content = await apexEditor.getContent();
-      // Monaco renders indentation with non-breaking spaces (U+00A0); normalize
-      // to regular spaces so the structural assertions match reliably.
+      // Normalize non-breaking-space indentation (U+00A0) so the regexes match.
       const normalized = content.replace(/ /g, ' ');
 
       // The declaration is now `Integer renamed = 0;`
@@ -226,13 +225,9 @@ test.describe('Apex Rename Symbol', () => {
 });
 
 /**
- * E2E tests for textDocument/rename of FIELDS (W-23631087) — single-file and
- * cross-file, driven through F2 like the renameLocal tests. The cross-file case
- * proves the multi-file WorkspaceEdit from `resolveFieldRename`'s workspace scan.
- *
- * F2 fires prepareRename first (prepareProvider is advertised); field support
- * was added to DispatchPrepareRename in this story (before it, F2 on a field
- * showed "The element can't be renamed"). Each test warms the pool with a
+ * E2E for textDocument/rename of FIELDS (W-23631087) — single-file + cross-file
+ * via F2, like the renameLocal tests. F2 fires prepareRename first; field support
+ * was added to DispatchPrepareRename here. Each test warms the pool with a
  * documentSymbol probe so prepareRename can parse the live buffer before F2.
  *
  * @group rename
@@ -250,8 +245,7 @@ test.describe('Apex Rename Symbol - Field', () => {
     });
 
     await test.step('Warm the request pool for prepareRename', async () => {
-      // documentSymbol threads this file's live buffer to the pool — exactly
-      // prepareRename's precondition (see the renameLocal tests for the rationale).
+      // documentSymbol threads the live buffer to the pool — prepareRename's precondition.
       await outlineView.open();
       const mainClass = await outlineView.findSymbol(
         'RenameFieldSample',
@@ -264,8 +258,7 @@ test.describe('Apex Rename Symbol - Field', () => {
     });
 
     await test.step('Position on the `counter` field declaration', async () => {
-      // Line 4 `    public Integer counter = 0;` — column 22 is inside `counter`.
-      // An in-word column avoids prepareRename's half-open [start, end) boundary.
+      // Line 4, column 22 is inside `counter` (in-word avoids prepareRename's boundary).
       await apexEditor.goToPosition(4, 22);
     });
 
@@ -277,8 +270,7 @@ test.describe('Apex Rename Symbol - Field', () => {
       await apexEditor.waitForContentToInclude('tally');
 
       const content = await apexEditor.getContent();
-      // Monaco renders indentation with non-breaking spaces (U+00A0); normalize
-      // to regular spaces so the structural assertions match reliably.
+      // Normalize non-breaking-space indentation (U+00A0) so the regexes match.
       const normalized = content.replace(/ /g, ' ');
 
       // Declaration: `public Integer tally = 0;`
@@ -288,8 +280,7 @@ test.describe('Apex Rename Symbol - Field', () => {
       // implicit-this read: `return tally;`
       expect(normalized).toMatch(/return\s+tally\s*;/);
 
-      // Old name gone — slice from the class decl so the leading comment (which
-      // mentions `counter`) doesn't false-positive.
+      // Old name gone (slice past the comment that also says `counter`).
       const classBody = normalized.slice(
         normalized.indexOf('public with sharing class'),
       );
@@ -302,8 +293,7 @@ test.describe('Apex Rename Symbol - Field', () => {
     outlineView,
   }) => {
     await test.step('Open the consumer and declaring files', async () => {
-      // Consumer first so its cross-file usage is ingested, then the declaring
-      // file where we invoke the rename (mirrors the cross-file find-refs test).
+      // Consumer first so its usage is ingested, then the declaring file (rename source).
       await apexEditor.openFile('RenameFieldClient.cls');
       await apexEditor.waitForLanguageServerReady();
       await apexEditor.openFile('RenameFieldModel.cls');
@@ -311,9 +301,8 @@ test.describe('Apex Rename Symbol - Field', () => {
     });
 
     await test.step('Wait for full workspace ingestion', async () => {
-      // renameField declines rather than emit a partial edit while the workspace
-      // is mid-load (W-23631084). Gate on full ingestion so the consumer file is
-      // stored and its cross-file occurrence is found.
+      // renameField declines mid-load rather than emit a partial edit (W-23631084);
+      // gate on full ingestion so the consumer file is stored.
       await apexEditor.waitForWorkspaceReady();
     });
 
@@ -328,7 +317,7 @@ test.describe('Apex Rename Symbol - Field', () => {
     });
 
     await test.step('Position on the `quantity` field declaration', async () => {
-      // Line 4 `    public Integer quantity = 0;` — column 23 is inside `quantity`.
+      // Line 4, column 23 is inside `quantity`.
       await apexEditor.goToPosition(4, 23);
     });
 

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -105,7 +105,10 @@ import {
   SymbolKind,
   SymbolTable,
 } from '@salesforce/apex-lsp-parser-ast';
-import { getLogger, getAllImmutableSchemes } from '@salesforce/apex-lsp-shared';
+import {
+  getLogger,
+  MUTABLE_DOCUMENT_SCHEMES,
+} from '@salesforce/apex-lsp-shared';
 import {
   CompilationWorkerPool,
   type CompilationWorkerPoolService,
@@ -3419,16 +3422,27 @@ export async function declarationLocationForCursor(
  * (W-23631087). The graph symbol's `identifierRange` can span the field's TYPE
  * token under full ingestion (renaming `Integer` instead of the field), so the
  * declaration must come from the same parse findFieldOccurrences uses for usages.
+ * When several same-named fields exist (nested/sibling types), the one whose
+ * OWNING TYPE FQN matches `declaringTypeFqn` is chosen; ambiguity fails closed
+ * to null so the caller declines.
+ *
+ * Exported for unit testing (the disambiguation logic is otherwise reachable
+ * only through the full worker topology).
  */
-function fieldDeclarationRangeFromParse(
+export function fieldDeclarationRangeFromParse(
   table: {
     getAllSymbols?: () => Array<{
+      id?: string;
       name?: string;
       kind?: unknown;
       parentId?: string;
       location?: { identifierRange?: OccurrenceRange };
     }>;
-    getSymbolById?: (id: string) => { name?: string } | undefined;
+    getSymbolById?: (
+      id: string,
+    ) =>
+      | { id?: string; name?: string; kind?: unknown; parentId?: string }
+      | undefined;
   },
   fieldName: string,
   declaringTypeFqn: string,
@@ -3444,18 +3458,88 @@ function fieldDeclarationRangeFromParse(
   });
   if (fields.length === 0) return null;
   if (fields.length === 1) return fields[0].location!.identifierRange!;
-  // Same-named fields (nested types) → match the declaring type's leaf name.
-  const declLeaf = declaringTypeFqn.split('.').pop()?.toLowerCase();
-  for (const f of fields) {
-    const parent = f.parentId ? table.getSymbolById?.(f.parentId) : undefined;
-    if (parent?.name?.toLowerCase() === declLeaf) {
-      return f.location!.identifierRange!;
+
+  // Same-named fields across nested/sibling types in one file. Disambiguate by
+  // the OWNING TYPE FQN, not just the immediate type leaf: two types in
+  // different branches can share a leaf name (`A.Dup` vs `B.Dup`), so a
+  // leaf-only comparison could match the wrong declaration. Walk each field's
+  // parent chain (fields are parented to a generated class-body BLOCK symbol,
+  // whose own parent is the type symbol — so skip everything but type symbols)
+  // to build its owning type path, then keep the field whose path is a suffix of
+  // the requested FQN (the graph FQN may carry a namespace the standalone parse
+  // can't see). A non-unique / no match → null so the caller FAILS CLOSED
+  // (declines) rather than guessing (W-23631087 review).
+  const requestedPath = declaringTypeFqn
+    .split('.')
+    .map((s) => s.toLowerCase())
+    .filter(Boolean);
+  if (requestedPath.length === 0) return null;
+
+  const ownerTypePath = (field: { parentId?: string }): string[] => {
+    const path: string[] = [];
+    const seen = new Set<string>();
+    let cur = field.parentId
+      ? table.getSymbolById?.(field.parentId)
+      : undefined;
+    let hops = 0;
+    while (cur && hops < 50) {
+      if (cur.id) {
+        if (seen.has(cur.id)) break;
+        seen.add(cur.id);
+      }
+      const kind = String(cur.kind).toLowerCase();
+      if (
+        cur.name &&
+        (kind === 'class' ||
+          kind === 'interface' ||
+          kind === 'enum' ||
+          kind === 'trigger')
+      ) {
+        path.unshift(cur.name.toLowerCase());
+      }
+      cur = cur.parentId ? table.getSymbolById?.(cur.parentId) : undefined;
+      hops++;
     }
-  }
-  // Ambiguous same-named fields with no declaring-type match: return null so the
-  // caller FAILS CLOSED (declines) rather than guessing the first match and
-  // possibly renaming the wrong field's declaration (W-23631087 review).
+    return path;
+  };
+  const isSuffix = (path: string[], suffix: string[]): boolean => {
+    if (suffix.length === 0 || suffix.length > path.length) return false;
+    for (let i = 1; i <= suffix.length; i++) {
+      if (path[path.length - i] !== suffix[suffix.length - i]) return false;
+    }
+    return true;
+  };
+
+  const matches = fields.filter((f) =>
+    isSuffix(requestedPath, ownerTypePath(f)),
+  );
+  if (matches.length === 1) return matches[0].location!.identifierRange!;
   return null;
+}
+
+/**
+ * Decide how a field rename must proceed once occurrences are gathered but
+ * BEFORE the declaration edit is assembled (W-23631087 re-review, P1). A field
+ * rename must ALWAYS rewrite the declaration alongside its usages; the Stage 6
+ * scan gathers usages ONLY (never the declaration). So:
+ *
+ *   - declaration resolved            → `proceed` (append the declaration edit)
+ *   - no declaration, no usages       → `nothing-to-rename` (return null)
+ *   - no declaration, but usages found → `decline-partial` — emitting the usage
+ *     edits alone would leave the declaration untouched (a broken partial edit),
+ *     so FAIL CLOSED and decline.
+ *
+ * Pure + exported so the fail-closed policy is unit-tested directly (the inline
+ * branch is otherwise reachable only when the shared resolver fails to locate a
+ * declaration it earlier resolved for context — hard to force end-to-end).
+ */
+export function fieldRenameDeclarationDecision(
+  hasDeclaration: boolean,
+  occurrenceCount: number,
+): 'proceed' | 'nothing-to-rename' | 'decline-partial' {
+  if (hasDeclaration) return 'proceed';
+  if (occurrenceCount === 0) return 'nothing-to-rename';
+  return 'decline-partial';
 }
 
 /**
@@ -3954,13 +4038,15 @@ async function resolvePrepareRenameForLocal(req: PositionReq): Promise<{
  * A rename target must live in a USER-OWNED Apex source (W-23631087 review). A
  * declaration in a synthetic URI — stdlib (`apexlib://`), generated SObject
  * (`apex-sobject://`), or any other non-workspace scheme — is not editable and
- * must never be offered for rename. Uses a POSITIVE allowlist of the immutable
+ * must never be offered for rename. Uses a POSITIVE allowlist of the EDITABLE
  * document-selector schemes VS Code opens user Apex docs under (`file`,
  * `vscode-test-web`, `memfs`, `reefs`), so an unknown/future synthetic scheme
- * fails CLOSED rather than slipping through a negative check.
+ * fails CLOSED rather than slipping through a negative check. Sourced from
+ * `MUTABLE_DOCUMENT_SCHEMES` (NOT `getAllImmutableSchemes`, which includes the
+ * synthetic `apexlib` stdlib scheme this guard must reject).
  */
 const USER_OWNED_URI_SCHEMES: ReadonlySet<string> = new Set(
-  getAllImmutableSchemes(),
+  MUTABLE_DOCUMENT_SCHEMES,
 );
 const isUserOwnedApexUri = (uri: string | undefined): boolean => {
   if (!uri) return false;
@@ -4691,6 +4777,24 @@ async function resolveFieldRename(
       uri,
       req.position,
     );
+    const declDecision = fieldRenameDeclarationDecision(
+      declaration !== null,
+      allOccurrences.length,
+    );
+    if (declDecision === 'nothing-to-rename') return null;
+    if (declDecision === 'decline-partial') {
+      // Usages were found but the declaration itself could not be located.
+      // Emitting the usage edits alone would be a PARTIAL rename that leaves the
+      // declaration untouched (Stage 6 gathers usages only, never declarations),
+      // so FAIL CLOSED and decline rather than corrupt (W-23631087 review, P1).
+      const message =
+        `Cannot safely rename '${target.name}': its declaration could not be ` +
+        'located, so renaming the usages alone would leave the declaration ' +
+        'untouched (a broken partial edit). The rename is declined.';
+      emitWorkerLog('warn', `[RENAME] declined field rename — ${message}`);
+      return { error: { code: -32600, message } };
+    }
+    // declDecision === 'proceed' — declaration resolved; assemble its edit.
     if (declaration) {
       // The graph range can span the field's TYPE token under full ingestion, so
       // it must NOT be trusted. Recompute the declaration range from a standalone
@@ -4736,8 +4840,8 @@ async function resolveFieldRename(
       }
       allOccurrences.push({ uri: declaration.uri, range: declRange });
     }
-
-    if (allOccurrences.length === 0) return null;
+    // A verified declaration was pushed above (the null-declaration case returned
+    // earlier), so allOccurrences always holds at least the declaration edit here.
 
     emitWorkerLog(
       'info',

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -105,7 +105,7 @@ import {
   SymbolKind,
   SymbolTable,
 } from '@salesforce/apex-lsp-parser-ast';
-import { getLogger } from '@salesforce/apex-lsp-shared';
+import { getLogger, getAllImmutableSchemes } from '@salesforce/apex-lsp-shared';
 import {
   CompilationWorkerPool,
   type CompilationWorkerPoolService,
@@ -3452,7 +3452,10 @@ function fieldDeclarationRangeFromParse(
       return f.location!.identifierRange!;
     }
   }
-  return fields[0].location!.identifierRange!;
+  // Ambiguous same-named fields with no declaring-type match: return null so the
+  // caller FAILS CLOSED (declines) rather than guessing the first match and
+  // possibly renaming the wrong field's declaration (W-23631087 review).
+  return null;
 }
 
 /**
@@ -3948,22 +3951,33 @@ async function resolvePrepareRenameForLocal(req: PositionReq): Promise<{
 }
 
 /**
+ * A rename target must live in a USER-OWNED Apex source (W-23631087 review). A
+ * declaration in a synthetic URI — stdlib (`apexlib://`), generated SObject
+ * (`apex-sobject://`), or any other non-workspace scheme — is not editable and
+ * must never be offered for rename. Uses a POSITIVE allowlist of the immutable
+ * document-selector schemes VS Code opens user Apex docs under (`file`,
+ * `vscode-test-web`, `memfs`, `reefs`), so an unknown/future synthetic scheme
+ * fails CLOSED rather than slipping through a negative check.
+ */
+const USER_OWNED_URI_SCHEMES: ReadonlySet<string> = new Set(
+  getAllImmutableSchemes(),
+);
+const isUserOwnedApexUri = (uri: string | undefined): boolean => {
+  if (!uri) return false;
+  const colon = uri.indexOf(':');
+  if (colon <= 0) return false;
+  return USER_OWNED_URI_SCHEMES.has(uri.slice(0, colon));
+};
+
+/**
  * prepareRename for a FIELD/PROPERTY (W-23631087). Locals-only prepareRename
  * returned null for a field, so with `prepareProvider` advertised VS Code
  * wouldn't open the rename box on F2. Resolves via the same svc primitives
  * resolveFieldRename uses (no accept/decline drift), returning the cursor-
- * containing range (usage token or declaration), or null.
+ * containing range (usage token or declaration), or null. Only user-owned
+ * sources are renamable — a stdlib/generated-SObject DECLARATION is rejected
+ * even when the cursor sits on a usage in an editable file.
  */
-/**
- * A rename target must live in a USER-OWNED Apex source (W-23631087 review). A
- * synthetic stdlib URI (`apexlib://`) or a generated-SObject URI
- * (`apex-sobject://`) is not editable, so members declared there must never be
- * offered for rename. User workspace docs use `file://` (desktop) or `memfs://`
- * (web), so a negative check on the synthetic schemes avoids breaking either.
- */
-const isUserOwnedApexUri = (uri: string | undefined): boolean =>
-  !!uri && !uri.startsWith('apexlib://') && !uri.startsWith('apex-sobject://');
-
 async function resolvePrepareRenameForField(
   svc: RequestServices,
   req: PositionReq,
@@ -4713,9 +4727,10 @@ async function resolveFieldRename(
       }
       if (!declRange) {
         const message =
-          `Cannot safely rename '${target.name}': its declaration range could ` +
-          'not be verified from a standalone parse, so the rename is declined ' +
-          'rather than risk corrupting the declaration.';
+          `Cannot safely rename '${target.name}': its declaration could not be ` +
+          'located in a loaded, parseable source (the declaring file may be ' +
+          'unloaded, unparseable, or its declaration ambiguous), so the rename ' +
+          'is declined rather than risk corrupting the declaration.';
         emitWorkerLog('warn', `[RENAME] declined field rename — ${message}`);
         return { error: { code: -32600, message } };
       }

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -3415,19 +3415,12 @@ export async function declarationLocationForCursor(
 }
 
 /**
- * The declaration identifier range of a field/property, taken from a STANDALONE
- * parse of the declaring file (W-23631087).
- *
- * The graph-stored field symbol's `identifierRange` cannot be trusted for the
- * declaration edit: under full workspace ingestion it can span the field's TYPE
- * token instead of the field NAME, so using it renames `Integer` instead of the
- * field (the exact corruption the renameField e2e caught). findFieldOccurrences
- * already derives the USAGE ranges from a standalone parse; the declaration must
- * come from the SAME source so the edits are consistent. Locates the field by
- * name (Apex identifiers are case-insensitive), disambiguating by declaring-type
- * leaf when several types in the file declare the same field name. Returns the
- * parser-owned identifier range, or null when the field isn't found (caller then
- * keeps the resolved range as a best-effort fallback).
+ * Field/property declaration identifier range from a STANDALONE parse of the
+ * declaring file (W-23631087). The graph symbol's `identifierRange` can span the
+ * field's TYPE token under full ingestion (which renamed `Integer` instead of
+ * the field — caught by the e2e), so the declaration must come from the same
+ * parse findFieldOccurrences uses for usages. Disambiguates same-named fields by
+ * declaring-type leaf; null when not found (caller falls back to the graph range).
  */
 function fieldDeclarationRangeFromParse(
   table: {
@@ -3453,8 +3446,7 @@ function fieldDeclarationRangeFromParse(
   });
   if (fields.length === 0) return null;
   if (fields.length === 1) return fields[0].location!.identifierRange!;
-  // Several same-named fields (e.g. nested types) → pick the one whose immediate
-  // containing type matches the declaring type's leaf name.
+  // Same-named fields (nested types) → match the declaring type's leaf name.
   const declLeaf = declaringTypeFqn.split('.').pop()?.toLowerCase();
   for (const f of fields) {
     const parent = f.parentId ? table.getSymbolById?.(f.parentId) : undefined;
@@ -3958,33 +3950,14 @@ async function resolvePrepareRenameForLocal(req: PositionReq): Promise<{
 }
 
 /**
- * Resolve prepareRename for a FIELD or PROPERTY (W-23631087 / 4.3).
- *
- * renameField (resolveFieldRename) handles fields end-to-end, but prepareRename
- * previously recognized ONLY locals — {@link resolvePrepareRenameForLocal}'s
- * findLocalOccurrences returns null for a field cursor. Because the server
- * advertises `renameProvider: { prepareProvider: true }`, VS Code fires
- * prepareRename FIRST on F2 and REFUSES to open the rename box when it returns
- * null, so field rename was unreachable through the editor even though the
- * engine fully supports it (verified: F2 on a field showed "The element can't
- * be renamed").
- *
- * This resolves the field/property cursor to the identifier range the cursor
- * sits in, using the SAME svc primitives resolveFieldRename uses (Stage 1
- * recompile + targetSymbolForCursor + the exactCursorReference/getSymbolAtPosition
- * resolution). Sharing the resolution path means prepareRename accepts exactly
- * the field cursors the rename can service — no accept-then-decline or
- * decline-then-accept drift between the two requests.
- *
- * Like the local path, it returns the range CONTAINING the cursor — a USAGE
- * token (`this.total`, bare `total`, `x.total`) when the cursor is on one, else
- * the DECLARATION identifier (a field declaration carries no field-access
- * reference). VS Code rejects a prepareRename range that does not contain the
- * cursor, so an unresolvable cursor returns null rather than a stray range.
- *
- * @param svc The request-pool services (cursor resolution + type loading).
- * @param req The position request (cursor position + live cursor text).
- * @returns `{ range, placeholder }` where `range` contains the cursor, or `null`.
+ * prepareRename for a FIELD/PROPERTY (W-23631087). prepareRename previously
+ * recognized only locals, so with `prepareProvider` advertised VS Code fired
+ * prepareRename on F2, got null for a field, and refused to open the rename box
+ * ("The element can't be renamed") even though resolveFieldRename supports it.
+ * Resolves via the SAME svc primitives resolveFieldRename uses, so prepareRename
+ * accepts exactly the field cursors the rename can service (no accept/decline
+ * drift). Returns the range CONTAINING the cursor (usage token or declaration
+ * identifier), or null — VS Code rejects a range that doesn't contain the cursor.
  */
 async function resolvePrepareRenameForField(
   svc: RequestServices,
@@ -3998,11 +3971,8 @@ async function resolvePrepareRenameForField(
 } | null> {
   const uri = req.textDocument.uri;
   try {
-    // Stage 1 (mirrors resolveFieldRename): recompile the cursor file at full
-    // detail so the live buffer's references/declarations resolve, then load
-    // referenced types so a cursor on a cross-file field USAGE still resolves to
-    // its (possibly cross-file) declaring symbol — the resolution that confirms
-    // kind === 'field'. Ingestion-independent: driven by the live buffer.
+    // Recompile the cursor file + load referenced types so the cursor resolves
+    // (mirrors resolveFieldRename Stage 1; driven by the live buffer).
     const cursorTextAvailable = typeof req.content === 'string';
     const cursorRecompiled = await recompileCursorFileAtFullDetail(
       svc,
@@ -4013,10 +3983,8 @@ async function resolvePrepareRenameForField(
     if (!cursorRecompiled && !cursorTextAvailable) return null;
     await loadReferencedTypesForFile(svc, uri);
 
-    // Confirm the cursor is on a field/property — the same gate resolveFieldRename
-    // Stage 2 applies. Anything else (local, type, method, keyword) → null so the
-    // caller reports "can't be renamed" rather than opening a box the rename
-    // engine would then decline.
+    // Gate on field/property (same as resolveFieldRename Stage 2); anything else
+    // → null, so the caller reports "can't be renamed" instead of a dead box.
     const target = await targetSymbolForCursor(svc, uri, req.position);
     if (!target?.name) return null;
     if (target.kind !== 'field' && target.kind !== 'property') return null;
@@ -4027,10 +3995,8 @@ async function resolvePrepareRenameForField(
       character: req.position.character,
     };
 
-    // Prefer the exact parser reference under the cursor — a USAGE token such as
-    // `this.total`, a bare `total`, or `x.total`. exactCursorReference already
-    // filters to references whose identifier token contains the cursor, so its
-    // range is guaranteed to contain the cursor.
+    // Prefer the usage token under the cursor (`this.total`, `total`, `x.total`);
+    // exactCursorReference already narrows to references containing the cursor.
     const references = await svc.symbolManager.getReferencesAtPosition(
       uri,
       parserPosition,
@@ -4038,10 +4004,8 @@ async function resolvePrepareRenameForField(
     const selected = exactCursorReference(references ?? [], parserPosition);
     let cursorRange = selected.reference?.location?.identifierRange;
 
-    // No field-access reference at the cursor → the cursor is on the field's
-    // own DECLARATION identifier (declarations carry no field-access reference).
-    // Take the declaration's identifier range, but only when it contains the
-    // cursor (VS Code requires prepareRename's range to contain the cursor).
+    // No usage reference → cursor is on the declaration identifier itself. Use
+    // its range only when it contains the cursor (VS Code requires that).
     if (!cursorRange) {
       const declaration = await svc.symbolManager.getSymbolAtPosition(
         uri,
@@ -4685,14 +4649,10 @@ async function resolveFieldRename(
       req.position,
     );
     if (declaration) {
-      // The resolved (graph) range can span the field's TYPE token rather than
-      // its NAME under full workspace ingestion, which would corrupt the
-      // declaration edit (rename `Integer` instead of the field — caught by the
-      // renameField e2e). Recompute the declaration token range from a STANDALONE
-      // parse of the declaring file — the same source findFieldOccurrences uses
-      // for the (correct) usage ranges — so declaration and usages stay
-      // consistent. Fall back to the resolved range only if the field can't be
-      // located in the standalone parse (W-23631087).
+      // The graph range can span the field's TYPE token under full ingestion,
+      // corrupting the declaration edit; recompute from a standalone parse of the
+      // declaring file (as findFieldOccurrences does for usages). See
+      // fieldDeclarationRangeFromParse (W-23631087).
       let declRange = declaration.identifierRange;
       const declContent =
         declaration.uri === uri && typeof req.content === 'string'
@@ -5090,14 +5050,10 @@ const requestHandlers = {
       return resolveFieldRename(svc, req);
     },
   ),
-  // prepareRename for locals (W-23631080) and fields/properties (W-23631087).
-  // Returns the identifier range + placeholder of the renamable symbol under the
-  // cursor, or `null` when the cursor doesn't land on one. Try the local path
-  // first (cheap standalone parse); a field cursor returns null there, so fall
-  // through to the field path (recompile + svc resolution). Without the field
-  // branch, F2 on a field returns null → VS Code shows "The element can't be
-  // renamed" and never opens the rename box, so renameField is unreachable
-  // through the editor even though resolveFieldRename supports it.
+  // prepareRename for locals (W-23631080) + fields/properties (W-23631087).
+  // Local path first (cheap standalone parse); a field cursor returns null there
+  // and falls through to the field path. Without it, F2 on a field can't open
+  // the rename box even though resolveFieldRename supports the rename.
   DispatchPrepareRename: requestHandler<PositionReq>(
     'DispatchPrepareRename',
     async (svc, req) =>

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -3415,12 +3415,10 @@ export async function declarationLocationForCursor(
 }
 
 /**
- * Field/property declaration identifier range from a STANDALONE parse of the
- * declaring file (W-23631087). The graph symbol's `identifierRange` can span the
- * field's TYPE token under full ingestion (which renamed `Integer` instead of
- * the field — caught by the e2e), so the declaration must come from the same
- * parse findFieldOccurrences uses for usages. Disambiguates same-named fields by
- * declaring-type leaf; null when not found (caller falls back to the graph range).
+ * Field/property declaration range from a STANDALONE parse of the declaring file
+ * (W-23631087). The graph symbol's `identifierRange` can span the field's TYPE
+ * token under full ingestion (renaming `Integer` instead of the field), so the
+ * declaration must come from the same parse findFieldOccurrences uses for usages.
  */
 function fieldDeclarationRangeFromParse(
   table: {
@@ -3950,14 +3948,11 @@ async function resolvePrepareRenameForLocal(req: PositionReq): Promise<{
 }
 
 /**
- * prepareRename for a FIELD/PROPERTY (W-23631087). prepareRename previously
- * recognized only locals, so with `prepareProvider` advertised VS Code fired
- * prepareRename on F2, got null for a field, and refused to open the rename box
- * ("The element can't be renamed") even though resolveFieldRename supports it.
- * Resolves via the SAME svc primitives resolveFieldRename uses, so prepareRename
- * accepts exactly the field cursors the rename can service (no accept/decline
- * drift). Returns the range CONTAINING the cursor (usage token or declaration
- * identifier), or null — VS Code rejects a range that doesn't contain the cursor.
+ * prepareRename for a FIELD/PROPERTY (W-23631087). Locals-only prepareRename
+ * returned null for a field, so with `prepareProvider` advertised VS Code
+ * wouldn't open the rename box on F2. Resolves via the same svc primitives
+ * resolveFieldRename uses (no accept/decline drift), returning the cursor-
+ * containing range (usage token or declaration), or null.
  */
 async function resolvePrepareRenameForField(
   svc: RequestServices,
@@ -3971,8 +3966,7 @@ async function resolvePrepareRenameForField(
 } | null> {
   const uri = req.textDocument.uri;
   try {
-    // Recompile the cursor file + load referenced types so the cursor resolves
-    // (mirrors resolveFieldRename Stage 1; driven by the live buffer).
+    // Recompile + load referenced types so the cursor resolves (Stage 1).
     const cursorTextAvailable = typeof req.content === 'string';
     const cursorRecompiled = await recompileCursorFileAtFullDetail(
       svc,
@@ -3983,8 +3977,7 @@ async function resolvePrepareRenameForField(
     if (!cursorRecompiled && !cursorTextAvailable) return null;
     await loadReferencedTypesForFile(svc, uri);
 
-    // Gate on field/property (same as resolveFieldRename Stage 2); anything else
-    // → null, so the caller reports "can't be renamed" instead of a dead box.
+    // Gate on field/property; anything else → null ("can't be renamed").
     const target = await targetSymbolForCursor(svc, uri, req.position);
     if (!target?.name) return null;
     if (target.kind !== 'field' && target.kind !== 'property') return null;
@@ -3995,8 +3988,7 @@ async function resolvePrepareRenameForField(
       character: req.position.character,
     };
 
-    // Prefer the usage token under the cursor (`this.total`, `total`, `x.total`);
-    // exactCursorReference already narrows to references containing the cursor.
+    // Prefer the usage token under the cursor; exactCursorReference narrows to it.
     const references = await svc.symbolManager.getReferencesAtPosition(
       uri,
       parserPosition,
@@ -4004,8 +3996,7 @@ async function resolvePrepareRenameForField(
     const selected = exactCursorReference(references ?? [], parserPosition);
     let cursorRange = selected.reference?.location?.identifierRange;
 
-    // No usage reference → cursor is on the declaration identifier itself. Use
-    // its range only when it contains the cursor (VS Code requires that).
+    // Else the cursor is on the declaration; use its range if it contains the cursor.
     if (!cursorRange) {
       const declaration = await svc.symbolManager.getSymbolAtPosition(
         uri,
@@ -4649,10 +4640,8 @@ async function resolveFieldRename(
       req.position,
     );
     if (declaration) {
-      // The graph range can span the field's TYPE token under full ingestion,
-      // corrupting the declaration edit; recompute from a standalone parse of the
-      // declaring file (as findFieldOccurrences does for usages). See
-      // fieldDeclarationRangeFromParse (W-23631087).
+      // The graph range can span the TYPE token under full ingestion; recompute
+      // from a standalone parse (see fieldDeclarationRangeFromParse, W-23631087).
       let declRange = declaration.identifierRange;
       const declContent =
         declaration.uri === uri && typeof req.content === 'string'
@@ -5050,10 +5039,8 @@ const requestHandlers = {
       return resolveFieldRename(svc, req);
     },
   ),
-  // prepareRename for locals (W-23631080) + fields/properties (W-23631087).
-  // Local path first (cheap standalone parse); a field cursor returns null there
-  // and falls through to the field path. Without it, F2 on a field can't open
-  // the rename box even though resolveFieldRename supports the rename.
+  // prepareRename for locals (W-23631080) + fields (W-23631087). Local path
+  // first; a field cursor falls through to the field path (else F2 can't open).
   DispatchPrepareRename: requestHandler<PositionReq>(
     'DispatchPrepareRename',
     async (svc, req) =>

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -3907,6 +3907,124 @@ async function resolvePrepareRenameForLocal(req: PositionReq): Promise<{
 }
 
 /**
+ * Resolve prepareRename for a FIELD or PROPERTY (W-23631087 / 4.3).
+ *
+ * renameField (resolveFieldRename) handles fields end-to-end, but prepareRename
+ * previously recognized ONLY locals — {@link resolvePrepareRenameForLocal}'s
+ * findLocalOccurrences returns null for a field cursor. Because the server
+ * advertises `renameProvider: { prepareProvider: true }`, VS Code fires
+ * prepareRename FIRST on F2 and REFUSES to open the rename box when it returns
+ * null, so field rename was unreachable through the editor even though the
+ * engine fully supports it (verified: F2 on a field showed "The element can't
+ * be renamed").
+ *
+ * This resolves the field/property cursor to the identifier range the cursor
+ * sits in, using the SAME svc primitives resolveFieldRename uses (Stage 1
+ * recompile + targetSymbolForCursor + the exactCursorReference/getSymbolAtPosition
+ * resolution). Sharing the resolution path means prepareRename accepts exactly
+ * the field cursors the rename can service — no accept-then-decline or
+ * decline-then-accept drift between the two requests.
+ *
+ * Like the local path, it returns the range CONTAINING the cursor — a USAGE
+ * token (`this.total`, bare `total`, `x.total`) when the cursor is on one, else
+ * the DECLARATION identifier (a field declaration carries no field-access
+ * reference). VS Code rejects a prepareRename range that does not contain the
+ * cursor, so an unresolvable cursor returns null rather than a stray range.
+ *
+ * @param svc The request-pool services (cursor resolution + type loading).
+ * @param req The position request (cursor position + live cursor text).
+ * @returns `{ range, placeholder }` where `range` contains the cursor, or `null`.
+ */
+async function resolvePrepareRenameForField(
+  svc: RequestServices,
+  req: PositionReq,
+): Promise<{
+  range: {
+    start: { line: number; character: number };
+    end: { line: number; character: number };
+  };
+  placeholder: string;
+} | null> {
+  const uri = req.textDocument.uri;
+  try {
+    // Stage 1 (mirrors resolveFieldRename): recompile the cursor file at full
+    // detail so the live buffer's references/declarations resolve, then load
+    // referenced types so a cursor on a cross-file field USAGE still resolves to
+    // its (possibly cross-file) declaring symbol — the resolution that confirms
+    // kind === 'field'. Ingestion-independent: driven by the live buffer.
+    const cursorTextAvailable = typeof req.content === 'string';
+    const cursorRecompiled = await recompileCursorFileAtFullDetail(
+      svc,
+      uri,
+      req.content,
+      { resolveCrossFileReferences: false },
+    );
+    if (!cursorRecompiled && !cursorTextAvailable) return null;
+    await loadReferencedTypesForFile(svc, uri);
+
+    // Confirm the cursor is on a field/property — the same gate resolveFieldRename
+    // Stage 2 applies. Anything else (local, type, method, keyword) → null so the
+    // caller reports "can't be renamed" rather than opening a box the rename
+    // engine would then decline.
+    const target = await targetSymbolForCursor(svc, uri, req.position);
+    if (!target?.name) return null;
+    if (target.kind !== 'field' && target.kind !== 'property') return null;
+
+    // LSP (0-based line) → parser (1-based line, 0-based column).
+    const parserPosition = {
+      line: req.position.line + 1,
+      character: req.position.character,
+    };
+
+    // Prefer the exact parser reference under the cursor — a USAGE token such as
+    // `this.total`, a bare `total`, or `x.total`. exactCursorReference already
+    // filters to references whose identifier token contains the cursor, so its
+    // range is guaranteed to contain the cursor.
+    const references = await svc.symbolManager.getReferencesAtPosition(
+      uri,
+      parserPosition,
+    );
+    const selected = exactCursorReference(references ?? [], parserPosition);
+    let cursorRange = selected.reference?.location?.identifierRange;
+
+    // No field-access reference at the cursor → the cursor is on the field's
+    // own DECLARATION identifier (declarations carry no field-access reference).
+    // Take the declaration's identifier range, but only when it contains the
+    // cursor (VS Code requires prepareRename's range to contain the cursor).
+    if (!cursorRange) {
+      const declaration = await svc.symbolManager.getSymbolAtPosition(
+        uri,
+        parserPosition,
+        'precise',
+      );
+      const declRange = declaration?.location?.identifierRange;
+      if (declRange && positionInRange(parserPosition, declRange)) {
+        cursorRange = declRange;
+      }
+    }
+
+    if (!cursorRange) return null;
+
+    return {
+      range: {
+        start: {
+          line: cursorRange.startLine - 1,
+          character: cursorRange.startColumn,
+        },
+        end: {
+          line: cursorRange.endLine - 1,
+          character: cursorRange.endColumn,
+        },
+      },
+      placeholder: target.name,
+    };
+  } catch (err) {
+    emitWorkerLog('warn', `[PREPARE_RENAME] field failed for ${uri}: ${err}`);
+    return null;
+  }
+}
+
+/**
  * Resolve the field/property under the cursor to its declaring-type FQN AND
  * whether the field itself is effectively private (W-23631084 / W-23631086).
  * renameField needs BOTH: the declaring type anchors receiver disambiguation
@@ -4888,12 +5006,19 @@ const requestHandlers = {
       return resolveFieldRename(svc, req);
     },
   ),
-  // W-23631080: prepareRename for locals. Returns the identifier range +
-  // placeholder of the renamable local under the cursor, or `null` when the
-  // cursor doesn't land on a renamable local.
+  // prepareRename for locals (W-23631080) and fields/properties (W-23631087).
+  // Returns the identifier range + placeholder of the renamable symbol under the
+  // cursor, or `null` when the cursor doesn't land on one. Try the local path
+  // first (cheap standalone parse); a field cursor returns null there, so fall
+  // through to the field path (recompile + svc resolution). Without the field
+  // branch, F2 on a field returns null → VS Code shows "The element can't be
+  // renamed" and never opens the rename box, so renameField is unreachable
+  // through the editor even though resolveFieldRename supports it.
   DispatchPrepareRename: requestHandler<PositionReq>(
     'DispatchPrepareRename',
-    async (_svc, req) => resolvePrepareRenameForLocal(req),
+    async (svc, req) =>
+      (await resolvePrepareRenameForLocal(req)) ??
+      (await resolvePrepareRenameForField(svc, req)),
   ),
   DispatchImplementation: effectRequestHandler<PositionReq>(
     'DispatchImplementation',

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -3954,6 +3954,16 @@ async function resolvePrepareRenameForLocal(req: PositionReq): Promise<{
  * resolveFieldRename uses (no accept/decline drift), returning the cursor-
  * containing range (usage token or declaration), or null.
  */
+/**
+ * A rename target must live in a USER-OWNED Apex source (W-23631087 review). A
+ * synthetic stdlib URI (`apexlib://`) or a generated-SObject URI
+ * (`apex-sobject://`) is not editable, so members declared there must never be
+ * offered for rename. User workspace docs use `file://` (desktop) or `memfs://`
+ * (web), so a negative check on the synthetic schemes avoids breaking either.
+ */
+const isUserOwnedApexUri = (uri: string | undefined): boolean =>
+  !!uri && !uri.startsWith('apexlib://') && !uri.startsWith('apex-sobject://');
+
 async function resolvePrepareRenameForField(
   svc: RequestServices,
   req: PositionReq,
@@ -3977,16 +3987,24 @@ async function resolvePrepareRenameForField(
     if (!cursorRecompiled && !cursorTextAvailable) return null;
     await loadReferencedTypesForFile(svc, uri);
 
-    // Gate on field/property; anything else → null ("can't be renamed").
-    const target = await targetSymbolForCursor(svc, uri, req.position);
-    if (!target?.name) return null;
-    if (target.kind !== 'field' && target.kind !== 'property') return null;
-
     // LSP (0-based line) → parser (1-based line, 0-based column).
     const parserPosition = {
       line: req.position.line + 1,
       character: req.position.character,
     };
+
+    // Resolve the cursor's declaration symbol to gate on BOTH kind and source
+    // provenance (W-23631087 review, P1): only a field/property declared in a
+    // USER-OWNED Apex source is renamable. A stdlib (`apexlib://`) or generated-
+    // SObject (`apex-sobject://`) member must not be advertised as renamable, or
+    // F2 would open the rename box on something we cannot (and must not) edit.
+    const symbol = await resolveCursorSymbol(svc, uri, parserPosition);
+    if (!symbol?.name) return null;
+    const kind = typeof symbol.kind === 'string' ? symbol.kind : undefined;
+    if (kind !== 'field' && kind !== 'property') return null;
+    if (!isUserOwnedApexUri((symbol as { fileUri?: string }).fileUri)) {
+      return null;
+    }
 
     // Prefer the usage token under the cursor; exactCursorReference narrows to it.
     const references = await svc.symbolManager.getReferencesAtPosition(
@@ -3996,20 +4014,33 @@ async function resolvePrepareRenameForField(
     const selected = exactCursorReference(references ?? [], parserPosition);
     let cursorRange = selected.reference?.location?.identifierRange;
 
-    // Else the cursor is on the declaration; use its range if it contains the cursor.
+    // Else the cursor is on the declaration identifier itself.
     if (!cursorRange) {
       const declaration = await svc.symbolManager.getSymbolAtPosition(
         uri,
         parserPosition,
         'precise',
       );
-      const declRange = declaration?.location?.identifierRange;
-      if (declRange && positionInRange(parserPosition, declRange)) {
-        cursorRange = declRange;
-      }
+      cursorRange = declaration?.location?.identifierRange;
     }
 
-    if (!cursorRange) return null;
+    // Half-open containment (W-23631087 review, P2): parser identifier ranges are
+    // [start, end), so a cursor AT endColumn sits one past the identifier and must
+    // be rejected — matching resolvePrepareRenameForLocal. `positionInRange` uses
+    // an INCLUSIVE end (`> endColumn`), which would wrongly accept that cursor, so
+    // verify half-open containment here before returning any range.
+    const containsCursor = (r: OccurrenceRange): boolean => {
+      const afterStart =
+        r.startLine < parserPosition.line ||
+        (r.startLine === parserPosition.line &&
+          r.startColumn <= parserPosition.character);
+      const beforeEnd =
+        r.endLine > parserPosition.line ||
+        (r.endLine === parserPosition.line &&
+          r.endColumn > parserPosition.character);
+      return afterStart && beforeEnd;
+    };
+    if (!cursorRange || !containsCursor(cursorRange)) return null;
 
     return {
       range: {
@@ -4022,7 +4053,7 @@ async function resolvePrepareRenameForField(
           character: cursorRange.endColumn,
         },
       },
-      placeholder: target.name,
+      placeholder: symbol.name,
     };
   } catch (err) {
     emitWorkerLog('warn', `[PREPARE_RENAME] field failed for ${uri}: ${err}`);
@@ -4069,6 +4100,13 @@ async function resolveFieldContextForCursor(
     };
     const symbol = await resolveCursorSymbol(svc, uri, parserPosition);
     if (!symbol) return null;
+    // Provenance guard (W-23631087 review, P1): only a field declared in a
+    // user-owned Apex source is renamable. A stdlib/generated-SObject field
+    // resolves to a synthetic URI and must not produce a WorkspaceEdit — return
+    // null so resolveFieldRename declines (mirrors the prepare-side guard).
+    if (!isUserOwnedApexUri((symbol as { fileUri?: string }).fileUri)) {
+      return null;
+    }
     const containingType = await svc.symbolManager.getContainingType(symbol);
     if (!containingType) return null;
     const declaringTypeFqn =
@@ -4640,13 +4678,17 @@ async function resolveFieldRename(
       req.position,
     );
     if (declaration) {
-      // The graph range can span the TYPE token under full ingestion; recompute
-      // from a standalone parse (see fieldDeclarationRangeFromParse, W-23631087).
-      let declRange = declaration.identifierRange;
+      // The graph range can span the field's TYPE token under full ingestion, so
+      // it must NOT be trusted. Recompute the declaration range from a standalone
+      // parse of the declaring file; if that verified range is unavailable (no
+      // content, parse failure, or no match) FAIL CLOSED — emitting the graph
+      // range risks renaming the type token (`Integer`) instead of the field
+      // (W-23631087 review, P1). Never fall back to the suspect range.
       const declContent =
         declaration.uri === uri && typeof req.content === 'string'
           ? req.content
           : candidates.find((c) => c.uri === declaration.uri)?.content;
+      let declRange: OccurrenceRange | null = null;
       if (declContent) {
         try {
           const declTable = new SymbolTable();
@@ -4660,15 +4702,22 @@ async function resolveFieldRename(
             declCompiled?.result instanceof SymbolTable
               ? declCompiled.result
               : declTable;
-          const standaloneRange = fieldDeclarationRangeFromParse(
+          declRange = fieldDeclarationRangeFromParse(
             parsedDeclTable as never,
             target.name,
             declaringType,
           );
-          if (standaloneRange) declRange = standaloneRange;
         } catch {
-          // Keep the resolved range if the standalone re-parse fails.
+          declRange = null;
         }
+      }
+      if (!declRange) {
+        const message =
+          `Cannot safely rename '${target.name}': its declaration range could ` +
+          'not be verified from a standalone parse, so the rename is declined ' +
+          'rather than risk corrupting the declaration.';
+        emitWorkerLog('warn', `[RENAME] declined field rename — ${message}`);
+        return { error: { code: -32600, message } };
       }
       allOccurrences.push({ uri: declaration.uri, range: declRange });
     }

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -3415,6 +3415,57 @@ export async function declarationLocationForCursor(
 }
 
 /**
+ * The declaration identifier range of a field/property, taken from a STANDALONE
+ * parse of the declaring file (W-23631087).
+ *
+ * The graph-stored field symbol's `identifierRange` cannot be trusted for the
+ * declaration edit: under full workspace ingestion it can span the field's TYPE
+ * token instead of the field NAME, so using it renames `Integer` instead of the
+ * field (the exact corruption the renameField e2e caught). findFieldOccurrences
+ * already derives the USAGE ranges from a standalone parse; the declaration must
+ * come from the SAME source so the edits are consistent. Locates the field by
+ * name (Apex identifiers are case-insensitive), disambiguating by declaring-type
+ * leaf when several types in the file declare the same field name. Returns the
+ * parser-owned identifier range, or null when the field isn't found (caller then
+ * keeps the resolved range as a best-effort fallback).
+ */
+function fieldDeclarationRangeFromParse(
+  table: {
+    getAllSymbols?: () => Array<{
+      name?: string;
+      kind?: unknown;
+      parentId?: string;
+      location?: { identifierRange?: OccurrenceRange };
+    }>;
+    getSymbolById?: (id: string) => { name?: string } | undefined;
+  },
+  fieldName: string,
+  declaringTypeFqn: string,
+): OccurrenceRange | null {
+  const targetName = fieldName.toLowerCase();
+  const fields = (table.getAllSymbols?.() ?? []).filter((s) => {
+    const kind = String(s?.kind).toLowerCase();
+    return (
+      s?.name?.toLowerCase() === targetName &&
+      (kind === 'field' || kind === 'property') &&
+      !!s.location?.identifierRange
+    );
+  });
+  if (fields.length === 0) return null;
+  if (fields.length === 1) return fields[0].location!.identifierRange!;
+  // Several same-named fields (e.g. nested types) → pick the one whose immediate
+  // containing type matches the declaring type's leaf name.
+  const declLeaf = declaringTypeFqn.split('.').pop()?.toLowerCase();
+  for (const f of fields) {
+    const parent = f.parentId ? table.getSymbolById?.(f.parentId) : undefined;
+    if (parent?.name?.toLowerCase() === declLeaf) {
+      return f.location!.identifierRange!;
+    }
+  }
+  return fields[0].location!.identifierRange!;
+}
+
+/**
  * The resolved target symbol plus every occurrence of it across the workspace,
  * as produced by {@link resolveOccurrencesForCursor}. `null` occurrences here
  * never happen — the helper returns the whole struct as `null` instead — but
@@ -4634,10 +4685,43 @@ async function resolveFieldRename(
       req.position,
     );
     if (declaration) {
-      allOccurrences.push({
-        uri: declaration.uri,
-        range: declaration.identifierRange,
-      });
+      // The resolved (graph) range can span the field's TYPE token rather than
+      // its NAME under full workspace ingestion, which would corrupt the
+      // declaration edit (rename `Integer` instead of the field — caught by the
+      // renameField e2e). Recompute the declaration token range from a STANDALONE
+      // parse of the declaring file — the same source findFieldOccurrences uses
+      // for the (correct) usage ranges — so declaration and usages stay
+      // consistent. Fall back to the resolved range only if the field can't be
+      // located in the standalone parse (W-23631087).
+      let declRange = declaration.identifierRange;
+      const declContent =
+        declaration.uri === uri && typeof req.content === 'string'
+          ? req.content
+          : candidates.find((c) => c.uri === declaration.uri)?.content;
+      if (declContent) {
+        try {
+          const declTable = new SymbolTable();
+          const declCompiled = new CompilerService().compile(
+            declContent,
+            declaration.uri,
+            new FullSymbolCollectorListener(declTable),
+            { collectReferences: true, resolveReferences: true },
+          );
+          const parsedDeclTable =
+            declCompiled?.result instanceof SymbolTable
+              ? declCompiled.result
+              : declTable;
+          const standaloneRange = fieldDeclarationRangeFromParse(
+            parsedDeclTable as never,
+            target.name,
+            declaringType,
+          );
+          if (standaloneRange) declRange = standaloneRange;
+        } catch {
+          // Keep the resolved range if the standalone re-parse fails.
+        }
+      }
+      allOccurrences.push({ uri: declaration.uri, range: declRange });
     }
 
     if (allOccurrences.length === 0) return null;

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -107,7 +107,7 @@ import {
 } from '@salesforce/apex-lsp-parser-ast';
 import {
   getLogger,
-  MUTABLE_DOCUMENT_SCHEMES,
+  READONLY_SYNTHETIC_SCHEMES,
 } from '@salesforce/apex-lsp-shared';
 import {
   CompilationWorkerPool,
@@ -4035,24 +4035,30 @@ async function resolvePrepareRenameForLocal(req: PositionReq): Promise<{
 }
 
 /**
- * A rename target must live in a USER-OWNED Apex source (W-23631087 review). A
- * declaration in a synthetic URI — stdlib (`apexlib://`), generated SObject
- * (`apex-sobject://`), or any other non-workspace scheme — is not editable and
- * must never be offered for rename. Uses a POSITIVE allowlist of the EDITABLE
- * document-selector schemes VS Code opens user Apex docs under (`file`,
- * `vscode-test-web`, `memfs`, `reefs`), so an unknown/future synthetic scheme
- * fails CLOSED rather than slipping through a negative check. Sourced from
- * `MUTABLE_DOCUMENT_SCHEMES` (NOT `getAllImmutableSchemes`, which includes the
- * synthetic `apexlib` stdlib scheme this guard must reject).
+ * A rename target must live in a USER-OWNED (editable) Apex source (W-23631087
+ * review). A declaration in a synthetic, READ-ONLY URI — stdlib (`apexlib://`) or
+ * generated SObject (`apex-sobject://`) — is not editable and must never be
+ * offered for rename or edited via a virtual-resource URI.
+ *
+ * Rejects the CLOSED set of server-generated read-only schemes
+ * (`READONLY_SYNTHETIC_SCHEMES`) rather than allow-listing editable schemes: the
+ * editable set is open-ended (the four `MUTABLE_DOCUMENT_SCHEMES` defaults PLUS
+ * any `apex.environment.additionalDocumentSchemes` a client configures, which
+ * apply to all capabilities by default) and those custom schemes are not synced
+ * to the worker. A positive allowlist therefore wrongly declined editable
+ * documents on a configured scheme (e.g. `orgtest://`), making rename behave
+ * inconsistently by symbol kind vs. renameLocal — the issue this blocklist fixes
+ * (W-23631087 re-review). The synthetic schemes are ones the SERVER mints, so a
+ * blocklist over that set stays authoritative.
  */
-const USER_OWNED_URI_SCHEMES: ReadonlySet<string> = new Set(
-  MUTABLE_DOCUMENT_SCHEMES,
+const READONLY_URI_SCHEMES: ReadonlySet<string> = new Set(
+  READONLY_SYNTHETIC_SCHEMES,
 );
 const isUserOwnedApexUri = (uri: string | undefined): boolean => {
   if (!uri) return false;
   const colon = uri.indexOf(':');
   if (colon <= 0) return false;
-  return USER_OWNED_URI_SCHEMES.has(uri.slice(0, colon));
+  return !READONLY_URI_SCHEMES.has(uri.slice(0, colon).toLowerCase());
 };
 
 /**

--- a/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
@@ -550,6 +550,155 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
     expect(result).toBeNull();
   }, 120_000);
 
+  // W-23631087 (4.3): prepareRename must recognize FIELDS, not just locals.
+  // resolveFieldRename supports fields end-to-end, but until the field branch was
+  // added to DispatchPrepareRename, F2 on a field returned null and VS Code
+  // refused to open the rename box (prepareProvider is advertised, so it gates
+  // F2) — making field rename unreachable through the editor. These two tests
+  // prove prepareRename returns the cursor-containing identifier range for a
+  // field declaration AND a field usage.
+  const PREP_FIELD_URI = 'file:///test/PrepareField.cls';
+  const PREP_FIELD_SRC = `public class PrepareField {
+    public Integer value;
+
+    public void useIt() {
+        value = 5;
+        Integer x = value;
+    }
+}`;
+
+  it('returns prepareRename range for a field DECLARATION cursor (W-23631087)', async () => {
+    const program = Effect.gen(function* () {
+      const topology = yield* initializeTopology({
+        poolSize: 1,
+        enableResourceLoader: true,
+        logger,
+        logLevel: LOG_LEVEL,
+        compilationPoolSize: COMPILATION_POOL_SIZE,
+        compilationConcurrency: 1,
+        workerLayerFactory,
+      });
+      const dispatcher = makeWorkerDispatcher(topology, logger, (uri) =>
+        uri === PREP_FIELD_URI ? PREP_FIELD_SRC : undefined,
+      );
+      wireProductionMediator(topology, dispatcher, logger);
+      yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentOpen', {
+          document: {
+            uri: PREP_FIELD_URI,
+            languageId: 'apex',
+            version: 1,
+            getText: () => PREP_FIELD_SRC,
+          },
+          textDocument: { uri: PREP_FIELD_URI },
+          text: PREP_FIELD_SRC,
+        }),
+      );
+
+      // Cursor on the `value` DECLARATION (LSP line 1 `    public Integer value;`,
+      // char 23 — inside the `value` token). A field declaration carries no
+      // field-access reference, so this exercises the getSymbolAtPosition branch.
+      const result = yield* Effect.promise(() =>
+        dispatcher.dispatch('prepareRename', {
+          textDocument: { uri: PREP_FIELD_URI },
+          position: { line: 1, character: 23 },
+          content: PREP_FIELD_SRC,
+        }),
+      );
+
+      return { result };
+    }).pipe(Effect.scoped);
+
+    const { result } = await Effect.runPromise(program);
+    logger.debug(
+      `[prepare-rename:field-declaration] ${JSON.stringify(result)}`,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('range');
+    const prepareInfo = result as {
+      range: {
+        start: { line: number; character: number };
+        end: { line: number; character: number };
+      };
+      placeholder: string;
+    };
+    // The declaration is on LSP line 1, and the range must CONTAIN the cursor
+    // (char 23) — VS Code rejects a prepareRename range that doesn't.
+    expect(prepareInfo.range.start.line).toBe(1);
+    expect(prepareInfo.range.end.line).toBe(1);
+    expect(prepareInfo.range.start.character).toBeLessThanOrEqual(23);
+    expect(prepareInfo.range.end.character).toBeGreaterThan(23);
+    expect(prepareInfo.placeholder).toBe('value');
+  }, 120_000);
+
+  it('returns prepareRename range for a field USAGE cursor (W-23631087)', async () => {
+    const program = Effect.gen(function* () {
+      const topology = yield* initializeTopology({
+        poolSize: 1,
+        enableResourceLoader: true,
+        logger,
+        logLevel: LOG_LEVEL,
+        compilationPoolSize: COMPILATION_POOL_SIZE,
+        compilationConcurrency: 1,
+        workerLayerFactory,
+      });
+      const dispatcher = makeWorkerDispatcher(topology, logger, (uri) =>
+        uri === PREP_FIELD_URI ? PREP_FIELD_SRC : undefined,
+      );
+      wireProductionMediator(topology, dispatcher, logger);
+      yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentOpen', {
+          document: {
+            uri: PREP_FIELD_URI,
+            languageId: 'apex',
+            version: 1,
+            getText: () => PREP_FIELD_SRC,
+          },
+          textDocument: { uri: PREP_FIELD_URI },
+          text: PREP_FIELD_SRC,
+        }),
+      );
+
+      // Cursor on the implicit-this `value` USAGE (LSP line 4 `        value = 5;`,
+      // char 10 — inside the `value` token). prepareRename must return THIS usage
+      // token's range (VS Code requires the range to contain the cursor), not the
+      // declaration's — exercising the exactCursorReference branch.
+      const result = yield* Effect.promise(() =>
+        dispatcher.dispatch('prepareRename', {
+          textDocument: { uri: PREP_FIELD_URI },
+          position: { line: 4, character: 10 },
+          content: PREP_FIELD_SRC,
+        }),
+      );
+
+      return { result };
+    }).pipe(Effect.scoped);
+
+    const { result } = await Effect.runPromise(program);
+    logger.debug(`[prepare-rename:field-usage] ${JSON.stringify(result)}`);
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('range');
+    const prepareInfo = result as {
+      range: {
+        start: { line: number; character: number };
+        end: { line: number; character: number };
+      };
+      placeholder: string;
+    };
+    // The usage is on LSP line 4, and the returned range must contain the cursor.
+    expect(prepareInfo.range.start.line).toBe(4);
+    expect(prepareInfo.range.end.line).toBe(4);
+    expect(prepareInfo.range.start.character).toBeLessThanOrEqual(10);
+    expect(prepareInfo.range.end.character).toBeGreaterThan(10);
+    expect(prepareInfo.placeholder).toBe('value');
+  }, 120_000);
+
   // W-23631084: Field rename tests (4.1)
   describe('renameField cross-file with receiver-type disambiguation (W-23631084)', () => {
     // Account.cls declares a `total` field, used in Caller.cls as `acct.total`.
@@ -804,6 +953,21 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
       } | null;
       expect(errorResult?.changes).toBeUndefined();
       expect(errorResult?.error).toBeDefined();
+      // Nit (W-23631084 final review): assert the decline is the ACTIVE-LOAD
+      // completeness guard, not just any error. A bare `error).toBeDefined()`
+      // would pass if an unrelated earlier failure (e.g. a validation decline or
+      // a thrown exception elsewhere) aborted the rename, so it would not prove
+      // this test still exercises the intended guard. Key off the guard's
+      // own signal: the -32600 InvalidRequest code and the active-load message
+      // ("Workspace load session still active" + "incomplete"), which
+      // FindOccurrenceCandidates raises and resolveFieldRename surfaces verbatim
+      // through the Stage-5 decline. If the guard regresses or a different path
+      // declines, these fail loudly.
+      expect(errorResult?.error?.code).toBe(-32600);
+      expect(errorResult?.error?.message).toMatch(
+        /workspace load session still active/i,
+      );
+      expect(errorResult?.error?.message).toMatch(/incomplete/i);
     }, 120_000);
 
     it('declines rename when another file has an unprovable non-local receiver (W-23631086 #1)', async () => {

--- a/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
@@ -550,13 +550,9 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
     expect(result).toBeNull();
   }, 120_000);
 
-  // W-23631087 (4.3): prepareRename must recognize FIELDS, not just locals.
-  // resolveFieldRename supports fields end-to-end, but until the field branch was
-  // added to DispatchPrepareRename, F2 on a field returned null and VS Code
-  // refused to open the rename box (prepareProvider is advertised, so it gates
-  // F2) — making field rename unreachable through the editor. These two tests
-  // prove prepareRename returns the cursor-containing identifier range for a
-  // field declaration AND a field usage.
+  // W-23631087: prepareRename must recognize FIELDS, not just locals — otherwise
+  // F2 on a field returns null and VS Code won't open the rename box. These prove
+  // it returns the cursor-containing range for a field declaration AND a usage.
   const PREP_FIELD_URI = 'file:///test/PrepareField.cls';
   const PREP_FIELD_SRC = `public class PrepareField {
     public Integer value;
@@ -597,9 +593,8 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
         }),
       );
 
-      // Cursor on the `value` DECLARATION (LSP line 1 `    public Integer value;`,
-      // char 23 — inside the `value` token). A field declaration carries no
-      // field-access reference, so this exercises the getSymbolAtPosition branch.
+      // Cursor on the `value` DECLARATION (LSP line 1, char 23) — no field-access
+      // reference there, so this exercises the getSymbolAtPosition branch.
       const result = yield* Effect.promise(() =>
         dispatcher.dispatch('prepareRename', {
           textDocument: { uri: PREP_FIELD_URI },
@@ -664,10 +659,9 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
         }),
       );
 
-      // Cursor on the implicit-this `value` USAGE (LSP line 4 `        value = 5;`,
-      // char 10 — inside the `value` token). prepareRename must return THIS usage
-      // token's range (VS Code requires the range to contain the cursor), not the
-      // declaration's — exercising the exactCursorReference branch.
+      // Cursor on the `value` USAGE (LSP line 4, char 10). prepareRename must
+      // return the usage token's range, not the declaration's — exercising the
+      // exactCursorReference branch.
       const result = yield* Effect.promise(() =>
         dispatcher.dispatch('prepareRename', {
           textDocument: { uri: PREP_FIELD_URI },
@@ -953,16 +947,10 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
       } | null;
       expect(errorResult?.changes).toBeUndefined();
       expect(errorResult?.error).toBeDefined();
-      // Nit (W-23631084 final review): assert the decline is the ACTIVE-LOAD
-      // completeness guard, not just any error. A bare `error).toBeDefined()`
-      // would pass if an unrelated earlier failure (e.g. a validation decline or
-      // a thrown exception elsewhere) aborted the rename, so it would not prove
-      // this test still exercises the intended guard. Key off the guard's
-      // own signal: the -32600 InvalidRequest code and the active-load message
-      // ("Workspace load session still active" + "incomplete"), which
-      // FindOccurrenceCandidates raises and resolveFieldRename surfaces verbatim
-      // through the Stage-5 decline. If the guard regresses or a different path
-      // declines, these fail loudly.
+      // Nit (W-23631084 final review): assert this is the ACTIVE-LOAD guard, not
+      // just any error — a bare `toBeDefined()` would pass on an unrelated
+      // failure. Key off the guard's own signal (-32600 + the active-load
+      // message) so a regression or a different decline path fails loudly.
       expect(errorResult?.error?.code).toBe(-32600);
       expect(errorResult?.error?.message).toMatch(
         /workspace load session still active/i,

--- a/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
@@ -740,6 +740,80 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
     expect(prepareInfo.placeholder).toBe('value');
   }, 120_000);
 
+  // W-23631087 re-review (P1): the provenance guard must reject STANDARD-LIBRARY
+  // declarations. `apexlib://` is a synthetic read-only scheme; a field declared
+  // there must never open the rename box (prepareRename → null) nor produce a
+  // WorkspaceEdit (rename → null). Regression: the guard was sourced from
+  // getAllImmutableSchemes(), which INCLUDES `apexlib`, so stdlib members slipped
+  // through. It now uses MUTABLE_DOCUMENT_SCHEMES, which excludes `apexlib`.
+  const STDLIB_FIELD_URI = 'apexlib://test/StdLibType.cls';
+  const STDLIB_FIELD_SRC = `public class StdLibType {
+    public Integer value;
+}`;
+
+  it('declines prepareRename AND rename for a standard-library (apexlib://) field (W-23631087 re-review)', async () => {
+    const program = Effect.gen(function* () {
+      const topology = yield* initializeTopology({
+        poolSize: 1,
+        enableResourceLoader: true,
+        logger,
+        logLevel: LOG_LEVEL,
+        compilationPoolSize: COMPILATION_POOL_SIZE,
+        compilationConcurrency: 1,
+        workerLayerFactory,
+      });
+      const dispatcher = makeWorkerDispatcher(topology, logger, (uri) =>
+        uri === STDLIB_FIELD_URI ? STDLIB_FIELD_SRC : undefined,
+      );
+      wireProductionMediator(topology, dispatcher, logger);
+      yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentOpen', {
+          document: {
+            uri: STDLIB_FIELD_URI,
+            languageId: 'apex',
+            version: 1,
+            getText: () => STDLIB_FIELD_SRC,
+          },
+          textDocument: { uri: STDLIB_FIELD_URI },
+          text: STDLIB_FIELD_SRC,
+        }),
+      );
+
+      // Cursor on `value` DECLARATION (LSP line 1, char 23).
+      const prepare = yield* Effect.promise(() =>
+        dispatcher.dispatch('prepareRename', {
+          textDocument: { uri: STDLIB_FIELD_URI },
+          position: { line: 1, character: 23 },
+          content: STDLIB_FIELD_SRC,
+        }),
+      );
+      const rename = yield* Effect.promise(() =>
+        dispatcher.dispatch('rename', {
+          textDocument: { uri: STDLIB_FIELD_URI },
+          position: { line: 1, character: 23 },
+          newName: 'amount',
+          content: STDLIB_FIELD_SRC,
+        }),
+      );
+
+      return { prepare, rename };
+    }).pipe(Effect.scoped);
+
+    const { prepare, rename } = await Effect.runPromise(program);
+    logger.debug(
+      `[rename-field:stdlib-guard] prepare=${JSON.stringify(prepare)} ` +
+        `rename=${JSON.stringify(rename)}`,
+    );
+
+    // prepareRename must NOT offer the stdlib field.
+    expect(prepare).toBeNull();
+    // rename must NOT emit any edit for the stdlib declaration.
+    const edit = rename as { changes?: Record<string, unknown> } | null;
+    expect(edit?.changes).toBeUndefined();
+  }, 120_000);
+
   // W-23631084: Field rename tests (4.1)
   describe('renameField cross-file with receiver-type disambiguation (W-23631084)', () => {
     // Account.cls declares a `total` field, used in Caller.cls as `acct.total`.
@@ -1357,6 +1431,16 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
       // OuterTwo.cls's same-named inner field must be untouched.
       expect(edit!.changes![OUTER_TWO_URI]).toBeUndefined();
     }, 120_000);
+
+    // NOTE (W-23631087 re-review, P2): the OWNING-FQN disambiguation inside
+    // fieldDeclarationRangeFromParse is covered deterministically by a unit test
+    // (test/unit/fieldDeclarationRangeFromParse.node.test.ts). An end-to-end
+    // same-leaf topology test is intentionally NOT added here: when two nested
+    // types in ONE file share both a leaf name AND a field name, the UPSTREAM
+    // cursor→containing-type resolution (shared graph infra) resolves to the
+    // FIRST same-named type regardless of cursor position, so the helper receives
+    // an already-wrong declaringType. That upstream limitation is out of scope
+    // for this field-rename change and tracked separately.
 
     // W-23631084 P1: an IN-FILE-resolvable static qualifier (`Account.total`
     // inside a NESTED class of `Account`) must be renamed end-to-end without a

--- a/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
@@ -626,6 +626,57 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
     expect(prepareInfo.placeholder).toBe('value');
   }, 120_000);
 
+  it('returns null from field prepareRename at the identifier-end boundary (W-23631087 review)', async () => {
+    // `value` on LSP line 1 occupies chars 19-24; the identifier range is half-open
+    // [19, 24), so a cursor at char 24 sits one past the last char and must be
+    // REJECTED (mirrors resolvePrepareRenameForLocal). Guards against the inclusive
+    // positionInRange end check accepting a cursor immediately after the identifier.
+    const program = Effect.gen(function* () {
+      const topology = yield* initializeTopology({
+        poolSize: 1,
+        enableResourceLoader: true,
+        logger,
+        logLevel: LOG_LEVEL,
+        compilationPoolSize: COMPILATION_POOL_SIZE,
+        compilationConcurrency: 1,
+        workerLayerFactory,
+      });
+      const dispatcher = makeWorkerDispatcher(topology, logger, (uri) =>
+        uri === PREP_FIELD_URI ? PREP_FIELD_SRC : undefined,
+      );
+      wireProductionMediator(topology, dispatcher, logger);
+      yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentOpen', {
+          document: {
+            uri: PREP_FIELD_URI,
+            languageId: 'apex',
+            version: 1,
+            getText: () => PREP_FIELD_SRC,
+          },
+          textDocument: { uri: PREP_FIELD_URI },
+          text: PREP_FIELD_SRC,
+        }),
+      );
+
+      const result = yield* Effect.promise(() =>
+        dispatcher.dispatch('prepareRename', {
+          textDocument: { uri: PREP_FIELD_URI },
+          position: { line: 1, character: 24 }, // one past `value`
+          content: PREP_FIELD_SRC,
+        }),
+      );
+
+      return { result };
+    }).pipe(Effect.scoped);
+
+    const { result } = await Effect.runPromise(program);
+    logger.debug(`[prepare-rename:field-boundary] ${JSON.stringify(result)}`);
+
+    expect(result).toBeNull();
+  }, 120_000);
+
   it('returns prepareRename range for a field USAGE cursor (W-23631087)', async () => {
     const program = Effect.gen(function* () {
       const topology = yield* initializeTopology({

--- a/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
@@ -550,9 +550,8 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
     expect(result).toBeNull();
   }, 120_000);
 
-  // W-23631087: prepareRename must recognize FIELDS, not just locals — otherwise
-  // F2 on a field returns null and VS Code won't open the rename box. These prove
-  // it returns the cursor-containing range for a field declaration AND a usage.
+  // W-23631087: prepareRename must recognize FIELDS, not just locals (else F2 on
+  // a field won't open the box). Covers a declaration cursor AND a usage cursor.
   const PREP_FIELD_URI = 'file:///test/PrepareField.cls';
   const PREP_FIELD_SRC = `public class PrepareField {
     public Integer value;
@@ -593,8 +592,7 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
         }),
       );
 
-      // Cursor on the `value` DECLARATION (LSP line 1, char 23) — no field-access
-      // reference there, so this exercises the getSymbolAtPosition branch.
+      // `value` DECLARATION (LSP line 1, char 23) — exercises getSymbolAtPosition.
       const result = yield* Effect.promise(() =>
         dispatcher.dispatch('prepareRename', {
           textDocument: { uri: PREP_FIELD_URI },
@@ -620,8 +618,7 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
       };
       placeholder: string;
     };
-    // The declaration is on LSP line 1, and the range must CONTAIN the cursor
-    // (char 23) — VS Code rejects a prepareRename range that doesn't.
+    // On LSP line 1, and the range must contain the cursor (char 23).
     expect(prepareInfo.range.start.line).toBe(1);
     expect(prepareInfo.range.end.line).toBe(1);
     expect(prepareInfo.range.start.character).toBeLessThanOrEqual(23);
@@ -659,9 +656,8 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
         }),
       );
 
-      // Cursor on the `value` USAGE (LSP line 4, char 10). prepareRename must
-      // return the usage token's range, not the declaration's — exercising the
-      // exactCursorReference branch.
+      // `value` USAGE (LSP line 4, char 10) — must return the usage range, not the
+      // declaration's (exercises exactCursorReference).
       const result = yield* Effect.promise(() =>
         dispatcher.dispatch('prepareRename', {
           textDocument: { uri: PREP_FIELD_URI },
@@ -947,10 +943,9 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
       } | null;
       expect(errorResult?.changes).toBeUndefined();
       expect(errorResult?.error).toBeDefined();
-      // Nit (W-23631084 final review): assert this is the ACTIVE-LOAD guard, not
-      // just any error — a bare `toBeDefined()` would pass on an unrelated
-      // failure. Key off the guard's own signal (-32600 + the active-load
-      // message) so a regression or a different decline path fails loudly.
+      // Nit (W-23631084 review): assert this is the ACTIVE-LOAD guard, not any
+      // error — key off its signal (-32600 + the active-load message) so a
+      // regression or different decline path fails loudly.
       expect(errorResult?.error?.code).toBe(-32600);
       expect(errorResult?.error?.message).toMatch(
         /workspace load session still active/i,

--- a/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
@@ -743,9 +743,9 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
   // W-23631087 re-review (P1): the provenance guard must reject STANDARD-LIBRARY
   // declarations. `apexlib://` is a synthetic read-only scheme; a field declared
   // there must never open the rename box (prepareRename → null) nor produce a
-  // WorkspaceEdit (rename → null). Regression: the guard was sourced from
-  // getAllImmutableSchemes(), which INCLUDES `apexlib`, so stdlib members slipped
-  // through. It now uses MUTABLE_DOCUMENT_SCHEMES, which excludes `apexlib`.
+  // WorkspaceEdit (rename → null). The guard rejects the closed set of
+  // server-generated read-only schemes (READONLY_SYNTHETIC_SCHEMES), which
+  // includes `apexlib`.
   const STDLIB_FIELD_URI = 'apexlib://test/StdLibType.cls';
   const STDLIB_FIELD_SRC = `public class StdLibType {
     public Integer value;
@@ -812,6 +812,94 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
     // rename must NOT emit any edit for the stdlib declaration.
     const edit = rename as { changes?: Record<string, unknown> } | null;
     expect(edit?.changes).toBeUndefined();
+  }, 120_000);
+
+  // W-23631087 re-review (P2): a CONFIGURED editable scheme must remain
+  // renamable. `apex.environment.additionalDocumentSchemes` lets a client serve
+  // editable Apex under a custom scheme (e.g. `orgtest://`) that applies to all
+  // capabilities. The provenance guard rejects only the server-generated
+  // read-only schemes, so such a document must open the rename box AND produce a
+  // WorkspaceEdit — matching renameLocal (which has no scheme restriction),
+  // rather than declining by symbol kind. A positive allowlist wrongly declined
+  // it because configured schemes are not synced to the worker.
+  const ORG_FIELD_URI = 'orgtest://project/OrgField.cls';
+  const ORG_FIELD_SRC = `public class OrgField {
+    public Integer amount;
+
+    public void useIt() {
+        amount = 5;
+    }
+}`;
+
+  it('allows prepareRename AND rename for a field on a configured custom scheme (W-23631087 re-review)', async () => {
+    const program = Effect.gen(function* () {
+      const topology = yield* initializeTopology({
+        poolSize: 1,
+        enableResourceLoader: true,
+        logger,
+        logLevel: LOG_LEVEL,
+        compilationPoolSize: COMPILATION_POOL_SIZE,
+        compilationConcurrency: 1,
+        workerLayerFactory,
+      });
+      const dispatcher = makeWorkerDispatcher(topology, logger, (uri) =>
+        uri === ORG_FIELD_URI ? ORG_FIELD_SRC : undefined,
+      );
+      wireProductionMediator(topology, dispatcher, logger);
+      yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentOpen', {
+          document: {
+            uri: ORG_FIELD_URI,
+            languageId: 'apex',
+            version: 1,
+            getText: () => ORG_FIELD_SRC,
+          },
+          textDocument: { uri: ORG_FIELD_URI },
+          text: ORG_FIELD_SRC,
+        }),
+      );
+
+      // Cursor on `amount` DECLARATION (LSP line 1, char 23).
+      const prepare = yield* Effect.promise(() =>
+        dispatcher.dispatch('prepareRename', {
+          textDocument: { uri: ORG_FIELD_URI },
+          position: { line: 1, character: 23 },
+          content: ORG_FIELD_SRC,
+        }),
+      );
+      const rename = yield* Effect.promise(() =>
+        dispatcher.dispatch('rename', {
+          textDocument: { uri: ORG_FIELD_URI },
+          position: { line: 1, character: 23 },
+          newName: 'total',
+          content: ORG_FIELD_SRC,
+        }),
+      );
+
+      return { prepare, rename };
+    }).pipe(Effect.scoped);
+
+    const { prepare, rename } = await Effect.runPromise(program);
+    logger.debug(
+      `[rename-field:custom-scheme] prepare=${JSON.stringify(prepare)} ` +
+        `rename=${JSON.stringify(rename)}`,
+    );
+
+    // prepareRename must OFFER the field (a range containing the cursor).
+    expect(prepare).not.toBeNull();
+    expect(prepare).toHaveProperty('range');
+    // rename must emit edits for the custom-scheme document.
+    const edit = rename as {
+      changes?: Record<string, Array<{ range: unknown; newText: string }>>;
+    } | null;
+    expect(edit?.changes).toBeDefined();
+    expect(edit!.changes![ORG_FIELD_URI]).toBeDefined();
+    expect(edit!.changes![ORG_FIELD_URI].length).toBeGreaterThan(0);
+    edit!.changes![ORG_FIELD_URI].forEach((e) =>
+      expect(e.newText).toBe('total'),
+    );
   }, 120_000);
 
   // W-23631084: Field rename tests (4.1)

--- a/packages/apex-ls/test/unit/fieldDeclarationRangeFromParse.node.test.ts
+++ b/packages/apex-ls/test/unit/fieldDeclarationRangeFromParse.node.test.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Unit tests for {@link fieldDeclarationRangeFromParse} (W-23631087 re-review,
+ * P2). The helper resolves a field/property's declaration identifier range from
+ * a STANDALONE parse of the declaring file. When multiple same-named fields
+ * exist across nested/sibling types in one file, it must disambiguate by the
+ * OWNING TYPE FQN (walking the parent chain past the generated class-body block
+ * to the enclosing type), NOT by the immediate type leaf name — two types in
+ * different branches can share a leaf (`A.Dup` vs `B.Dup`). Genuine ambiguity
+ * fails closed to null so the caller declines rather than rename the wrong
+ * declaration.
+ *
+ * These run against a real parse (no mocks) so they stay honest about the
+ * symbol shape the production standalone parse actually produces.
+ */
+import {
+  CompilerService,
+  SymbolTable,
+  FullSymbolCollectorListener,
+} from '@salesforce/apex-lsp-parser-ast';
+import {
+  fieldDeclarationRangeFromParse,
+  fieldRenameDeclarationDecision,
+} from '../../src/worker.platform.shared';
+
+/** Parse `src` the same way resolveFieldRename parses the declaring file. */
+const parse = (src: string): SymbolTable => {
+  const table = new SymbolTable();
+  const compiled = new CompilerService().compile(
+    src,
+    'F.cls',
+    new FullSymbolCollectorListener(table),
+    { collectReferences: true, resolveReferences: true },
+  );
+  return compiled?.result instanceof SymbolTable ? compiled.result : table;
+};
+
+describe('fieldDeclarationRangeFromParse', () => {
+  it('returns the single field range when the name is unique', () => {
+    const table = parse(`public class Solo {
+    public Integer amount;
+}`);
+    const range = fieldDeclarationRangeFromParse(
+      table as never,
+      'amount',
+      'Solo',
+    );
+    expect(range).not.toBeNull();
+    // `amount` is on parser line 2 (1-based).
+    expect(range!.startLine).toBe(2);
+  });
+
+  it('returns null when the field name is not present', () => {
+    const table = parse(`public class Solo {
+    public Integer amount;
+}`);
+    expect(
+      fieldDeclarationRangeFromParse(table as never, 'missing', 'Solo'),
+    ).toBeNull();
+  });
+
+  it('disambiguates same-named fields across DIFFERENT-leaf nested types', () => {
+    const table = parse(`public class Outer {
+    public Integer amount;
+    public class Inner {
+        public Integer amount;
+    }
+}`);
+    const outer = fieldDeclarationRangeFromParse(
+      table as never,
+      'amount',
+      'Outer',
+    );
+    const inner = fieldDeclarationRangeFromParse(
+      table as never,
+      'amount',
+      'Outer.Inner',
+    );
+    expect(outer).not.toBeNull();
+    expect(inner).not.toBeNull();
+    // Outer.amount on line 2, Outer.Inner.amount on line 4 — distinct ranges.
+    expect(outer!.startLine).toBe(2);
+    expect(inner!.startLine).toBe(4);
+  });
+
+  it('disambiguates SAME-leaf nested types in different branches by owning FQN', () => {
+    // Both `Wrapper.Leaf` and `Other.Leaf` share the leaf `Leaf` and field
+    // `total`; a leaf-only match would return the FIRST `Leaf` for both.
+    const table = parse(`public class Root {
+    public class Wrapper {
+        public class Leaf {
+            public Integer total;
+        }
+    }
+    public class Other {
+        public class Leaf {
+            public Integer total;
+        }
+    }
+}`);
+    const wrapper = fieldDeclarationRangeFromParse(
+      table as never,
+      'total',
+      'Root.Wrapper.Leaf',
+    );
+    const other = fieldDeclarationRangeFromParse(
+      table as never,
+      'total',
+      'Root.Other.Leaf',
+    );
+    expect(wrapper).not.toBeNull();
+    expect(other).not.toBeNull();
+    // Wrapper.Leaf.total on line 4, Other.Leaf.total on line 9 — the owning-FQN
+    // walk keeps them distinct where a leaf-only match would collapse both.
+    expect(wrapper!.startLine).toBe(4);
+    expect(other!.startLine).toBe(9);
+    expect(wrapper!.startLine).not.toBe(other!.startLine);
+  });
+
+  it('tolerates a namespace-qualified requested FQN (suffix match)', () => {
+    const table = parse(`public class Outer {
+    public Integer amount;
+    public class Inner {
+        public Integer amount;
+    }
+}`);
+    // The graph FQN may carry a namespace the standalone parse cannot see.
+    const inner = fieldDeclarationRangeFromParse(
+      table as never,
+      'amount',
+      'MyNamespace.Outer.Inner',
+    );
+    expect(inner).not.toBeNull();
+    expect(inner!.startLine).toBe(4);
+  });
+
+  it('fails closed (null) when the requested FQN is too ambiguous to disambiguate', () => {
+    // A bare leaf `Leaf` matches BOTH same-leaf types → no unique match → null,
+    // so the caller declines rather than rename the wrong declaration.
+    const table = parse(`public class Root {
+    public class Wrapper {
+        public class Leaf {
+            public Integer total;
+        }
+    }
+    public class Other {
+        public class Leaf {
+            public Integer total;
+        }
+    }
+}`);
+    expect(
+      fieldDeclarationRangeFromParse(table as never, 'total', 'Leaf'),
+    ).toBeNull();
+  });
+});
+
+/**
+ * W-23631087 re-review (P1): a field rename must never emit a usage-only
+ * WorkspaceEdit. When the declaration cannot be located but usages WERE found,
+ * the rename must decline (fail closed) rather than rewrite the usages and leave
+ * the declaration dangling.
+ */
+describe('fieldRenameDeclarationDecision', () => {
+  it('proceeds when the declaration resolved (regardless of usage count)', () => {
+    expect(fieldRenameDeclarationDecision(true, 0)).toBe('proceed');
+    expect(fieldRenameDeclarationDecision(true, 5)).toBe('proceed');
+  });
+
+  it('reports nothing-to-rename when there is no declaration AND no usage', () => {
+    expect(fieldRenameDeclarationDecision(false, 0)).toBe('nothing-to-rename');
+  });
+
+  it('DECLINES a partial edit when usages exist but the declaration is missing', () => {
+    // The core regression: old code returned the usage-only edit here.
+    expect(fieldRenameDeclarationDecision(false, 1)).toBe('decline-partial');
+    expect(fieldRenameDeclarationDecision(false, 42)).toBe('decline-partial');
+  });
+});

--- a/packages/apex-lsp-shared/src/document/DocumentSelectorUtils.ts
+++ b/packages/apex-lsp-shared/src/document/DocumentSelectorUtils.ts
@@ -77,15 +77,29 @@ export const DEFAULT_SCHEMES_FOR_MOST: readonly string[] = [
 ] as const;
 
 /**
- * Immutable default schemes for CodeLens capability
- * Excludes 'apexlib' as CodeLens should not operate on standard library files
+ * User-editable ("mutable") document schemes: the real workspace filesystems VS
+ * Code opens editable Apex under (`file`, plus the web variants). Deliberately
+ * EXCLUDES synthetic read-only schemes — standard library (`apexlib`) and
+ * generated SObjects (`apex-sobject`) — which back non-editable virtual
+ * documents. This is the source-of-truth for "can the user edit this file?"
+ * decisions (e.g. rename provenance), so a synthetic scheme is never treated as
+ * user-owned. Note this intentionally differs from {@link getAllImmutableSchemes},
+ * which INCLUDES `apexlib`.
  */
-export const DEFAULT_SCHEMES_FOR_CODELENS: readonly string[] = [
+export const MUTABLE_DOCUMENT_SCHEMES: readonly string[] = [
   'file',
   'vscode-test-web',
   'memfs',
   'reefs',
 ] as const;
+
+/**
+ * Immutable default schemes for CodeLens capability
+ * Excludes 'apexlib' as CodeLens should not operate on standard library files.
+ * Same set as {@link MUTABLE_DOCUMENT_SCHEMES} (both mean "real editable files").
+ */
+export const DEFAULT_SCHEMES_FOR_CODELENS: readonly string[] =
+  MUTABLE_DOCUMENT_SCHEMES;
 
 /**
  * Get all immutable scheme names (union of all default schemes)

--- a/packages/apex-lsp-shared/src/document/DocumentSelectorUtils.ts
+++ b/packages/apex-lsp-shared/src/document/DocumentSelectorUtils.ts
@@ -94,6 +94,26 @@ export const MUTABLE_DOCUMENT_SCHEMES: readonly string[] = [
 ] as const;
 
 /**
+ * Synthetic, READ-ONLY document schemes the language server itself generates for
+ * non-editable virtual documents: the standard library (`apexlib`) and generated
+ * SObjects (`apex-sobject`). These are a CLOSED set the server controls (a client
+ * never opens editable Apex under them), so they are the source-of-truth for "is
+ * this scheme NOT writable?" decisions.
+ *
+ * Rename provenance uses this as a BLOCKLIST rather than allow-listing the
+ * editable schemes: the editable set is open-ended — `MUTABLE_DOCUMENT_SCHEMES`
+ * plus any `apex.environment.additionalDocumentSchemes` a client configures
+ * (which apply to all capabilities by default) — and those custom schemes are
+ * not visible to the worker. Rejecting only the known synthetic read-only schemes
+ * keeps configured editable schemes renamable while still refusing stdlib and
+ * generated-SObject sources (W-23631087 re-review).
+ */
+export const READONLY_SYNTHETIC_SCHEMES: readonly string[] = [
+  'apexlib',
+  'apex-sobject',
+] as const;
+
+/**
  * Immutable default schemes for CodeLens capability
  * Excludes 'apexlib' as CodeLens should not operate on standard library files.
  * Same set as {@link MUTABLE_DOCUMENT_SCHEMES} (both mean "real editable files").


### PR DESCRIPTION
### What does this PR do?

Delivers **4.3 renameField e2e coverage**, plus the two fixes that coverage surfaced.

**1. prepareRename now recognizes fields/properties (not just locals).** The server advertises `renameProvider: { prepareProvider: true }`, so VS Code fires `textDocument/prepareRename` FIRST on F2 and won't open the rename box unless it returns a range containing the cursor. `DispatchPrepareRename` only resolved locals, so F2 on a field showed **"The element can't be renamed"** — renameField was unreachable through the editor even though `resolveFieldRename` fully supports it. The new field branch resolves via the **same `svc` cursor primitives `resolveFieldRename` uses**, so prepareRename accepts exactly the field cursors the rename can service (no accept-then-decline drift), returning the identifier range containing the cursor — declaration or usage token.

**2. Declaration edit no longer corrupts the type token.** The e2e caught a bug the unit/worker-topology tests missed (they assert edit *count* + *newText*, never *ranges*): under full-workspace ingestion the graph-stored field symbol's `identifierRange` can span the field's **type** token, so `declarationLocationForCursor` returned that and the rename edited `Integer` instead of the field name. Usage edits were correct because they come from `findFieldOccurrences`' standalone parse. Fix: recompute the declaration token range from a **standalone parse** of the declaring file (`fieldDeclarationRangeFromParse`) — the same source as the usage ranges — so declaration and usages stay consistent.

**3. e2e coverage** (`apex-rename-symbol.spec.ts`, reusing the 3.3 `ApexEditorPage.rename()` helper), both passing on web:
- Single-file field rename — declaration + `this`-qualified + implicit-`this` usages.
- Cross-file field rename — declaration in `RenameFieldModel` + field-access occurrences in `RenameFieldClient`, proving the multi-file `WorkspaceEdit`. Gated on full workspace ingestion.
- New fixtures: `RenameFieldSample`, `RenameFieldModel`, `RenameFieldClient` (+ `-meta.xml`).
- Scoped `BasePage`'s editor locator to exclude the Monaco rename widget (`.monaco-editor.rename-box`), which lingers in the DOM after a rename and otherwise breaks `openFile` with a strict-mode violation when switching files post-rename (renameMethod/renameType e2e will need this too).

**4. Integration coverage:** field prepareRename worker-topology tests for a declaration cursor and a usage cursor.

**5. Review nit (W-23631084 final review):** the active-load rename regression asserted only that *some* error was returned; it now asserts the decline carries the active/incomplete workspace-load signal (`-32600` + a message matching `workspace load session still active`/`incomplete`).

Validation: full pre-commit test matrix green (5505 passed, 0 failed); `RenameThroughWorkerTopology` 25/25 (incl. the 2 field prepareRename tests + the strengthened active-load regression); both renameField e2e tests pass on web. The live e2e is exercised in CI.

### What issues does this PR fix or reference?

@W-23631087@

### Functionality Before

F2 on an Apex **field** → "The element can't be renamed" (prepareRename returned null for non-locals). Field rename was only reachable programmatically, never through the editor.

### Functionality After

F2 on a field opens the rename box; confirming renames the declaration and all field occurrences — single-file and cross-file — as a `WorkspaceEdit`, with the declaration token renamed correctly.
