### PR TITLE
feat(apex-lsp-compliant-services): renameMethod WorkspaceEdit construction - W-23631132

### DIFF
--- a/docs/plans/W-23631132-renamemethod-workspaceedit-plan.md
+++ b/docs/plans/W-23631132-renamemethod-workspaceedit-plan.md
@@ -1,0 +1,159 @@
+# W-23631132 — 5.2 renameMethod: WorkspaceEdit construction across overrides + interfaces
+
+Implementation plan for the renameMethod WorkspaceEdit-construction WI. Companion to
+the epic spike plan (`W-22629631-rename-symbol-spike-plan.md`, WI 5.2). Reflects the
+recon (worker seam, parser-ast method model, jorje parity) and the plan-adversary
+review that revised the fan-out design before build.
+
+## Scope
+
+**In scope (5.2):** produce the multi-file `WorkspaceEdit` for renaming an Apex
+method — the clicked method's declaration + all its occurrences, plus every override
+declaration and call across the type family (supertypes, interfaces, subtypes,
+implementors), matched by signature-equivalence; the static-vs-instance
+reference-collection split; qualify-on-conflict rewrites for static-method-in-outer-
+class shadows; wired into the pool `DispatchRename` path.
+
+**Out of scope:** conflict-detection verdict + validation wiring (**5.3**, consumes
+4.0's `CheckMemberConflicts`), method `prepareRename` (**5.3**; see the open question
+below), editor e2e (**5.4**). The family-walk core (`walkTypeFamily`) + verdict query
+were delivered by **4.0** and are reused, not rebuilt.
+
+## Execution path
+
+- Add `resolveMethodRename(svc, req)` after `resolveFieldRename` in the `DispatchRename`
+  handler (`packages/apex-ls/src/worker.platform.shared.ts`). Only a `null` from
+  `resolveFieldRename` may fall through — a `RenameErrorResult` must return.
+- Gate on `target.kind === 'method'`; decline `'constructor'` with a clear message
+  ("Constructor rename isn't supported here; rename the type instead") — constructors
+  route to renameType, not method rename.
+- Use the pool `DispatchRename` path + a data-owner assist, **not**
+  `RenameProcessingService.processRename` (an unimplemented `return null` stub at
+  `RenameProcessingService.ts:62-92`). renameField (4.1) set this precedent.
+  > NOTE: the GUS WI subject says "wire into processRename" — that framing is stale;
+  > the pool path is correct. Flag to the epic owner.
+
+## New parser-ast op: `findMethodOccurrences`
+
+`packages/apex-parser-ast/src/symbols/ops/findMethodOccurrences.ts`, exported from
+`index.ts`. Returns `{ occurrences, skipped, unsafe }` like `FieldOccurrenceResult`,
+so the worker's unsafe→decline orchestration carries over unchanged.
+
+1. **Candidate set:** `findOccurrencesInFile(table, uri, {name, kind:'method'})` —
+   already matches `METHOD_CALL` by leaf name and position-dedups (no signature check).
+2. **Signature-equivalence filter** (new): reuse
+   `semantics/validation/utils/methodSignatureUtils.ts` (`doesSignatureMatch`). Match
+   each call's `argumentCount` against the target overload's arity.
+   - **Arity is the primary (in practice, only) signal.** VERIFIED during build:
+     `argumentTypes` is **never populated in this build** — even for literal args
+     (`foo('x')`, `foo(42)`) — so the type-comparison branch is retained but dormant.
+   - **Arity-only match (adversary H3):** `argumentCount` matches the target arity AND
+     the family declares a **single** overload at that arity → match. Only **multiple**
+     same-arity overloads + an untyped call → `unsafe` → decline. Different arity →
+     skip (binds to a different overload). Without this, renameMethod would decline on
+     ordinary code like `foo(someVar)`.
+3. **Receiver + static-vs-instance classifier** (new; method-model-specific — do NOT
+   lift `findFieldOccurrences`' co-located-at-token index; method-call receivers sit at
+   the qualifier/root position or in `chainNodes`, not the method-name token). VERIFIED
+   parser model:
+   - bare `foo()` → implicit-this (instance): keep iff enclosing type FQN ∈ family; if
+     the enclosing type has a superclass/interfaces it *could* inherit a family method
+     → unsafe; else skip.
+   - `this.foo()` → implicit-this too (emitted as a bare call or a **length-2** chain
+     rooted at `CHAIN_STEP:this`, NOT multi-hop). Only `chainNodes.length >= 3`
+     (`a.b.foo()`) is multi-hop → unsafe.
+   - `obj.foo()` → the chain root is a `CLASS_REFERENCE`/`CHAIN_STEP` (NOT a
+     `VARIABLE_USAGE`), so instance-var vs static can't be told by context; resolve the
+     root name via `resolveVariableAtPosition` (variable-like → instance type; else →
+     static type qualifier), mirroring the field op's fallback.
+   - `Type.foo()` static → co-located resolved `CLASS_REFERENCE` qualifier → its type
+     FQN.
+   - `new T().foo()` / `getX().foo()` / `super.foo()` → non-variable / ancestor receiver
+     → unsafe (result type unprovable standalone).
+   - `ref.isStatic` is **unset** on method-call refs — never rely on it.
+4. **Keep occurrences whose receiver type ∈ the family FQN set** (see fan-out). Compare
+   FQN-to-FQN (as renameField does with `declaringTypeFqn`); a receiver that only
+   resolves to a bare name and can't be FQN-qualified inherits renameField's documented
+   simple-name limitation (namespace/nested-name collisions deferred), or is skipped.
+5. Compile the new op (`npm run compile -w @salesforce/apex-lsp-parser-ast`) before the
+   worker imports it — the worker-topology test loads the built `out/`; a source-only
+   change throws `is not a function` inside the phase-2 try/catch and is swallowed.
+
+## The fan-out (revised after plan-adversary)
+
+Renaming an instance method must rewrite override **declarations** (`Child.foo()`,
+interface impls) AND calls binding anywhere in the family. The pool worker cannot
+compute the complete family (its graph is a transient per-request subset). So:
+
+**Data-owner assist** `dataOwner:ResolveMethodRenameFamily`
+(`{ declaringTypeFqn, methodName, signature, isStatic }`):
+- **static** → returns only the declaring type (no cone).
+- **instance** → `walkTypeFamily(declaringType)` returns `ApexSymbol[]` that carry
+  `.fqn`; return **FQNs** (not the simple names `collectRelatedTypeNames` emits —
+  fixes adversary C2). For each family type that declares a **signature-matching**
+  method, return `{ typeFqn, fileUri }` (the override site) plus the full family FQN
+  set.
+
+**Pool assembly:**
+- **Override declarations (fixes adversary C1):** for each `{ typeFqn, fileUri }`,
+  standalone-parse the file and extract the method-name range via
+  `methodDeclarationRangeFromParse` — explicitly collecting override declarations.
+  `findInstanceMethodReferences` returns call sites only, so declarations must be
+  collected this way, not inferred from references.
+- **Calls:** `dataOwner:FindOccurrenceCandidates` (all stored docs) → per-candidate
+  `findMethodOccurrences`, keeping occurrences whose receiver FQN ∈ family FQN set.
+- **Ranges come from the standalone parse, never the graph** (graph declaration ranges
+  can span the return-type token — the same hazard `fieldDeclarationRangeFromParse`
+  exists for).
+- Any `unsafe` occurrence → decline the whole rename (correctness over completeness).
+
+## `methodDeclarationRangeFromParse`
+
+Mirrors `fieldDeclarationRangeFromParse` but: (a) match by name **+ signature** (the
+cursor's parameter types are available from the resolved `MethodSymbol`), declining on
+ambiguity; (b) handle **no-body** declarations — abstract/interface methods end in `;`,
+not a `{ }` body — so don't assume a body token exists.
+
+## Qualify-on-conflict
+
+Emit `OuterType.newName` for a static-method-in-outer-class shadow. May start
+**minimal = decline on conflict** (matching renameField, which has no qualify rewrite);
+the full rewrite can follow. Document whichever is shipped — don't claim a rewrite that
+isn't implemented.
+
+## Tests (5.2 verification)
+
+- **parser-ast unit** (`findMethodOccurrences.test.ts`): arity-distinct overload
+  separation; single-overload arity-only match (untyped arg still matches); multiple
+  same-arity overloads + untyped arg → unsafe; receiver forms (bare / `this` /
+  instance-var / `Type.static`); abstract/interface declaration ranges; no-body decl.
+- **worker-topology** (`RenameThroughWorkerTopology.node.test.ts`): single-file method
+  rename; override across files (declaration in child renamed); interface-implementer;
+  static method; overload disambiguation; `super.foo()`; unsafe→decline.
+- Full editor F2 e2e is **5.4**; 5.2's proof is the topology tests producing a correct
+  multi-file `WorkspaceEdit`.
+
+## Sequencing / risks
+
+- Branch stacked on **4.3** (`feature/W-23631087`) — heavy overlap in
+  `worker.platform.shared.ts` + reuse of the prepareRename / declaration-range
+  scaffolding; rebase onto `main` once 4.3 merges.
+- **Carried-forward field gotchas:** bind by name+context, never `resolvedSymbolId`
+  (undefined in standalone parses → silent zero-match); keep position-dedup; never
+  trust `resolvedTypeId` (never populated); conservative skip+report; `getEnclosingType`
+  must pick the innermost containing type.
+- **Open question — method `prepareRename`:** nominally 5.3, but renameField's prepare
+  was pulled into 4.3 because the e2e needed it; 5.4 will likely need method prepare the
+  same way. Decide whether to pull it into 5.2/5.3. Keep the resolver surfacing a clean
+  `identifierRange` so 5.3's prepare is a thin wrapper either way.
+- **Edge cases to cover:** interface `default` methods (have bodies, callable),
+  abstract methods (no body), `super.foo()`, constructor routing (declined here).
+
+## Slices (build order)
+
+1. `findMethodOccurrences` op + unit tests (parser-ast; no cross-worker deps). ← first
+2. `dataOwner:ResolveMethodRenameFamily` assist + wire schema + coordinator route.
+3. `resolveMethodRename` in the worker + `methodDeclarationRangeFromParse`; fan-out
+   assembly; dispatch fall-through.
+4. Worker-topology tests.
+5. Qualify-on-conflict emission (or documented minimal-decline).

--- a/docs/plans/W-23631132-renamemethod-workspaceedit-plan.md
+++ b/docs/plans/W-23631132-renamemethod-workspaceedit-plan.md
@@ -114,12 +114,14 @@ cursor's parameter types are available from the resolved `MethodSymbol`), declin
 ambiguity; (b) handle **no-body** declarations — abstract/interface methods end in `;`,
 not a `{ }` body — so don't assume a body token exists.
 
-## Qualify-on-conflict
+## Qualify-on-conflict — DEFERRED (follow-up)
 
-Emit `OuterType.newName` for a static-method-in-outer-class shadow. May start
-**minimal = decline on conflict** (matching renameField, which has no qualify rewrite);
-the full rewrite can follow. Document whichever is shipped — don't claim a rewrite that
-isn't implemented.
+**Not implemented in 5.2**, matching the renameField precedent: 4.1 explicitly
+deferred the equivalent field rewrite (`shouldQualifyOnConflict` returns false —
+epic plan 4.1 item iii), so renameField ships without it. The `OuterType.newName`
+static-method-in-outer-class shadow rewrite is a follow-up enhancement; deferring
+it keeps renameMethod consistent with renameField. Note conflict *detection*
+itself is 5.3, so 5.2 has no conflict handling to qualify around yet.
 
 ## Tests (5.2 verification)
 
@@ -149,11 +151,18 @@ isn't implemented.
 - **Edge cases to cover:** interface `default` methods (have bodies, callable),
   abstract methods (no body), `super.foo()`, constructor routing (declined here).
 
-## Slices (build order)
+## Slices (build order / status)
 
-1. `findMethodOccurrences` op + unit tests (parser-ast; no cross-worker deps). ← first
-2. `dataOwner:ResolveMethodRenameFamily` assist + wire schema + coordinator route.
-3. `resolveMethodRename` in the worker + `methodDeclarationRangeFromParse`; fan-out
-   assembly; dispatch fall-through.
-4. Worker-topology tests.
-5. Qualify-on-conflict emission (or documented minimal-decline).
+1. ✅ **DONE** — `findMethodOccurrences` op + 17 unit tests (parser-ast).
+2. ✅ **DONE** — `dataOwner:ResolveMethodRenameFamily` assist + wire schema +
+   coordinator route; extracted the shared `getTypeMembersFullDetail` reader.
+3. ✅ **DONE** — `resolveMethodRename` + `resolveMethodContextForCursor` +
+   `methodDeclarationRangeFromParse`; fan-out assembly; dispatch fall-through
+   (local → field → method) + single-file smoke topology test.
+4. ✅ **DONE** — `RenameMethodThroughWorkerTopology.node.test.ts`: cross-file
+   override, interface implementer, static, overload disambiguation, unsafe→decline.
+5. ⏸️ **DEFERRED** — qualify-on-conflict (see that section; matches the renameField
+   deferral). renameMethod 5.2 is substantively complete without it.
+
+**Not in 5.2 (later WIs):** conflict-detection + validation wiring + method
+`prepareRename` (5.3); editor F2 e2e (5.4).

--- a/packages/apex-ls/src/server/WorkerCoordinator.ts
+++ b/packages/apex-ls/src/server/WorkerCoordinator.ts
@@ -30,6 +30,7 @@ import {
   ResolveDependentUris,
   CheckMemberConflicts,
   FindOccurrenceCandidates,
+  ResolveMethodRenameFamily,
   WIRE_PROTOCOL_VERSION,
   WorkspaceBatchIngest,
   WorkspaceBatchCompileOnDataOwner,
@@ -1157,6 +1158,22 @@ function createDispatcher(
             new FindOccurrenceCandidates({
               symbolName: pfc.symbolName,
               skipTextFilter: pfc.skipTextFilter,
+            }),
+          );
+        }
+        case 'ResolveMethodRenameFamily': {
+          const prm = params as {
+            definingTypeFqn: string;
+            methodName: string;
+            signature?: string[];
+            isStatic: boolean;
+          };
+          return sendTracedToDataOwner(
+            new ResolveMethodRenameFamily({
+              definingTypeFqn: prm.definingTypeFqn,
+              methodName: prm.methodName,
+              signature: prm.signature,
+              isStatic: prm.isStatic,
             }),
           );
         }

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -76,6 +76,7 @@ import {
   DataOwnerQuerySymbolByName,
   CheckMemberConflicts,
   FindOccurrenceCandidates,
+  ResolveMethodRenameFamily,
   WIRE_PROTOCOL_VERSION,
   ApexCapabilitiesManager,
   ApexSettingsManager,
@@ -151,6 +152,7 @@ export const AllWorkerRequests = Schema.Union(
   DataOwnerQuerySymbolByName,
   CheckMemberConflicts,
   FindOccurrenceCandidates,
+  ResolveMethodRenameFamily,
   CompileDocument,
   ResourceLoaderGetSymbolTable,
   ResourceLoaderGetSymbolTables,
@@ -5460,6 +5462,73 @@ function walkTypeFamily(
   });
 }
 
+/**
+ * Read a type's declared members from its BLOCK scope, guaranteeing the canonical
+ * table is FULL-detail AND known-complete first. Batch-loaded files are served at
+ * public-api detail (which drops private/protected/default members) and a
+ * recovered/unknown table can silently drop declarations, so a naive read risks a
+ * truncated set. (Re-)enriches from retained source to establish completeness, and
+ * FAILS (with a message) when it cannot — callers preserve uncertainty rather than
+ * trust an incomplete set. Shared by CheckMemberConflicts (4.0 conflict verdict)
+ * and ResolveMethodRenameFamily (5.2 override discovery); callers re-tag the
+ * string failure to their own error type.
+ */
+function getTypeMembersFullDetail(
+  svc: DataOwnerServices,
+  type: ApexSymbol,
+): Effect.Effect<ApexSymbol[], string, never> {
+  return Effect.gen(function* () {
+    const { SymbolKind } = yield* Effect.promise(
+      () => import('@salesforce/apex-lsp-parser-ast'),
+    );
+    let typeTable = yield* Effect.promise(() =>
+      svc.symbolManager.getSymbolTableForFile(type.fileUri),
+    );
+    const isFullAndComplete = (
+      t: typeof typeTable | null | undefined,
+    ): boolean =>
+      t?.getDetailLevel() === 'full' &&
+      t.getMetadata().parseCompleteness === 'complete';
+    if (!isFullAndComplete(typeTable)) {
+      const doc = yield* Effect.promise(() =>
+        svc.storageManager.getStorage().getDocument(type.fileUri),
+      );
+      const text = doc?.getText();
+      if (!text) {
+        return yield* Effect.fail(
+          `Cannot read members for ${type.fileUri}: source text unavailable to ` +
+            'establish a complete full-detail parse, so non-public members ' +
+            'cannot be reliably inspected.',
+        );
+      }
+      yield* svc.symbolManager.enrichToLevel(type.fileUri, 'full', text);
+      typeTable = yield* Effect.promise(() =>
+        svc.symbolManager.getSymbolTableForFile(type.fileUri),
+      );
+      if (!isFullAndComplete(typeTable)) {
+        return yield* Effect.fail(
+          `Cannot read members for ${type.fileUri}: could not establish a ` +
+            'complete full-detail parse (canonical table at ' +
+            `${typeTable?.getDetailLevel() ?? 'none'} / ` +
+            `${typeTable?.getMetadata().parseCompleteness ?? 'unknown'}); the ` +
+            'member set may be incomplete.',
+        );
+      }
+    }
+    if (!typeTable) {
+      return yield* Effect.fail(
+        `Cannot read members: no symbol table for ${type.fileUri}.`,
+      );
+    }
+    // Members are children of the type's BLOCK scope, not the type itself.
+    const blockSymbol = typeTable
+      .getSymbolsInScope(type.id)
+      .find((s) => s.kind === SymbolKind.Block);
+    if (!blockSymbol) return [] as ApexSymbol[];
+    return typeTable.getSymbolsInScope(blockSymbol.id);
+  });
+}
+
 const untracedHandlers: SerializedWorkerHandlers = {
   InitializeCompilationWorker: (req) =>
     guardRole('InitializeCompilationWorker').pipe(
@@ -6131,116 +6200,17 @@ const untracedHandlers: SerializedWorkerHandlers = {
               symbol.modifiers.visibility === SymbolVisibility.Private ||
               symbol.modifiers.visibility === SymbolVisibility.Default;
 
-            // Helper: resolve a type's declared members from its BLOCK scope,
-            // guaranteeing the canonical table is full-detail AND known-complete
-            // first (see the fail-closed rationale below). Returns [] when the
-            // type has no block scope (no members). Shared by hasMemberNamed and
-            // the renamed-member visibility self-verify, so both read the exact
-            // same trusted member set.
+            // Resolve a type's full+complete member set (fails closed on an
+            // unverifiable/truncated parse — see getTypeMembersFullDetail). Shared
+            // with ResolveMethodRenameFamily via that module helper; re-tag its
+            // string failure to this query's error type.
             const getTypeMembers = (type: ApexSymbol) =>
-              Effect.gen(function* () {
-                // Batch-loaded workspace files are served at 'public-api' detail,
-                // which DROPS private/protected/default-visibility members from the
-                // symbol table entirely (VisibilitySymbolListener never adds them at
-                // public-api). All three checks below need non-public members:
-                //   - same-type: needs ALL members (incl. private)
-                //   - ancestor:  needs protected members present
-                //   - descendant: needs ALL members (incl. private/default)
-                // So this type's file MUST be at 'full' detail before we read it.
-                //
-                // FAIL CLOSED (W-23631128 re-review, P1): require the CANONICAL
-                // table to be BOTH full-detail AND a KNOWN-complete parse before
-                // reading members. Two independent hazards make full-detail alone
-                // insufficient:
-                //   (1) getDetailLevel() derives from the symbols actually present
-                //       (not the stale getDetailLevelForFile() side-channel), so a
-                //       newer public-api table that replaced an enriched one is
-                //       observed at its true 'public-api' level.
-                //   (2) A malformed source still yields a RECOVERED table that
-                //       reports 'full' but silently dropped declarations, AND a
-                //       full table can arrive from a producer that never
-                //       established completeness at the protocol boundary — a raw
-                //       cursor recompile written back via UpdateSymbolSubset lands
-                //       as full + parseCompleteness='unknown'. `SymbolTable`
-                //       defaults completeness to 'unknown', so trusting anything
-                //       other than an explicit 'complete' fails OPEN.
-                // So we require parseCompleteness === 'complete'. When the table is
-                // not full+complete we (re-)enrich from retained source to
-                // ESTABLISH completeness (enrichToLevel re-parses a full/unknown
-                // table for exactly this reason and stamps 'complete'/'incomplete'
-                // from SYNTAX errors — benign SEMANTIC cross-file errors do not
-                // drop declarations and do not mark incompleteness, so clean files
-                // are not over-declined). If retained source is unavailable, or
-                // enrichment cannot reach full+complete (e.g. the source is
-                // syntax-broken → 'incomplete'), fail the whole query so the caller
-                // preserves uncertainty rather than trusting a truncated set.
-                let typeTable = yield* Effect.promise(() =>
-                  svc.symbolManager.getSymbolTableForFile(type.fileUri),
-                );
-                const isFullAndComplete = (
-                  t: typeof typeTable | null | undefined,
-                ): boolean =>
-                  t?.getDetailLevel() === 'full' &&
-                  t.getMetadata().parseCompleteness === 'complete';
-                if (!isFullAndComplete(typeTable)) {
-                  const doc = yield* Effect.promise(() =>
-                    svc.storageManager.getStorage().getDocument(type.fileUri),
-                  );
-                  const text = doc?.getText();
-                  if (!text) {
-                    return yield* Effect.fail({
-                      _tag: 'CheckMemberConflictsError' as const,
-                      message:
-                        `Cannot verify member conflicts for ${type.fileUri}: ` +
-                        'source text unavailable to establish a complete ' +
-                        'full-detail parse, so non-public members cannot be ' +
-                        'reliably inspected.',
-                    });
-                  }
-                  yield* svc.symbolManager.enrichToLevel(
-                    type.fileUri,
-                    'full',
-                    text,
-                  );
-                  typeTable = yield* Effect.promise(() =>
-                    svc.symbolManager.getSymbolTableForFile(type.fileUri),
-                  );
-                  if (!isFullAndComplete(typeTable)) {
-                    return yield* Effect.fail({
-                      _tag: 'CheckMemberConflictsError' as const,
-                      message:
-                        `Cannot verify member conflicts for ${type.fileUri}: ` +
-                        'could not establish a complete full-detail parse ' +
-                        '(canonical table at ' +
-                        `${typeTable?.getDetailLevel() ?? 'none'} / ` +
-                        `${
-                          typeTable?.getMetadata().parseCompleteness ??
-                          'unknown'
-                        }); the member set may be incomplete, so a "no conflict" ` +
-                        'result cannot be trusted.',
-                    });
-                  }
-                }
-
-                if (!typeTable) {
-                  return yield* Effect.fail({
-                    _tag: 'CheckMemberConflictsError' as const,
-                    message: `Cannot verify member conflicts: no symbol table for ${type.fileUri}.`,
-                  });
-                }
-
-                // Members are children of the type's BLOCK scope, not the type itself.
-                // Find the block symbol (it's a child of the type with kind === 'block')
-                const blockSymbol = typeTable
-                  .getSymbolsInScope(type.id)
-                  .find((s) => s.kind === SymbolKind.Block);
-                if (!blockSymbol) {
-                  // No block scope means no members
-                  return [] as ApexSymbol[];
-                }
-
-                return typeTable.getSymbolsInScope(blockSymbol.id);
-              });
+              getTypeMembersFullDetail(svc, type).pipe(
+                Effect.mapError((message) => ({
+                  _tag: 'CheckMemberConflictsError' as const,
+                  message,
+                })),
+              );
 
             // Helper: check type for member with newName (as an Effect generator)
             // NOTE: For methods, this does name-based matching only.
@@ -6398,6 +6368,107 @@ const untracedHandlers: SerializedWorkerHandlers = {
               `[RENAME] CheckMemberConflicts: no conflict for ${req.definingTypeFqn}.${req.newName}`,
             );
             return { conflict: false };
+          }),
+        ),
+      ),
+    ),
+
+  // renameMethod edit-target discovery (WI 5.2). Returns the type-family cone
+  // (FQNs) whose calls the pool accepts as occurrences, plus each family type
+  // that DECLARES a signature-matching method (an override site the rename must
+  // rewrite). Runs on the data owner because only its post-load graph has the
+  // complete subtype/implementor cone.
+  ResolveMethodRenameFamily: (req) =>
+    guardRole('ResolveMethodRenameFamily').pipe(
+      Effect.flatMap(() =>
+        dataOwnerRead(
+          Effect.gen(function* () {
+            const svc = yield* ensureDataOwnerServices;
+
+            // Same completeness precondition as CheckMemberConflicts: the family
+            // walk needs the resolved inheritance cone, which only exists after
+            // endWorkspaceLoadSession. Mid-load, findSubtypes/findSupertypes are
+            // partial → we would miss override sites (a dangling partial rename).
+            if (svc.symbolManager.isWorkspaceLoadSessionActive()) {
+              return yield* Effect.fail({
+                _tag: 'ResolveMethodRenameFamilyError' as const,
+                message:
+                  'Workspace load session still active; hierarchy graph not ' +
+                  'yet complete for method family resolution',
+              });
+            }
+
+            const { SymbolKind, inTypeSymbolGroup, doesSignatureMatch } =
+              yield* Effect.promise(
+                () => import('@salesforce/apex-lsp-parser-ast'),
+              );
+
+            const definingType = yield* Effect.promise(() =>
+              svc.symbolManager.findSymbolByFQN(req.definingTypeFqn),
+            );
+            if (!definingType || !inTypeSymbolGroup(definingType)) {
+              return yield* Effect.fail({
+                _tag: 'ResolveMethodRenameFamilyError' as const,
+                message: `Type not found or not a type symbol: ${req.definingTypeFqn}`,
+              });
+            }
+
+            // Static methods are not inherited, so the family is the declaring
+            // type alone. Instance methods fan out over the whole cone; ancestors
+            // fold in extended/implemented interfaces and descendants fold in
+            // implementors (findSupertypes/findSubtypes read both edge kinds).
+            const family: ApexSymbol[] = [definingType];
+            if (!req.isStatic) {
+              const { ancestors, descendants } = yield* walkTypeFamily(
+                svc,
+                definingType,
+              );
+              family.push(...ancestors, ...descendants);
+            }
+
+            const methodNameLower = req.methodName.toLowerCase();
+            const familyFqns: string[] = [];
+            const overrideSites: Array<{ typeFqn: string; fileUri: string }> =
+              [];
+            const seen = new Set<string>();
+
+            for (const type of family) {
+              const typeFqn =
+                type.fqn ||
+                (yield* Effect.promise(() =>
+                  svc.symbolManager.constructFQN(type),
+                ));
+              if (!typeFqn || seen.has(typeFqn)) continue;
+              seen.add(typeFqn);
+              familyFqns.push(typeFqn);
+
+              // Does this type DECLARE a signature-matching method to rename?
+              const members = yield* getTypeMembersFullDetail(svc, type).pipe(
+                Effect.mapError((message) => ({
+                  _tag: 'ResolveMethodRenameFamilyError' as const,
+                  message,
+                })),
+              );
+              const declares = members.some(
+                (m) =>
+                  m.kind === SymbolKind.Method &&
+                  m.name.toLowerCase() === methodNameLower &&
+                  (req.signature
+                    ? doesSignatureMatch(m, req.methodName, [...req.signature])
+                    : true),
+              );
+              if (declares && type.fileUri) {
+                overrideSites.push({ typeFqn, fileUri: type.fileUri });
+              }
+            }
+
+            emitWorkerLog(
+              'info',
+              `[RENAME] ResolveMethodRenameFamily: ${req.definingTypeFqn}.` +
+                `${req.methodName} → ${familyFqns.length} family type(s), ` +
+                `${overrideSites.length} override site(s)`,
+            );
+            return { familyFqns, overrideSites };
           }),
         ),
       ),

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -6913,8 +6913,8 @@ const untracedHandlers: SerializedWorkerHandlers = {
                     : true),
               );
 
-            // Static methods are not inherited, so the family is the declaring
-            // type alone. Instance methods fan out over the whole cone; ancestors
+            // The occurrence family: types whose calls to this method must be
+            // renamed. Instance methods fan out over the whole cone; ancestors
             // fold in extended/implemented interfaces and descendants fold in
             // implementors (findSupertypes/findSubtypes read both edge kinds).
             const family: ApexSymbol[] = [definingType];
@@ -6938,6 +6938,24 @@ const untracedHandlers: SerializedWorkerHandlers = {
                   svc.symbolManager.findSubtypes(intro),
                 );
                 for (const s of subs) if (inTypeSymbolGroup(s)) family.push(s);
+              }
+            } else {
+              // Static methods ARE inherited and callable from subclasses in Apex
+              // (an unqualified `foo()` in a subclass body, or `Sub.foo()`), so
+              // calls to the inherited static are real occurrences that must be
+              // renamed — include the DESCENDANT cone (W-23631132 re-review, 5.2).
+              // But a subclass that REDECLARES a same-name static is method
+              // HIDING — a DISTINCT method whose declaration and calls must NOT be
+              // renamed — so exclude any descendant that declares its own matching
+              // method; that file then fail-closes in the pool (unsafe → decline)
+              // if it references the name, rather than being mis-renamed. Statics
+              // have no override sites: only the declaring type declares this
+              // method, so the overrideSites gate below (declaresTargetSig)
+              // naturally yields just `definingType`. Ancestors are irrelevant —
+              // they cannot see a subtype's static.
+              const { descendants } = yield* walkTypeFamily(svc, definingType);
+              for (const d of descendants) {
+                if (!declaresTargetSig(yield* membersOf(d))) family.push(d);
               }
             }
 

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -4317,6 +4317,13 @@ async function resolveMethodContextForCursor(
     };
     const symbol = await resolveCursorSymbol(svc, uri, parserPosition);
     if (!symbol) return null;
+    // Provenance guard (W-23631087 review, P1): only a method declared in a
+    // user-owned Apex source is renamable. A stdlib/generated-SObject method
+    // resolves to a synthetic URI and must not produce a WorkspaceEdit — return
+    // null so resolveMethodRename declines (mirrors the field-side guard).
+    if (!isUserOwnedApexUri((symbol as { fileUri?: string }).fileUri)) {
+      return null;
+    }
     const containingType = await svc.symbolManager.getContainingType(symbol);
     if (!containingType) return null;
     const declaringTypeFqn =

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -3420,6 +3420,93 @@ export async function declarationLocationForCursor(
 }
 
 /**
+ * A minimal SymbolTable view for declaration-range disambiguation: enough to
+ * walk the parent chain from a member to its enclosing type(s).
+ */
+type DeclParseTable = {
+  getSymbolById?: (
+    id: string,
+  ) =>
+    | { id?: string; name?: string; kind?: unknown; parentId?: string }
+    | undefined;
+};
+
+/**
+ * Owning TYPE FQN path (leaf-last, lowercased) for a member symbol from a
+ * standalone parse: walk its parent chain, collecting enclosing TYPE names and
+ * skipping the generated class-body BLOCK symbols. Shared by field/method
+ * declaration disambiguation.
+ */
+function ownerTypePathFromParse(
+  table: DeclParseTable,
+  member: { parentId?: string },
+): string[] {
+  const path: string[] = [];
+  const seen = new Set<string>();
+  let cur = member.parentId
+    ? table.getSymbolById?.(member.parentId)
+    : undefined;
+  let hops = 0;
+  while (cur && hops < 50) {
+    if (cur.id) {
+      if (seen.has(cur.id)) break;
+      seen.add(cur.id);
+    }
+    const kind = String(cur.kind).toLowerCase();
+    if (
+      cur.name &&
+      (kind === 'class' ||
+        kind === 'interface' ||
+        kind === 'enum' ||
+        kind === 'trigger')
+    ) {
+      path.unshift(cur.name.toLowerCase());
+    }
+    cur = cur.parentId ? table.getSymbolById?.(cur.parentId) : undefined;
+    hops++;
+  }
+  return path;
+}
+
+/** True when `suffix` is a non-empty tail of `path` (lowercased segment arrays). */
+function isFqnPathSuffix(path: string[], suffix: string[]): boolean {
+  if (suffix.length === 0 || suffix.length > path.length) return false;
+  for (let i = 1; i <= suffix.length; i++) {
+    if (path[path.length - i] !== suffix[suffix.length - i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Among same-named declaration `members` (fields, or method overloads already
+ * narrowed by signature), the UNIQUE one whose owning-type FQN is a suffix of
+ * `declaringTypeFqn` (namespace-tolerant — the graph FQN may carry a namespace
+ * the standalone parse can't see). Returns its identifier range, or null when
+ * there is no unique match so the caller FAILS CLOSED (declines): two types in
+ * different branches can share a leaf name (`A.Dup` vs `B.Dup`), so a leaf-only
+ * comparison could rewrite the wrong declaration.
+ */
+function uniqueDeclarationRangeByOwningFqn(
+  table: DeclParseTable,
+  members: Array<{
+    parentId?: string;
+    location?: { identifierRange?: OccurrenceRange };
+  }>,
+  declaringTypeFqn: string,
+): OccurrenceRange | null {
+  const requestedPath = declaringTypeFqn
+    .split('.')
+    .map((s) => s.toLowerCase())
+    .filter(Boolean);
+  if (requestedPath.length === 0) return null;
+  const matches = members.filter((m) =>
+    isFqnPathSuffix(requestedPath, ownerTypePathFromParse(table, m)),
+  );
+  if (matches.length === 1) return matches[0].location!.identifierRange!;
+  return null;
+}
+
+/**
  * Field/property declaration range from a STANDALONE parse of the declaring file
  * (W-23631087). The graph symbol's `identifierRange` can span the field's TYPE
  * token under full ingestion (renaming `Integer` instead of the field), so the
@@ -3440,12 +3527,7 @@ export function fieldDeclarationRangeFromParse(
       parentId?: string;
       location?: { identifierRange?: OccurrenceRange };
     }>;
-    getSymbolById?: (
-      id: string,
-    ) =>
-      | { id?: string; name?: string; kind?: unknown; parentId?: string }
-      | undefined;
-  },
+  } & DeclParseTable,
   fieldName: string,
   declaringTypeFqn: string,
 ): OccurrenceRange | null {
@@ -3460,63 +3542,9 @@ export function fieldDeclarationRangeFromParse(
   });
   if (fields.length === 0) return null;
   if (fields.length === 1) return fields[0].location!.identifierRange!;
-
-  // Same-named fields across nested/sibling types in one file. Disambiguate by
-  // the OWNING TYPE FQN, not just the immediate type leaf: two types in
-  // different branches can share a leaf name (`A.Dup` vs `B.Dup`), so a
-  // leaf-only comparison could match the wrong declaration. Walk each field's
-  // parent chain (fields are parented to a generated class-body BLOCK symbol,
-  // whose own parent is the type symbol — so skip everything but type symbols)
-  // to build its owning type path, then keep the field whose path is a suffix of
-  // the requested FQN (the graph FQN may carry a namespace the standalone parse
-  // can't see). A non-unique / no match → null so the caller FAILS CLOSED
-  // (declines) rather than guessing (W-23631087 review).
-  const requestedPath = declaringTypeFqn
-    .split('.')
-    .map((s) => s.toLowerCase())
-    .filter(Boolean);
-  if (requestedPath.length === 0) return null;
-
-  const ownerTypePath = (field: { parentId?: string }): string[] => {
-    const path: string[] = [];
-    const seen = new Set<string>();
-    let cur = field.parentId
-      ? table.getSymbolById?.(field.parentId)
-      : undefined;
-    let hops = 0;
-    while (cur && hops < 50) {
-      if (cur.id) {
-        if (seen.has(cur.id)) break;
-        seen.add(cur.id);
-      }
-      const kind = String(cur.kind).toLowerCase();
-      if (
-        cur.name &&
-        (kind === 'class' ||
-          kind === 'interface' ||
-          kind === 'enum' ||
-          kind === 'trigger')
-      ) {
-        path.unshift(cur.name.toLowerCase());
-      }
-      cur = cur.parentId ? table.getSymbolById?.(cur.parentId) : undefined;
-      hops++;
-    }
-    return path;
-  };
-  const isSuffix = (path: string[], suffix: string[]): boolean => {
-    if (suffix.length === 0 || suffix.length > path.length) return false;
-    for (let i = 1; i <= suffix.length; i++) {
-      if (path[path.length - i] !== suffix[suffix.length - i]) return false;
-    }
-    return true;
-  };
-
-  const matches = fields.filter((f) =>
-    isSuffix(requestedPath, ownerTypePath(f)),
-  );
-  if (matches.length === 1) return matches[0].location!.identifierRange!;
-  return null;
+  // Same-named fields across nested/sibling types in one file — disambiguate by
+  // owning-type FQN; ambiguity fails closed (W-23631087 review).
+  return uniqueDeclarationRangeByOwningFqn(table, fields, declaringTypeFqn);
 }
 
 /**
@@ -3555,6 +3583,7 @@ export function fieldRenameDeclarationDecision(
 function methodDeclarationRangeFromParse(
   table: {
     getAllSymbols?: () => Array<{
+      id?: string;
       name?: string;
       kind?: unknown;
       parentId?: string;
@@ -3563,8 +3592,7 @@ function methodDeclarationRangeFromParse(
       }>;
       location?: { identifierRange?: OccurrenceRange };
     }>;
-    getSymbolById?: (id: string) => { name?: string } | undefined;
-  },
+  } & DeclParseTable,
   methodName: string,
   declaringTypeFqn: string,
   signature?: string[],
@@ -3593,16 +3621,11 @@ function methodDeclarationRangeFromParse(
     if (sigMatches.length >= 1) methods = sigMatches;
   }
   if (methods.length === 1) return methods[0].location!.identifierRange!;
-  // Still ambiguous (same-named + same-signature in nested types) → declaring
-  // type leaf, then best-effort first match.
-  const declLeaf = declaringTypeFqn.split('.').pop()?.toLowerCase();
-  for (const m of methods) {
-    const parent = m.parentId ? table.getSymbolById?.(m.parentId) : undefined;
-    if (parent?.name?.toLowerCase() === declLeaf) {
-      return m.location!.identifierRange!;
-    }
-  }
-  return methods[0].location!.identifierRange!;
+  // Multiple same-name (+ same-signature) methods across nested/sibling types in
+  // one file — disambiguate by owning-type FQN; ambiguity fails closed to null so
+  // the caller declines rather than guessing methods[0] and rewriting the wrong
+  // declaration (review P2).
+  return uniqueDeclarationRangeByOwningFqn(table, methods, declaringTypeFqn);
 }
 
 /**
@@ -5079,6 +5102,18 @@ async function resolveMethodRename(
       return null;
     }
     const { declaringTypeFqn: declaringType, signature, isStatic } = ctx;
+    // An empty signature slot means a parameter's declared type could not be read
+    // (parse degradation). doesSignatureMatch would then fail to match the real
+    // overload, silently dropping its declaration from the override set while
+    // still renaming calls (a partial edit). FAIL CLOSED (review P3).
+    if (signature.some((s) => s === '')) {
+      const message =
+        `Cannot safely rename '${declaringType}.${target.name}': a parameter ` +
+        "type in the method's signature could not be resolved, so its overload " +
+        'cannot be disambiguated. The rename is declined.';
+      emitWorkerLog('warn', `[RENAME] declined method rename — ${message}`);
+      return { error: { code: -32600, message } };
+    }
     const methodTarget = {
       name: target.name,
       kind: 'method' as const,
@@ -5099,6 +5134,7 @@ async function resolveMethodRename(
     let family: {
       familyFqns?: string[];
       overrideSites?: Array<{ typeFqn: string; fileUri: string }>;
+      targetArityAmbiguous?: boolean;
     };
     try {
       family = (await requestCoordinatorAssistancePromiseShared(
@@ -5113,6 +5149,7 @@ async function resolveMethodRename(
       )) as {
         familyFqns?: string[];
         overrideSites?: Array<{ typeFqn: string; fileUri: string }>;
+        targetArityAmbiguous?: boolean;
       };
     } catch (err) {
       const message =
@@ -5124,6 +5161,7 @@ async function resolveMethodRename(
     }
     const familyFqns = new Set<string>(family?.familyFqns ?? [declaringType]);
     const overrideSites = family?.overrideSites ?? [];
+    const familyArityAmbiguous = family?.targetArityAmbiguous === true;
 
     // Stage 5b: candidate discovery — ALL stored docs (no raw-text prefilter),
     // same correctness rationale as resolveFieldRename.
@@ -5200,7 +5238,7 @@ async function resolveMethodRename(
           candidate.uri,
           methodTarget,
           declaringType,
-          { familyFqns },
+          { familyFqns, familyArityAmbiguous },
         );
         for (const occ of occurrences) {
           allOccurrences.push({ uri: occ.uri, range: occ.identifierRange });
@@ -6845,6 +6883,36 @@ const untracedHandlers: SerializedWorkerHandlers = {
               });
             }
 
+            const methodNameLower = req.methodName.toLowerCase();
+            const targetArity = req.signature?.length;
+
+            // Read a type's full+complete members once (cached by symbol ref —
+            // ancestors are visited both when seeding introducers and in the main
+            // loop, and re-enrichment is not free).
+            const membersCache = new Map<ApexSymbol, ApexSymbol[]>();
+            const membersOf = (type: ApexSymbol) =>
+              Effect.gen(function* () {
+                const cached = membersCache.get(type);
+                if (cached) return cached;
+                const members = yield* getTypeMembersFullDetail(svc, type).pipe(
+                  Effect.mapError((message) => ({
+                    _tag: 'ResolveMethodRenameFamilyError' as const,
+                    message,
+                  })),
+                );
+                membersCache.set(type, members);
+                return members;
+              });
+            const declaresTargetSig = (members: ApexSymbol[]): boolean =>
+              members.some(
+                (m) =>
+                  m.kind === SymbolKind.Method &&
+                  m.name.toLowerCase() === methodNameLower &&
+                  (req.signature
+                    ? doesSignatureMatch(m, req.methodName, [...req.signature])
+                    : true),
+              );
+
             // Static methods are not inherited, so the family is the declaring
             // type alone. Instance methods fan out over the whole cone; ancestors
             // fold in extended/implemented interfaces and descendants fold in
@@ -6856,13 +6924,50 @@ const untracedHandlers: SerializedWorkerHandlers = {
                 definingType,
               );
               family.push(...ancestors, ...descendants);
+
+              // Sibling-override capture (review P2): the cursor's type can be a
+              // MID-cone override, so a sibling that overrides the SAME method is
+              // neither its ancestor nor its descendant — it would be silently
+              // left behind (and, if it has no calls, nothing trips the unsafe
+              // decline). Any ancestor (or the cursor type) that DECLARES the
+              // signature INTRODUCES the method, so that introducer's full subtype
+              // cone contains every override incl. siblings. Expand from each.
+              for (const intro of [definingType, ...ancestors]) {
+                if (!declaresTargetSig(yield* membersOf(intro))) continue;
+                const subs = yield* Effect.promise(() =>
+                  svc.symbolManager.findSubtypes(intro),
+                );
+                for (const s of subs) if (inTypeSymbolGroup(s)) family.push(s);
+              }
             }
 
-            const methodNameLower = req.methodName.toLowerCase();
             const familyFqns: string[] = [];
             const overrideSites: Array<{ typeFqn: string; fileUri: string }> =
               [];
             const seen = new Set<string>();
+            // Distinct overload signatures (by param-type list) among family
+            // methods named the target at the target arity. ≥2 ⇒ an UNTYPED call
+            // at that arity cannot be attributed to the target overload (review
+            // P1) — the pool must then decline it in every file.
+            const overloadSigsAtArity = new Set<string>();
+            const sigKeyOf = (m: ApexSymbol): string =>
+              (
+                (
+                  m as {
+                    parameters?: Array<{
+                      type?: { name?: string; originalTypeString?: string };
+                    }>;
+                  }
+                ).parameters ?? []
+              )
+                .map((p) =>
+                  (
+                    p.type?.originalTypeString ??
+                    p.type?.name ??
+                    ''
+                  ).toLowerCase(),
+                )
+                .join(',');
 
             for (const type of family) {
               const typeFqn =
@@ -6874,33 +6979,39 @@ const untracedHandlers: SerializedWorkerHandlers = {
               seen.add(typeFqn);
               familyFqns.push(typeFqn);
 
+              const members = yield* membersOf(type);
+
+              // Accumulate distinct overload signatures at the target arity.
+              for (const m of members) {
+                if (
+                  m.kind !== SymbolKind.Method ||
+                  m.name.toLowerCase() !== methodNameLower
+                )
+                  continue;
+                const arity = (
+                  (m as { parameters?: unknown[] }).parameters ?? []
+                ).length;
+                if (targetArity === undefined || arity === targetArity) {
+                  overloadSigsAtArity.add(sigKeyOf(m));
+                }
+              }
+
               // Does this type DECLARE a signature-matching method to rename?
-              const members = yield* getTypeMembersFullDetail(svc, type).pipe(
-                Effect.mapError((message) => ({
-                  _tag: 'ResolveMethodRenameFamilyError' as const,
-                  message,
-                })),
-              );
-              const declares = members.some(
-                (m) =>
-                  m.kind === SymbolKind.Method &&
-                  m.name.toLowerCase() === methodNameLower &&
-                  (req.signature
-                    ? doesSignatureMatch(m, req.methodName, [...req.signature])
-                    : true),
-              );
-              if (declares && type.fileUri) {
+              if (declaresTargetSig(members) && type.fileUri) {
                 overrideSites.push({ typeFqn, fileUri: type.fileUri });
               }
             }
+
+            const targetArityAmbiguous = overloadSigsAtArity.size >= 2;
 
             emitWorkerLog(
               'info',
               `[RENAME] ResolveMethodRenameFamily: ${req.definingTypeFqn}.` +
                 `${req.methodName} → ${familyFqns.length} family type(s), ` +
-                `${overrideSites.length} override site(s)`,
+                `${overrideSites.length} override site(s)` +
+                (targetArityAmbiguous ? ', arity-ambiguous' : ''),
             );
-            return { familyFqns, overrideSites };
+            return { familyFqns, overrideSites, targetArityAmbiguous };
           }),
         ),
       ),

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -3545,6 +3545,67 @@ export function fieldRenameDeclarationDecision(
 }
 
 /**
+ * Method declaration name-token range from a STANDALONE parse of the declaring
+ * file (W-23631132) — the method analogue of {@link fieldDeclarationRangeFromParse}.
+ * The graph range can span the RETURN-TYPE token under full ingestion, so the
+ * declaration must come from the same parse the occurrence scan uses. Overloads
+ * are disambiguated by signature (parameter type strings); works for no-body
+ * (abstract/interface) declarations since it reads the method symbol, not a body.
+ */
+function methodDeclarationRangeFromParse(
+  table: {
+    getAllSymbols?: () => Array<{
+      name?: string;
+      kind?: unknown;
+      parentId?: string;
+      parameters?: Array<{
+        type?: { name?: string; originalTypeString?: string };
+      }>;
+      location?: { identifierRange?: OccurrenceRange };
+    }>;
+    getSymbolById?: (id: string) => { name?: string } | undefined;
+  },
+  methodName: string,
+  declaringTypeFqn: string,
+  signature?: string[],
+): OccurrenceRange | null {
+  const targetName = methodName.toLowerCase();
+  let methods = (table.getAllSymbols?.() ?? []).filter((s) => {
+    const kind = String(s?.kind).toLowerCase();
+    return (
+      s?.name?.toLowerCase() === targetName &&
+      kind === 'method' &&
+      !!s.location?.identifierRange
+    );
+  });
+  if (methods.length === 0) return null;
+  // Disambiguate overloads by parameter-type signature (case-insensitive).
+  if (methods.length > 1 && signature) {
+    const sigMatches = methods.filter((m) => {
+      const params = m.parameters ?? [];
+      if (params.length !== signature.length) return false;
+      return params.every(
+        (p, i) =>
+          (p.type?.originalTypeString ?? p.type?.name ?? '').toLowerCase() ===
+          signature[i].toLowerCase(),
+      );
+    });
+    if (sigMatches.length >= 1) methods = sigMatches;
+  }
+  if (methods.length === 1) return methods[0].location!.identifierRange!;
+  // Still ambiguous (same-named + same-signature in nested types) → declaring
+  // type leaf, then best-effort first match.
+  const declLeaf = declaringTypeFqn.split('.').pop()?.toLowerCase();
+  for (const m of methods) {
+    const parent = m.parentId ? table.getSymbolById?.(m.parentId) : undefined;
+    if (parent?.name?.toLowerCase() === declLeaf) {
+      return m.location!.identifierRange!;
+    }
+  }
+  return methods[0].location!.identifierRange!;
+}
+
+/**
  * The resolved target symbol plus every occurrence of it across the workspace,
  * as produced by {@link resolveOccurrencesForCursor}. `null` occurrences here
  * never happen — the helper returns the whole struct as `null` instead — but
@@ -4234,6 +4295,56 @@ async function resolveFieldContextForCursor(
 }
 
 /**
+ * Resolve the method under the cursor to its declaring-type FQN, parameter-type
+ * signature, and static-ness (W-23631132). renameMethod needs all three: the FQN
+ * anchors the family walk + occurrence matching, the signature disambiguates
+ * overloads, and static-ness decides whether the rename fans out over the
+ * inheritance cone (instance) or stays same-type (static).
+ */
+async function resolveMethodContextForCursor(
+  svc: RequestServices,
+  uri: string,
+  position: { line: number; character: number },
+): Promise<{
+  declaringTypeFqn: string;
+  signature: string[];
+  isStatic: boolean;
+} | null> {
+  try {
+    const parserPosition = {
+      line: position.line + 1,
+      character: position.character,
+    };
+    const symbol = await resolveCursorSymbol(svc, uri, parserPosition);
+    if (!symbol) return null;
+    const containingType = await svc.symbolManager.getContainingType(symbol);
+    if (!containingType) return null;
+    const declaringTypeFqn =
+      containingType.fqn ??
+      (await svc.symbolManager.constructFQN(containingType)) ??
+      containingType.name ??
+      null;
+    if (!declaringTypeFqn) return null;
+    const methodSym = symbol as {
+      parameters?: Array<{
+        type?: { name?: string; originalTypeString?: string };
+      }>;
+      modifiers?: { isStatic?: boolean };
+    };
+    const signature = (methodSym.parameters ?? []).map(
+      (p) => p.type?.originalTypeString ?? p.type?.name ?? '',
+    );
+    return {
+      declaringTypeFqn,
+      signature,
+      isStatic: methodSym.modifiers?.isStatic === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * LOCAL, parser-owned fallback for Stage 4.5 when the authoritative
  * `dataOwner:CheckMemberConflicts` query is unavailable (W-23631086 review, P1).
  *
@@ -4898,6 +5009,316 @@ async function resolveFieldRename(
   }
 }
 
+/**
+ * renameMethod WorkspaceEdit construction (WI 5.2). Renames a method's
+ * declaration + every call across the type family, plus every override
+ * declaration (Child.foo(), interface impls). Mirrors resolveFieldRename's
+ * pool-side scan, but the family knowledge comes from the data-owner assist
+ * `dataOwner:ResolveMethodRenameFamily` (the pool graph can't see unloaded
+ * subtypes/implementors):
+ *
+ *   - CALLS: FindOccurrenceCandidates (all stored docs) → per-candidate
+ *     findMethodOccurrences, keeping occurrences whose receiver FQN ∈ the family
+ *     cone; any unprovable occurrence → decline (no partial edit).
+ *   - DECLARATIONS: for each override site the assist returns, recompute the
+ *     name-token range from a standalone parse (methodDeclarationRangeFromParse)
+ *     so a graph range that spans the return-type token never corrupts the edit.
+ *
+ * Conflict detection + validation wiring is WI 5.3; this slice is pure edit
+ * construction. Constructors are not methods here (renameType territory).
+ */
+async function resolveMethodRename(
+  svc: RequestServices,
+  req: RenameReq,
+): Promise<WorkspaceEditResult | RenameErrorResult | null> {
+  const {
+    CompilerService,
+    ErrorType,
+    FullSymbolCollectorListener,
+    SymbolKind,
+    SymbolTable,
+    findMethodOccurrences,
+    lexMentionsIdentifier,
+    validateRenameName,
+  } = await import('@salesforce/apex-lsp-parser-ast');
+
+  const uri = req.textDocument.uri;
+
+  try {
+    // Stage 1: recompile the cursor file, then load its referenced types.
+    const cursorTextAvailable = typeof req.content === 'string';
+    const cursorRecompiled = await recompileCursorFileAtFullDetail(
+      svc,
+      uri,
+      req.content,
+      { resolveCrossFileReferences: false },
+    );
+    if (!cursorRecompiled && !cursorTextAvailable) return null;
+    await loadReferencedTypesForFile(svc, uri);
+
+    // Stage 2: confirm the cursor is on a method (constructors resolve to a
+    // different kind and fall through — renameType handles them, not here).
+    const target = await targetSymbolForCursor(svc, uri, req.position);
+    if (!target?.name) return null;
+    if (target.kind !== 'method') return null;
+
+    // Stage 3: declaring-type FQN + parameter signature + static-ness.
+    const ctx = await resolveMethodContextForCursor(svc, uri, req.position);
+    if (!ctx) {
+      emitWorkerLog(
+        'warn',
+        `[RENAME] cannot determine method context for '${target.name}' in ${uri}`,
+      );
+      return null;
+    }
+    const { declaringTypeFqn: declaringType, signature, isStatic } = ctx;
+    const methodTarget = {
+      name: target.name,
+      kind: 'method' as const,
+      signature,
+    };
+
+    // Stage 4: validate the newName. Invalid → RenameErrorResult, not null.
+    const validation = validateRenameName(req.newName, SymbolKind.Method);
+    if (!validation.ok) {
+      return { error: { code: -32602, message: validation.message } };
+    }
+
+    // (Stage 4.5 conflict detection deferred to WI 5.3.)
+
+    // Stage 5a: resolve the type family + override declaration sites on the
+    // data-owner's complete graph. On failure we cannot know the override set,
+    // so we must decline rather than emit a declaration-only partial edit.
+    let family: {
+      familyFqns?: string[];
+      overrideSites?: Array<{ typeFqn: string; fileUri: string }>;
+    };
+    try {
+      family = (await requestCoordinatorAssistancePromiseShared(
+        'dataOwner:ResolveMethodRenameFamily',
+        {
+          definingTypeFqn: declaringType,
+          methodName: target.name,
+          signature,
+          isStatic,
+        },
+        true,
+      )) as {
+        familyFqns?: string[];
+        overrideSites?: Array<{ typeFqn: string; fileUri: string }>;
+      };
+    } catch (err) {
+      const message =
+        `Cannot resolve the type family for '${declaringType}.${target.name}': ` +
+        "the method's overrides/implementors could not be determined, so this " +
+        `rename cannot be applied safely. (${err})`;
+      emitWorkerLog('warn', `[RENAME] declined method rename — ${message}`);
+      return { error: { code: -32600, message } };
+    }
+    const familyFqns = new Set<string>(family?.familyFqns ?? [declaringType]);
+    const overrideSites = family?.overrideSites ?? [];
+
+    // Stage 5b: candidate discovery — ALL stored docs (no raw-text prefilter),
+    // same correctness rationale as resolveFieldRename.
+    let scan: { candidates?: Array<{ uri: string; content: string }> };
+    try {
+      scan = (await requestCoordinatorAssistancePromiseShared(
+        'dataOwner:FindOccurrenceCandidates',
+        { symbolName: target.name, skipTextFilter: true },
+        true,
+      )) as { candidates?: Array<{ uri: string; content: string }> };
+    } catch (err) {
+      const message =
+        `Cannot verify references to '${target.name}': the workspace document ` +
+        'set could not be retrieved, so this rename cannot be applied safely. ' +
+        `(${err})`;
+      emitWorkerLog('warn', `[RENAME] declined method rename — ${message}`);
+      return { error: { code: -32600, message } };
+    }
+    const rawCandidates = scan?.candidates ?? [];
+    let candidates: Array<{ uri: string; content: string }> = rawCandidates;
+    if (typeof req.content === 'string') {
+      let cursorPresent = false;
+      candidates = rawCandidates.map((c) => {
+        if (c.uri === uri) {
+          cursorPresent = true;
+          return { ...c, content: req.content as string };
+        }
+        return c;
+      });
+      if (!cursorPresent) {
+        candidates = [{ uri, content: req.content }, ...candidates];
+      }
+    }
+    const contentByUri = new Map(candidates.map((c) => [c.uri, c.content]));
+
+    // Stage 6: per-candidate standalone parse + method occurrence classification.
+    const allOccurrences: Array<{ uri: string; range: OccurrenceRange }> = [];
+    let totalSkipped = 0;
+    const unsafeOccurrences: Array<{ uri: string; reason: string }> = [];
+    const seen = new Set<string>();
+    for (const candidate of candidates) {
+      if (seen.has(candidate.uri)) continue;
+      seen.add(candidate.uri);
+      try {
+        const t = new SymbolTable();
+        const compiled = new CompilerService().compile(
+          candidate.content,
+          candidate.uri,
+          new FullSymbolCollectorListener(t),
+          { collectReferences: true, resolveReferences: true },
+        );
+        const syntaxErrorCount = (compiled?.errors ?? []).filter(
+          (e) => e.type === ErrorType.Syntax,
+        ).length;
+        if (
+          !(compiled?.result instanceof SymbolTable) ||
+          syntaxErrorCount > 0
+        ) {
+          // A broken parse only endangers this rename if the file could mention
+          // the method; a lexer check (parser-owned, not regex) lets us skip
+          // provably-unrelated broken files rather than block every rename.
+          if (!lexMentionsIdentifier(candidate.content, target.name)) continue;
+          const detail = !(compiled?.result instanceof SymbolTable)
+            ? 'no-result'
+            : `${syntaxErrorCount} syntax error(s)`;
+          unsafeOccurrences.push({
+            uri: candidate.uri,
+            reason: `candidate-parse-incomplete:${detail}`,
+          });
+          continue;
+        }
+        const { occurrences, skipped, unsafe } = findMethodOccurrences(
+          compiled.result,
+          candidate.uri,
+          methodTarget,
+          declaringType,
+          { familyFqns },
+        );
+        for (const occ of occurrences) {
+          allOccurrences.push({ uri: occ.uri, range: occ.identifierRange });
+        }
+        totalSkipped += skipped.length;
+        for (const u of unsafe) {
+          unsafeOccurrences.push({ uri: candidate.uri, reason: u.reason });
+        }
+      } catch (err) {
+        unsafeOccurrences.push({
+          uri: candidate.uri,
+          reason: `candidate-scan-failed: ${err}`,
+        });
+      }
+    }
+
+    // Override DECLARATIONS: findMethodOccurrences matches CALLS only, so each
+    // family override's declaration token is added here from a standalone parse
+    // of its file. A missing override-site file (the family says a signature-
+    // matching method is declared there but its content is unavailable) means we
+    // cannot rewrite that declaration → decline rather than emit a partial edit.
+    for (const site of overrideSites) {
+      const content = contentByUri.get(site.fileUri);
+      if (content === undefined) {
+        unsafeOccurrences.push({
+          uri: site.fileUri,
+          reason: 'override-declaration-content-unavailable',
+        });
+        continue;
+      }
+      try {
+        const declTable = new SymbolTable();
+        const declCompiled = new CompilerService().compile(
+          content,
+          site.fileUri,
+          new FullSymbolCollectorListener(declTable),
+          { collectReferences: true, resolveReferences: true },
+        );
+        const parsed =
+          declCompiled?.result instanceof SymbolTable
+            ? declCompiled.result
+            : declTable;
+        const range = methodDeclarationRangeFromParse(
+          parsed as never,
+          target.name,
+          site.typeFqn,
+          signature,
+        );
+        if (range) {
+          allOccurrences.push({ uri: site.fileUri, range });
+        } else {
+          unsafeOccurrences.push({
+            uri: site.fileUri,
+            reason: `override-declaration-not-found:${site.typeFqn}`,
+          });
+        }
+      } catch (err) {
+        unsafeOccurrences.push({
+          uri: site.fileUri,
+          reason: `override-declaration-scan-failed: ${err}`,
+        });
+      }
+    }
+
+    // Decline the whole rename if ANY occurrence/declaration was unprovable —
+    // applying edits while omitting one would emit a broken partial WorkspaceEdit.
+    if (unsafeOccurrences.length > 0) {
+      const sample = unsafeOccurrences
+        .slice(0, 3)
+        .map((u) => `${u.uri} (${u.reason})`)
+        .join(', ');
+      const message =
+        `Cannot safely rename '${target.name}': ${unsafeOccurrences.length} ` +
+        'occurrence(s) or override declaration(s) could not be resolved without ' +
+        `risking a broken partial edit. Examples: ${sample}.`;
+      emitWorkerLog('warn', `[RENAME] declined method rename — ${message}`);
+      return { error: { code: -32600, message } };
+    }
+
+    if (allOccurrences.length === 0) return null;
+
+    emitWorkerLog(
+      'info',
+      `[RENAME] method '${declaringType}.${target.name}' → '${req.newName}': ` +
+        `${allOccurrences.length} edit(s) across ${familyFqns.size} family ` +
+        `type(s), ${overrideSites.length} declaration site(s), ` +
+        `${totalSkipped} skipped`,
+    );
+
+    // Stage 7: assemble the multi-file WorkspaceEdit (parser 1-based → LSP
+    // 0-based), deduped per URI by position.
+    const changes: Record<
+      string,
+      Array<{
+        range: {
+          start: { line: number; character: number };
+          end: { line: number; character: number };
+        };
+        newText: string;
+      }>
+    > = {};
+    const seenEdits = new Set<string>();
+    for (const occ of allOccurrences) {
+      const r = occ.range;
+      const key =
+        `${occ.uri}\x1f${r.startLine}:${r.startColumn}:` +
+        `${r.endLine}:${r.endColumn}`;
+      if (seenEdits.has(key)) continue;
+      seenEdits.add(key);
+      (changes[occ.uri] ??= []).push({
+        range: {
+          start: { line: r.startLine - 1, character: r.startColumn },
+          end: { line: r.endLine - 1, character: r.endColumn },
+        },
+        newText: req.newName,
+      });
+    }
+
+    return { changes };
+  } catch (err) {
+    emitWorkerLog('warn', `[RENAME] method rename failed for ${uri}: ${err}`);
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Enrichment dispatch handlers (Step 11 on the original file)
 // ---------------------------------------------------------------------------
@@ -5206,13 +5627,17 @@ const requestHandlers = {
   DispatchRename: requestHandler<RenameReq>(
     'DispatchRename',
     async (svc, req) => {
-      // renameLocal first (single-file, no svc needed). A `null` result means
-      // the cursor isn't a local — fall through to renameField (W-23631084),
-      // which needs `svc` for the workspace-wide two-phase scan. A field/method/
-      // type cursor that isn't a field still returns null from both.
+      // renameLocal first (single-file, no svc needed). A `null` means the
+      // cursor isn't a local → fall through to renameField (W-23631084), then
+      // renameMethod (W-23631132) — both use `svc` for the workspace-wide scan.
+      // A type/constructor cursor returns null from all three (renameType TBD).
       const local = await resolveLocalRename(req);
       if (local !== null) return local;
-      return resolveFieldRename(svc, req);
+      // Only a `null` (not-my-kind) may fall through; a RenameErrorResult must
+      // return so a field/method name-conflict isn't retried as another kind.
+      const field = await resolveFieldRename(svc, req);
+      if (field !== null) return field;
+      return resolveMethodRename(svc, req);
     },
   ),
   // prepareRename for locals (W-23631080) + fields (W-23631087). Local path

--- a/packages/apex-ls/test/integration/RenameMethodThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/RenameMethodThroughWorkerTopology.node.test.ts
@@ -117,6 +117,35 @@ const RM_FACTORY_SRC = `public class RmFactory {
     public void go() { build().ship(); }
 }`;
 
+// Case 6 (review P1): cross-file SAME-ARITY overloads. Renaming pick(Integer)
+// must decline because a caller's untyped same-arity call pick('hi') could bind
+// the OTHER overload, and argumentTypes are never populated to disambiguate.
+const RM_SVC_URI = 'file:///test/RmSvc.cls';
+const RM_SVC_SRC = `public class RmSvc {
+    public void pick(Integer a) { }
+    public void pick(String a) { }
+}`;
+const RM_SVCCALLER_URI = 'file:///test/RmSvcCaller.cls';
+const RM_SVCCALLER_SRC = `public class RmSvcCaller {
+    public void run(RmSvc s) { s.pick('hi'); }
+}`;
+
+// Case 7 (review P2): SIBLING override with no calls. Renaming from the mid-cone
+// override RmCircle.draw must also rename the sibling RmSquare.draw declaration
+// (both override RmShape.draw), not silently leave it behind.
+const RM_SHAPE_URI = 'file:///test/RmShape.cls';
+const RM_SHAPE_SRC = `public virtual class RmShape {
+    public virtual void draw() { }
+}`;
+const RM_CIRCLE_URI = 'file:///test/RmCircle.cls';
+const RM_CIRCLE_SRC = `public class RmCircle extends RmShape {
+    public override void draw() { }
+}`;
+const RM_SQUARE_URI = 'file:///test/RmSquare.cls';
+const RM_SQUARE_SRC = `public class RmSquare extends RmShape {
+    public override void draw() { }
+}`;
+
 const SOURCES: Record<string, string> = {
   [RM_BASE_URI]: RM_BASE_SRC,
   [RM_CHILD_URI]: RM_CHILD_SRC,
@@ -126,6 +155,11 @@ const SOURCES: Record<string, string> = {
   [RM_OVERLOAD_URI]: RM_OVERLOAD_SRC,
   [RM_PRODUCT_URI]: RM_PRODUCT_SRC,
   [RM_FACTORY_URI]: RM_FACTORY_SRC,
+  [RM_SVC_URI]: RM_SVC_SRC,
+  [RM_SVCCALLER_URI]: RM_SVCCALLER_SRC,
+  [RM_SHAPE_URI]: RM_SHAPE_SRC,
+  [RM_CIRCLE_URI]: RM_CIRCLE_SRC,
+  [RM_SQUARE_URI]: RM_SQUARE_SRC,
 };
 
 const WORKSPACE_ENTRIES = Object.entries(SOURCES).map(([uri, content]) => ({
@@ -363,5 +397,50 @@ describe('renameMethod through the worker topology (W-23631132, slice 4)', () =>
     expect(result!.error!.code).toBe(-32600);
     expect(typeof result!.error!.message).toBe('string');
     expect(result!.error!.message.length).toBeGreaterThan(0);
+  }, 120_000);
+
+  it('declines a cross-file untyped call to a same-arity overload (review P1)', async () => {
+    // Cursor on RmSvc.pick(Integer) declaration (LSP line 1, char 18). RmSvc
+    // declares two arity-1 overloads; RmSvcCaller's `s.pick('hi')` is untyped
+    // (argumentTypes never populated) so it could bind pick(String). The family
+    // is arity-ambiguous, so the whole rename must DECLINE — never silently
+    // rewrite that call while leaving pick(String) behind.
+    const result = await rename(
+      RM_SVC_URI,
+      { line: 1, character: 18 },
+      'choose',
+    );
+    logger.debug(
+      `[rename-method:overload-crossfile] ${JSON.stringify(result)}`,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('error');
+    expect(result).not.toHaveProperty('changes');
+    expect(result!.error!.code).toBe(-32600);
+    expect(result!.error!.message.length).toBeGreaterThan(0);
+  }, 120_000);
+
+  it('renames a SIBLING override declaration with no calls (review P2)', async () => {
+    // Cursor on the mid-cone override RmCircle.draw (LSP line 1, char 27).
+    // RmSquare.draw is a SIBLING override (both extend RmShape) with no call
+    // sites — it must still be renamed, not silently left behind.
+    const result = await rename(
+      RM_CIRCLE_URI,
+      { line: 1, character: 27 },
+      'render',
+    );
+    logger.debug(`[rename-method:sibling] ${JSON.stringify(result)}`);
+
+    expect(result?.error).toBeUndefined();
+    expect(result?.changes).toBeDefined();
+    const changes = result!.changes!;
+    // All three override declarations renamed — including the sibling RmSquare.
+    expect(changes[RM_SHAPE_URI]).toBeDefined();
+    expect(changes[RM_CIRCLE_URI]).toBeDefined();
+    expect(changes[RM_SQUARE_URI]).toBeDefined();
+    Object.values(changes)
+      .flat()
+      .forEach((e) => expect(e.newText).toBe('render'));
   }, 120_000);
 });

--- a/packages/apex-ls/test/integration/RenameMethodThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/RenameMethodThroughWorkerTopology.node.test.ts
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * renameMethod worker-topology tests (W-23631132 / WI 5.2, slice 4).
+ *
+ * Exercises resolveMethodRename end-to-end across the worker boundary:
+ *   dispatch('rename') → request-pool `DispatchRename` handler →
+ *   data-owner assist `dataOwner:ResolveMethodRenameFamily` (family cone +
+ *   override declaration sites) → per-candidate `findMethodOccurrences` scan →
+ *   multi-file WorkspaceEdit (declaration + all calls + every override decl).
+ *
+ * The KEY proof is the cross-file OVERRIDE case: renaming a base method must
+ * also rewrite each subclass/implementor override DECLARATION, which is only
+ * discoverable from the data-owner's COMPLETE inheritance cone. That cone only
+ * exists after a full workspace load (Begin → ingest → compile → Drain) — plain
+ * documentOpen does NOT resolve cross-file override edges — so this suite copies
+ * CheckMemberConflicts' SUITE-LEVEL setup: one Scope-owned topology + one
+ * ingested/compiled/drained workspace built in `beforeAll`. Each test then
+ * dispatches a single pool rename via the production mediator (required so the
+ * pool's requestCoordinatorAssistance reaches the data-owner assist).
+ *
+ * Every fixture uses a unique type name and a unique target method name so all
+ * fixtures coexist in ONE workspace without cross-contamination.
+ */
+
+import * as path from 'node:path';
+import { Effect, Exit, Scope } from 'effect';
+import {
+  getLogger,
+  setLogLevel,
+  type LoggerInterface,
+  type WorkerRole,
+} from '@salesforce/apex-lsp-shared';
+import {
+  clearRawWorkers,
+  initializeTopology,
+  makeNodeWorkerLayer,
+  makeWorkerDispatcher,
+  getRawWorkers,
+  getAssistancePorts,
+  getWorkerNames,
+  runRemoteStdlibWarmupPhase,
+  type WorkerTopology,
+} from '../../src/server/WorkerCoordinator';
+import { CoordinatorAssistanceMediator } from '../../src/server/CoordinatorAssistanceMediator';
+import { createPrimaryAssistanceHandler } from '../../src/server/CoordinatorPrimaryAssistanceHandler';
+import { ResourceLoaderProxy } from '../../src/server/ResourceLoaderProxy';
+
+const WORKER_ENTRY = path.resolve(__dirname, '../../src/worker.platform.ts');
+const COMPILATION_POOL_SIZE = 2;
+const SESSION_ID = 'rename-method-shared-session';
+
+const workerLayerFactory = (role: WorkerRole) =>
+  makeNodeWorkerLayer(WORKER_ENTRY, {
+    name: `test-${role}`,
+    execArgv: ['--import', 'tsx'],
+    workerData: {
+      role,
+      compilationPoolSize: COMPILATION_POOL_SIZE,
+      compilationConcurrency: 1,
+    },
+  });
+
+// --- Fixtures ---------------------------------------------------------------
+// Cursor positions are LSP 0-based {line, character}, placed INSIDE the method-
+// name token (columns computed against the raw source below).
+
+// Case 1: cross-file override. RmBase.run() is overridden by RmChild.run().
+const RM_BASE_URI = 'file:///test/RmBase.cls';
+const RM_BASE_SRC = `public virtual class RmBase {
+    public virtual void run() { }
+}`;
+const RM_CHILD_URI = 'file:///test/RmChild.cls';
+const RM_CHILD_SRC = `public class RmChild extends RmBase {
+    public override void run() { }
+}`;
+
+// Case 2: interface implementer. RmGreeter implements RmIGreeter.greet().
+const RM_IGREETER_URI = 'file:///test/RmIGreeter.cls';
+const RM_IGREETER_SRC = `public interface RmIGreeter {
+    void greet();
+}`;
+const RM_GREETER_URI = 'file:///test/RmGreeter.cls';
+const RM_GREETER_SRC = `public class RmGreeter implements RmIGreeter {
+    public void greet() { }
+}`;
+
+// Case 3: static method (no family cone) + an in-class call.
+const RM_UTIL_URI = 'file:///test/RmUtil.cls';
+const RM_UTIL_SRC = `public class RmUtil {
+    public static Integer compute() { return 1; }
+    public static Integer caller() { return compute(); }
+}`;
+
+// Case 4: overload disambiguation — rename the 0-arg m() only.
+const RM_OVERLOAD_URI = 'file:///test/RmOverload.cls';
+const RM_OVERLOAD_SRC = `public class RmOverload {
+    public void m() { }
+    public void m(Integer x) { }
+    public void caller() { m(); }
+}`;
+
+// Case 5: unsafe method-result receiver → decline.
+const RM_PRODUCT_URI = 'file:///test/RmProduct.cls';
+const RM_PRODUCT_SRC = `public class RmProduct {
+    public void ship() { }
+}`;
+const RM_FACTORY_URI = 'file:///test/RmFactory.cls';
+const RM_FACTORY_SRC = `public class RmFactory {
+    public RmProduct build() { return new RmProduct(); }
+    public void go() { build().ship(); }
+}`;
+
+const SOURCES: Record<string, string> = {
+  [RM_BASE_URI]: RM_BASE_SRC,
+  [RM_CHILD_URI]: RM_CHILD_SRC,
+  [RM_IGREETER_URI]: RM_IGREETER_SRC,
+  [RM_GREETER_URI]: RM_GREETER_SRC,
+  [RM_UTIL_URI]: RM_UTIL_SRC,
+  [RM_OVERLOAD_URI]: RM_OVERLOAD_SRC,
+  [RM_PRODUCT_URI]: RM_PRODUCT_SRC,
+  [RM_FACTORY_URI]: RM_FACTORY_SRC,
+};
+
+const WORKSPACE_ENTRIES = Object.entries(SOURCES).map(([uri, content]) => ({
+  uri,
+  content,
+  languageId: 'apex' as const,
+  version: 1,
+}));
+
+const stubConnection = {
+  sendRequest: async () => null,
+  sendNotification: async () => undefined,
+};
+
+// Copied from RenameThroughWorkerTopology: wires the pool's assistance channel
+// to the data owner so `dataOwner:ResolveMethodRenameFamily` / `...Candidates`
+// requests are answered via queryDataOwner.
+function wireProductionMediator(
+  topology: WorkerTopology,
+  dispatcher: ReturnType<typeof makeWorkerDispatcher>,
+  logger: LoggerInterface,
+): CoordinatorAssistanceMediator {
+  const resourceLoaderProxy = topology.resourceLoader
+    ? new ResourceLoaderProxy(topology.resourceLoader, logger)
+    : undefined;
+  const mediator = new CoordinatorAssistanceMediator(
+    createPrimaryAssistanceHandler({
+      connection: stubConnection,
+      logger,
+      getResourceLoaderProxy: () => resourceLoaderProxy,
+    }),
+    logger,
+    (method, params) => dispatcher.queryDataOwner(method, params),
+  );
+  mediator.attachToWorkers(
+    getRawWorkers(),
+    getAssistancePorts(),
+    getWorkerNames(),
+  );
+  return mediator;
+}
+
+type EditList = Array<{
+  range: {
+    start: { line: number; character: number };
+    end: { line: number; character: number };
+  };
+  newText: string;
+}>;
+type RenameResult = {
+  changes?: Record<string, EditList>;
+  error?: { code: number; message: string };
+} | null;
+
+describe('renameMethod through the worker topology (W-23631132, slice 4)', () => {
+  let logger: LoggerInterface;
+  let scope: Scope.CloseableScope;
+  let dispatcher: ReturnType<typeof makeWorkerDispatcher>;
+
+  beforeAll(async () => {
+    setLogLevel('error');
+    logger = getLogger();
+
+    // Long-lived, suite-owned scope keeps the workers alive across every test.
+    scope = Effect.runSync(Scope.make());
+
+    const setup = Effect.gen(function* () {
+      const topology = yield* initializeTopology({
+        poolSize: 1,
+        enableResourceLoader: true,
+        compilationPoolSize: COMPILATION_POOL_SIZE,
+        compilationConcurrency: 1,
+        logger,
+        logLevel: 'error',
+        workerLayerFactory,
+      });
+      const d = makeWorkerDispatcher(topology, logger, (uri) => SOURCES[uri]);
+      wireProductionMediator(topology, d, logger);
+      yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+      const session = d.createWorkspaceLoadSessionDispatcher();
+      const ingest = d.createBatchIngestionDispatcher();
+      const compile = d.createDataOwnerCompileDispatcher();
+
+      // Begin → ingest → compile → Drain builds the COMPLETE inheritance cone,
+      // so cross-file override / implementor edges resolve.
+      yield* Effect.promise(() =>
+        session({ _tag: 'BeginWorkspaceLoadSession', sessionId: SESSION_ID }),
+      );
+      yield* Effect.promise(() => ingest(SESSION_ID, WORKSPACE_ENTRIES));
+      yield* Effect.promise(() =>
+        compile({ sessionId: SESSION_ID, entries: WORKSPACE_ENTRIES }),
+      );
+      yield* Effect.promise(() =>
+        session({ _tag: 'DrainDeferredReferences', sessionId: SESSION_ID }),
+      );
+      return d;
+    });
+
+    dispatcher = await Effect.runPromise(
+      Effect.provideService(setup, Scope.Scope, scope),
+    );
+  }, 120_000);
+
+  afterAll(async () => {
+    if (scope) {
+      await Effect.runPromise(Scope.close(scope, Exit.void));
+    }
+    clearRawWorkers();
+  }, 30_000);
+
+  // Dispatch a single pool rename with the cursor file's live buffer content.
+  const rename = (
+    uri: string,
+    position: { line: number; character: number },
+    newName: string,
+  ): Promise<RenameResult> =>
+    dispatcher.dispatch('rename', {
+      textDocument: { uri },
+      position,
+      newName,
+      content: SOURCES[uri],
+    }) as Promise<RenameResult>;
+
+  it('renames a base method AND its cross-file override declaration', async () => {
+    // Cursor on RmBase.run declaration (LSP line 1, char 25 — inside `run`).
+    const result = await rename(
+      RM_BASE_URI,
+      { line: 1, character: 25 },
+      'execute',
+    );
+    logger.debug(`[rename-method:override] ${JSON.stringify(result)}`);
+
+    expect(result?.error).toBeUndefined();
+    expect(result?.changes).toBeDefined();
+    const changes = result!.changes!;
+    // BOTH the base and the child override declaration files are edited.
+    expect(Object.keys(changes).sort()).toEqual(
+      [RM_BASE_URI, RM_CHILD_URI].sort(),
+    );
+
+    // Base: the `run` declaration on line 1 is renamed to `execute`.
+    const baseEdits = changes[RM_BASE_URI];
+    expect(baseEdits.length).toBeGreaterThan(0);
+    baseEdits.forEach((e) => expect(e.newText).toBe('execute'));
+    expect(baseEdits.some((e) => e.range.start.line === 1)).toBe(true);
+
+    // KEY PROOF: the child OVERRIDE DECLARATION (line 1 of RmChild) is renamed.
+    const childEdits = changes[RM_CHILD_URI];
+    expect(childEdits.length).toBeGreaterThan(0);
+    childEdits.forEach((e) => expect(e.newText).toBe('execute'));
+    expect(childEdits.some((e) => e.range.start.line === 1)).toBe(true);
+  }, 120_000);
+
+  it('renames an interface method AND its implementor declaration', async () => {
+    // Cursor on RmIGreeter.greet declaration (LSP line 1, char 11).
+    const result = await rename(
+      RM_IGREETER_URI,
+      { line: 1, character: 11 },
+      'hail',
+    );
+    logger.debug(`[rename-method:interface] ${JSON.stringify(result)}`);
+
+    expect(result?.error).toBeUndefined();
+    expect(result?.changes).toBeDefined();
+    const changes = result!.changes!;
+    // Both the interface declaration and the implementor declaration renamed.
+    expect(changes[RM_IGREETER_URI]).toBeDefined();
+    expect(changes[RM_GREETER_URI]).toBeDefined();
+    expect(changes[RM_IGREETER_URI].every((e) => e.newText === 'hail')).toBe(
+      true,
+    );
+    expect(changes[RM_GREETER_URI].every((e) => e.newText === 'hail')).toBe(
+      true,
+    );
+  }, 120_000);
+
+  it('renames a static method declaration and its in-class call (no cone)', async () => {
+    // Cursor on RmUtil.compute declaration (LSP line 1, char 29).
+    const result = await rename(
+      RM_UTIL_URI,
+      { line: 1, character: 29 },
+      'calc',
+    );
+    logger.debug(`[rename-method:static] ${JSON.stringify(result)}`);
+
+    expect(result?.error).toBeUndefined();
+    expect(result?.changes).toBeDefined();
+    const changes = result!.changes!;
+    // Static method: family is the declaring type alone — only RmUtil edited.
+    expect(Object.keys(changes)).toEqual([RM_UTIL_URI]);
+    const edits = changes[RM_UTIL_URI];
+    // Declaration (line 1) + the compute() call (line 2).
+    expect(edits.length).toBeGreaterThanOrEqual(2);
+    edits.forEach((e) => expect(e.newText).toBe('calc'));
+    expect(edits.some((e) => e.range.start.line === 1)).toBe(true);
+    expect(edits.some((e) => e.range.start.line === 2)).toBe(true);
+  }, 120_000);
+
+  it('renames only the 0-arg overload, leaving m(Integer x) untouched', async () => {
+    // Cursor on the 0-arg m() declaration (LSP line 1, char 16).
+    const result = await rename(
+      RM_OVERLOAD_URI,
+      { line: 1, character: 16 },
+      'run',
+    );
+    logger.debug(`[rename-method:overload] ${JSON.stringify(result)}`);
+
+    expect(result?.error).toBeUndefined();
+    expect(result?.changes).toBeDefined();
+    const edits = result!.changes![RM_OVERLOAD_URI];
+    expect(edits).toBeDefined();
+    edits.forEach((e) => expect(e.newText).toBe('run'));
+    // The 0-arg declaration (line 1) and its call in caller() (line 3) renamed.
+    expect(edits.some((e) => e.range.start.line === 1)).toBe(true);
+    expect(edits.some((e) => e.range.start.line === 3)).toBe(true);
+    // The m(Integer x) declaration (line 2) is NOT renamed (arity distinguishes).
+    expect(edits.some((e) => e.range.start.line === 2)).toBe(false);
+  }, 120_000);
+
+  it('declines when a candidate reaches the method via a method-result receiver', async () => {
+    // Cursor on RmProduct.ship declaration (LSP line 1, char 17). RmFactory's
+    // `build().ship()` is a method-result receiver that cannot be proven
+    // standalone → the whole rename must decline (no partial edit).
+    const result = await rename(
+      RM_PRODUCT_URI,
+      { line: 1, character: 17 },
+      'deliver',
+    );
+    logger.debug(`[rename-method:decline] ${JSON.stringify(result)}`);
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('error');
+    expect(result).not.toHaveProperty('changes');
+    expect(result!.error!.code).toBe(-32600);
+    expect(typeof result!.error!.message).toBe('string');
+    expect(result!.error!.message.length).toBeGreaterThan(0);
+  }, 120_000);
+});

--- a/packages/apex-ls/test/integration/RenameMethodThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/RenameMethodThroughWorkerTopology.node.test.ts
@@ -146,6 +146,32 @@ const RM_SQUARE_SRC = `public class RmSquare extends RmShape {
     public override void draw() { }
 }`;
 
+// Case 8 (re-review 5.2): STATIC method inherited by a subclass. Statics are
+// inherited/callable in Apex, so renaming the base static must also rename the
+// subclass's inherited call (`RmStatChild` does NOT redeclare `tally`).
+const RM_STATBASE_URI = 'file:///test/RmStatBase.cls';
+const RM_STATBASE_SRC = `public virtual class RmStatBase {
+    public static Integer tally() { return 1; }
+}`;
+const RM_STATCHILD_URI = 'file:///test/RmStatChild.cls';
+const RM_STATCHILD_SRC = `public class RmStatChild extends RmStatBase {
+    public Integer use() { return tally(); }
+}`;
+
+// Case 9 (re-review 5.2): static method HIDING. `RmStatHideChild` redeclares a
+// same-name static (a DISTINCT method), so renaming the base static must NOT
+// rename the child's declaration or its call — the child's call cannot be proven
+// unrelated standalone, so the rename fail-closes (declines) rather than corrupt.
+const RM_STATHIDEBASE_URI = 'file:///test/RmStatHideBase.cls';
+const RM_STATHIDEBASE_SRC = `public virtual class RmStatHideBase {
+    public static Integer score() { return 1; }
+}`;
+const RM_STATHIDECHILD_URI = 'file:///test/RmStatHideChild.cls';
+const RM_STATHIDECHILD_SRC = `public class RmStatHideChild extends RmStatHideBase {
+    public static Integer score() { return 2; }
+    public Integer use() { return score(); }
+}`;
+
 const SOURCES: Record<string, string> = {
   [RM_BASE_URI]: RM_BASE_SRC,
   [RM_CHILD_URI]: RM_CHILD_SRC,
@@ -160,6 +186,10 @@ const SOURCES: Record<string, string> = {
   [RM_SHAPE_URI]: RM_SHAPE_SRC,
   [RM_CIRCLE_URI]: RM_CIRCLE_SRC,
   [RM_SQUARE_URI]: RM_SQUARE_SRC,
+  [RM_STATBASE_URI]: RM_STATBASE_SRC,
+  [RM_STATCHILD_URI]: RM_STATCHILD_SRC,
+  [RM_STATHIDEBASE_URI]: RM_STATHIDEBASE_SRC,
+  [RM_STATHIDECHILD_URI]: RM_STATHIDECHILD_SRC,
 };
 
 const WORKSPACE_ENTRIES = Object.entries(SOURCES).map(([uri, content]) => ({
@@ -357,6 +387,47 @@ describe('renameMethod through the worker topology (W-23631132, slice 4)', () =>
     edits.forEach((e) => expect(e.newText).toBe('calc'));
     expect(edits.some((e) => e.range.start.line === 1)).toBe(true);
     expect(edits.some((e) => e.range.start.line === 2)).toBe(true);
+  }, 120_000);
+
+  it('renames an inherited static call in a subclass cross-file (re-review 5.2)', async () => {
+    // Cursor on RmStatBase.tally declaration (LSP line 1, char 28). Statics are
+    // inherited, so RmStatChild's unqualified `tally()` call binds to this static
+    // and must be renamed too — the descendant cone is now part of the occurrence
+    // family for statics.
+    const result = await rename(
+      RM_STATBASE_URI,
+      { line: 1, character: 28 },
+      'count',
+    );
+    logger.debug(`[rename-method:static-inherited] ${JSON.stringify(result)}`);
+
+    expect(result?.error).toBeUndefined();
+    expect(result?.changes).toBeDefined();
+    const changes = result!.changes!;
+    // Base declaration renamed AND the subclass's inherited call renamed.
+    expect(changes[RM_STATBASE_URI]).toBeDefined();
+    expect(changes[RM_STATCHILD_URI]).toBeDefined();
+    Object.values(changes)
+      .flat()
+      .forEach((e) => expect(e.newText).toBe('count'));
+  }, 120_000);
+
+  it('declines a static rename when a subclass HIDES it with its own static (re-review 5.2)', async () => {
+    // Cursor on RmStatHideBase.score (LSP line 1, char 28). RmStatHideChild
+    // redeclares a same-name static (method hiding — a DISTINCT method), so its
+    // `score()` call cannot be proven unrelated standalone → fail closed (decline)
+    // rather than rename a call that binds to the child's own static.
+    const result = await rename(
+      RM_STATHIDEBASE_URI,
+      { line: 1, character: 28 },
+      'points',
+    );
+    logger.debug(`[rename-method:static-hiding] ${JSON.stringify(result)}`);
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('error');
+    expect(result).not.toHaveProperty('changes');
+    expect(result!.error!.code).toBe(-32600);
   }, 120_000);
 
   it('renames only the 0-arg overload, leaving m(Integer x) untouched', async () => {

--- a/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
@@ -168,14 +168,16 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
         }),
       );
 
-      // Dispatch rename on the `greet` method. The Phase-0 handler ignores the
-      // position/newName and returns null; what we're proving is that the
-      // request crosses the worker boundary and settles.
+      // Dispatch rename on the TYPE name `RenameTarget` — an unsupported rename
+      // kind (renameType is TBD), so every resolver returns null. We're proving
+      // the request crosses the worker boundary and settles, not the edit. (A
+      // method/field cursor now produces a real WorkspaceEdit, so this uses a
+      // type cursor to keep asserting the null-settles path.)
       const result = yield* Effect.promise(() =>
         dispatcher.dispatch('rename', {
           textDocument: { uri: UTIL_URI },
-          position: { line: 1, character: 18 }, // on `greet`
-          newName: 'salute',
+          position: { line: 0, character: 18 }, // on `RenameTarget`
+          newName: 'Renamed',
         }),
       );
 
@@ -187,9 +189,9 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
       `[rename-topology] canDispatch=${canDispatch} result=${JSON.stringify(result)}`,
     );
 
-    // The pipe is live (rename is pool-dispatchable) and a method cursor (not
-    // yet a supported rename kind) returns null across the boundary — no throw,
-    // no hang.
+    // The pipe is live (rename is pool-dispatchable) and a type cursor (not yet
+    // a supported rename kind) returns null across the boundary — no throw, no
+    // hang.
     expect(canDispatch).toBe(true);
     expect(result).toBeNull();
   }, 120_000);
@@ -2068,6 +2070,82 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
       expect(errResult.error.code).toBe(-32600);
       expect(errResult.error.message).toContain('amount');
       expect(result).not.toHaveProperty('changes');
+    }, 120_000);
+  });
+
+  // W-23631132 (5.2): renameMethod WorkspaceEdit construction. Slice-3 smoke test
+  // for the wiring (dispatch → ResolveMethodRenameFamily assist → candidate scan →
+  // findMethodOccurrences → override-declaration collection → WorkspaceEdit). The
+  // comprehensive cross-file override / interface / static / overload suite is 5.4.
+  describe('renameMethod (W-23631132)', () => {
+    it('renames an instance method declaration and its in-class calls', async () => {
+      const METHOD_URI = 'file:///test/MethodSample.cls';
+      const METHOD_SRC = `public class MethodSample {
+    public Integer compute() {
+        return helper() + this.helper();
+    }
+
+    public Integer helper() {
+        return 1;
+    }
+}`;
+
+      const program = Effect.gen(function* () {
+        const topology = yield* initializeTopology({
+          poolSize: 1,
+          enableResourceLoader: true,
+          logger,
+          logLevel: LOG_LEVEL,
+          compilationPoolSize: COMPILATION_POOL_SIZE,
+          compilationConcurrency: 1,
+          workerLayerFactory,
+        });
+        const dispatcher = makeWorkerDispatcher(topology, logger, (uri) =>
+          uri === METHOD_URI ? METHOD_SRC : undefined,
+        );
+        wireProductionMediator(topology, dispatcher, logger);
+        yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+        yield* Effect.promise(() =>
+          dispatcher.dispatch('documentOpen', {
+            document: {
+              uri: METHOD_URI,
+              languageId: 'apex',
+              version: 1,
+              getText: () => METHOD_SRC,
+            },
+            textDocument: { uri: METHOD_URI },
+            text: METHOD_SRC,
+          }),
+        );
+
+        // Cursor on the `helper` DECLARATION (LSP line 5 `    public Integer
+        // helper() {`, char 21 — inside `helper`).
+        const result = yield* Effect.promise(() =>
+          dispatcher.dispatch('rename', {
+            textDocument: { uri: METHOD_URI },
+            position: { line: 5, character: 21 },
+            newName: 'assist',
+            content: METHOD_SRC,
+          }),
+        );
+        return { result };
+      }).pipe(Effect.scoped);
+
+      const { result } = await Effect.runPromise(program);
+      logger.debug(`[rename-method:single-file] ${JSON.stringify(result)}`);
+
+      const edit = result as {
+        changes?: Record<string, Array<{ range: any; newText: string }>>;
+      } | null;
+      expect(edit?.changes).toBeDefined();
+      const edits = edit!.changes![METHOD_URI];
+      expect(edits).toBeDefined();
+      // Declaration + bare `helper()` call + `this.helper()` call.
+      expect(edits.length).toBeGreaterThanOrEqual(3);
+      edits.forEach((e) => expect(e.newText).toBe('assist'));
+      // The declaration (LSP line 5) must be among the edits.
+      expect(edits.some((e) => e.range.start.line === 5)).toBe(true);
     }, 120_000);
   });
 });

--- a/packages/apex-lsp-shared/src/index.ts
+++ b/packages/apex-lsp-shared/src/index.ts
@@ -539,6 +539,7 @@ export {
   ResolveDependentUris,
   CheckMemberConflicts,
   FindOccurrenceCandidates,
+  ResolveMethodRenameFamily,
   EnsureWorkspaceLoaded,
   WorkspaceBatchIngest,
   CompileDocument,

--- a/packages/apex-lsp-shared/src/workerWireSchemas.ts
+++ b/packages/apex-lsp-shared/src/workerWireSchemas.ts
@@ -1099,6 +1099,42 @@ export class CheckMemberConflicts extends Schema.TaggedRequest<CheckMemberConfli
 ) {}
 
 // ---------------------------------------------------------------------------
+// ResolveMethodRenameFamily — data-owner method-rename edit-target discovery
+// (WI 5.2). Given a defining type FQN + method name/signature, walks the type
+// family on the COMPLETE graph and returns (a) `familyFqns` — every type in the
+// cone (self + ancestors + descendants, folding in interfaces + implementors)
+// whose calls the pool must accept as occurrences, and (b) `overrideSites` — the
+// {typeFqn, fileUri} of each family type that DECLARES a signature-matching
+// method (the declarations the rename must rewrite). Static methods have no cone
+// (family = the declaring type only). The pool cannot compute this: its
+// request-subset graph never fetches unloaded subtypes/implementors.
+// ---------------------------------------------------------------------------
+
+export class ResolveMethodRenameFamily extends Schema.TaggedRequest<ResolveMethodRenameFamily>()(
+  'ResolveMethodRenameFamily',
+  {
+    success: Schema.Struct({
+      familyFqns: Schema.Array(Schema.String),
+      overrideSites: Schema.Array(
+        Schema.Struct({ typeFqn: Schema.String, fileUri: Schema.String }),
+      ),
+    }),
+    failure: Schema.Struct({
+      _tag: Schema.Literal('ResolveMethodRenameFamilyError'),
+      message: Schema.String,
+    }),
+    payload: {
+      definingTypeFqn: Schema.String,
+      methodName: Schema.String,
+      // Target parameter type strings, for signature-equivalence when a family
+      // type declares same-named overloads. Absent → name-only match.
+      signature: Schema.optional(Schema.Array(Schema.String)),
+      isStatic: Schema.Boolean,
+    },
+  },
+) {}
+
+// ---------------------------------------------------------------------------
 // EnsureWorkspaceLoaded — worker → coordinator (over the assistance bus) to
 // ask the coordinator to send a workspace-load notification to the LSP
 // client. Fire-and-forget at the LSP layer (the notification carries no
@@ -1271,6 +1307,7 @@ export const DataOwnerTags = [
   'ResolveDependentUris',
   'CheckMemberConflicts',
   'FindOccurrenceCandidates',
+  'ResolveMethodRenameFamily',
   'WorkspaceBatchIngest',
   'WorkspaceBatchCompileOnDataOwner',
   'BeginWorkspaceLoadSession',
@@ -1356,6 +1393,7 @@ export type DataOwnerRequest =
   | ResolveDependentUris
   | CheckMemberConflicts
   | FindOccurrenceCandidates
+  | ResolveMethodRenameFamily
   | WorkspaceBatchIngest
   | WorkspaceBatchCompileOnDataOwner
   | BeginWorkspaceLoadSession

--- a/packages/apex-lsp-shared/src/workerWireSchemas.ts
+++ b/packages/apex-lsp-shared/src/workerWireSchemas.ts
@@ -1118,6 +1118,12 @@ export class ResolveMethodRenameFamily extends Schema.TaggedRequest<ResolveMetho
       overrideSites: Schema.Array(
         Schema.Struct({ typeFqn: Schema.String, fileUri: Schema.String }),
       ),
+      // True when the family declares ≥2 distinct overloads named the target at
+      // the target arity. `argumentTypes` are never populated in this build, so a
+      // caller file cannot detect same-arity overload ambiguity locally; the pool
+      // must decline every UNTYPED same-arity call when this is set (else it could
+      // rewrite a call that binds a DIFFERENT overload). Optional for wire compat.
+      targetArityAmbiguous: Schema.optional(Schema.Boolean),
     }),
     failure: Schema.Struct({
       _tag: Schema.Literal('ResolveMethodRenameFamilyError'),

--- a/packages/apex-parser-ast/src/index.ts
+++ b/packages/apex-parser-ast/src/index.ts
@@ -175,6 +175,10 @@ export {
   type FindMethodOccurrencesOptions,
 } from './symbols/ops/findMethodOccurrences';
 export {
+  areMethodSignaturesIdentical,
+  doesSignatureMatch,
+} from './semantics/validation/utils/methodSignatureUtils';
+export {
   validateRenameName,
   type ValidateRenameNameResult,
 } from './symbols/ops/validateRenameName';

--- a/packages/apex-parser-ast/src/index.ts
+++ b/packages/apex-parser-ast/src/index.ts
@@ -168,6 +168,13 @@ export {
   type FieldOccurrenceResult,
 } from './symbols/ops/findFieldOccurrences';
 export {
+  findMethodOccurrences,
+  type MethodOccurrenceResult,
+  type MethodOccurrenceCandidateNote,
+  type MethodRenameTarget,
+  type FindMethodOccurrencesOptions,
+} from './symbols/ops/findMethodOccurrences';
+export {
   validateRenameName,
   type ValidateRenameNameResult,
 } from './symbols/ops/validateRenameName';

--- a/packages/apex-parser-ast/src/symbols/ops/findMethodOccurrences.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/findMethodOccurrences.ts
@@ -1,0 +1,653 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  SymbolTable,
+  TypeSymbol,
+  ApexSymbol,
+  MethodSymbol,
+} from '../../types/symbol';
+import { SymbolReference, ReferenceContext } from '../../types/symbolReference';
+import { calculateFQN } from '../../utils/FQNUtils';
+import { isMethodSymbol } from '../../utils/symbolNarrowing';
+import { doesSignatureMatch } from '../../semantics/validation/utils/methodSignatureUtils';
+import {
+  findOccurrencesInFile,
+  OccurrenceMatch,
+} from './findOccurrencesInFile';
+
+/**
+ * A candidate that was neither kept as an occurrence nor safely dismissed.
+ */
+export interface MethodOccurrenceCandidateNote {
+  uri: string;
+  identifierRange: OccurrenceMatch['identifierRange'];
+  reason: string;
+}
+
+/**
+ * Method occurrences, plus two disjoint sets of non-occurrences — the same
+ * shape (and unsafe→decline contract) as `FieldOccurrenceResult`:
+ *
+ * - `skipped` — candidates PROVABLY unrelated to the target method: a call whose
+ *   arity does not match the target overload (binds to a different overload), a
+ *   bare/`this` call in a type outside the family that cannot inherit a family
+ *   method (no superclass, no interfaces), or a qualified call whose receiver is
+ *   a distinct locally-declared type outside the family with no supertypes. Safe
+ *   to omit while still renaming the declaration.
+ * - `unsafe` — candidates that MIGHT be the target method but cannot be proven so
+ *   from this single-file standalone parse: a `super.foo()` ancestor call, a
+ *   multi-hop chained call (`a.b.foo()`), a method/constructor-result receiver
+ *   (`getX().foo()`, `new T().foo()`), an unresolvable receiver, a receiver whose
+ *   type could be a subtype/implementor in the family cone, or an untyped call
+ *   that matches the target arity when the family declares multiple same-arity
+ *   overloads (cannot disambiguate). The caller MUST decline the whole rename
+ *   when `unsafe` is non-empty rather than emit a broken partial edit.
+ */
+export interface MethodOccurrenceResult {
+  occurrences: OccurrenceMatch[];
+  skipped: MethodOccurrenceCandidateNote[];
+  unsafe: MethodOccurrenceCandidateNote[];
+}
+
+/** The target method under rename. `signature` = parameter type strings. */
+export interface MethodRenameTarget {
+  name: string;
+  kind: 'method';
+  signature?: string[];
+}
+
+/** Optional inputs, notably the type-family cone for override call sites. */
+export interface FindMethodOccurrencesOptions {
+  /**
+   * Extra FQNs in the type-family cone (supertypes, subtypes, interfaces,
+   * implementors) whose override/inherited calls must also match. When absent,
+   * only `declaringTypeFqn` matches. The set a receiver type must belong to is
+   * `familyFqns ∪ {declaringTypeFqn}`.
+   */
+  familyFqns?: ReadonlySet<string>;
+}
+
+const isVariableLike = (symbol: ApexSymbol): boolean =>
+  symbol.kind === 'variable' ||
+  symbol.kind === 'parameter' ||
+  symbol.kind === 'field' ||
+  symbol.kind === 'property';
+
+/**
+ * Normalize an FQN for case-insensitive, block-artifact-insensitive comparison.
+ * Collapses consecutive duplicate segments so the graph's block-name duplication
+ * (`outerone.outerone.inner`) compares equal to this op's block-free
+ * `outerone.inner` — identical to `findFieldOccurrences`.
+ */
+function normalizeFqn(fqn: string): string {
+  const segments = fqn.toLowerCase().split('.');
+  const collapsed: string[] = [];
+  for (const seg of segments) {
+    if (collapsed.length === 0 || collapsed[collapsed.length - 1] !== seg) {
+      collapsed.push(seg);
+    }
+  }
+  return collapsed.join('.');
+}
+
+/** Normalized, block-artifact-free FQN for a type symbol from this table. */
+function computeTypeFqn(table: SymbolTable, type: TypeSymbol): string {
+  const fqn = calculateFQN(
+    type,
+    { excludeBlockSymbols: true, normalizeCase: true },
+    (parentId) => table.getSymbolById(parentId) ?? null,
+  );
+  return normalizeFqn(fqn);
+}
+
+/** A parser position → dedup/index key. */
+const posKey = (r: { startLine: number; startColumn: number }): string =>
+  `${r.startLine}:${r.startColumn}`;
+
+/**
+ * Disambiguate method-call occurrences by signature + receiver type
+ * (W-23631132). Mirrors `findFieldOccurrences`' return shape and conservative
+ * posture, but the receiver model is method-specific:
+ *
+ * `findOccurrencesInFile` matches METHOD_CALL leaves by name only; a candidate
+ * `foo()` could be the target overload, a same-named different-arity overload, an
+ * unrelated type's method, or an inherited family call. This layer keeps a
+ * candidate only when (a) its arity/argument types match the target overload and
+ * (b) its receiver type FQN-matches the family set. Anything that MIGHT be the
+ * target but cannot be proven standalone is `unsafe` → the caller declines.
+ *
+ * @param table Candidate file's parsed SymbolTable (full detail, standalone).
+ * @param fileUri Candidate file URI (echoed onto occurrences + notes).
+ * @param target Target method name/kind and (optional) parameter-type signature.
+ * @param declaringTypeFqn The method's declaring type FQN.
+ * @param options `familyFqns` — the type-family cone (see the interface).
+ */
+export function findMethodOccurrences(
+  table: SymbolTable,
+  fileUri: string,
+  target: MethodRenameTarget,
+  declaringTypeFqn: string,
+  options?: FindMethodOccurrencesOptions,
+): MethodOccurrenceResult {
+  const candidates = findOccurrencesInFile(table, fileUri, target);
+
+  const occurrences: OccurrenceMatch[] = [];
+  const skipped: MethodOccurrenceResult['skipped'] = [];
+  const unsafe: MethodOccurrenceResult['unsafe'] = [];
+
+  const targetLeaf = target.name.includes('.')
+    ? target.name.slice(target.name.lastIndexOf('.') + 1)
+    : target.name;
+  const targetLeafLower = targetLeaf.toLowerCase();
+  const targetArity = target.signature?.length;
+
+  // Family FQN set (declaring type + cone), all normalized.
+  const familySet = new Set<string>([normalizeFqn(declaringTypeFqn)]);
+  if (options?.familyFqns) {
+    for (const fqn of options.familyFqns) familySet.add(normalizeFqn(fqn));
+  }
+
+  // --- Per-file indexes, built once ----------------------------------------
+  // (a) call-arity/arg-types by METHOD_CALL leaf position. A chained call's arity
+  //     lives on the whole-expression ref (at the ROOT position), so record it at
+  //     the LEAF position too. First DEFINED value wins (later listener passes
+  //     re-emit the same call with argumentCount undefined).
+  const argInfoByPos = new Map<string, { argc?: number; argt?: string[] }>();
+  // (b) per METHOD_CALL node named the target, its position within any chain and
+  //     that chain's root receiver. index 0 = the node is itself the chain root
+  //     (a bare call feeding a further hop); index 1 = a single receiver (the
+  //     root); index >= 2 = a multi-hop chain (`a.b.foo()`) → unsafe. Method-call
+  //     receivers sit at the qualifier/root position, NOT co-located at the
+  //     method token, so this replaces `findFieldOccurrences`' co-located index.
+  const chainMembersByPos = new Map<
+    string,
+    Array<{ index: number; root: SymbolReference }>
+  >();
+  // (c) positions carrying a co-located standalone (dot-free) METHOD_CALL /
+  //     CONSTRUCTOR_CALL, keyed to the callee name. Used to recognize a
+  //     method/constructor-result receiver (`getX().foo()`) whose chain root is
+  //     emitted as a CHAIN_STEP but is really an invocation, not a variable/type.
+  const invocationNameByPos = new Map<string, Set<string>>();
+  // (d) co-located static TYPE qualifiers by position (resolved CLASS_REFERENCE),
+  //     used to resolve a `Type.foo()` static qualifier to its FQN.
+  const staticQualifierByPos = new Map<string, SymbolReference>();
+
+  const recordArgInfo = (pos: string, argc?: number, argt?: string[]): void => {
+    const existing = argInfoByPos.get(pos);
+    if (!existing) {
+      argInfoByPos.set(pos, { argc, argt });
+      return;
+    }
+    if (existing.argc === undefined && argc !== undefined) existing.argc = argc;
+    if (existing.argt === undefined && argt !== undefined) existing.argt = argt;
+  };
+
+  const recordInvocationName = (ref: SymbolReference): void => {
+    if (
+      ref.context !== ReferenceContext.METHOD_CALL &&
+      ref.context !== ReferenceContext.CONSTRUCTOR_CALL
+    )
+      return;
+    if (ref.name.includes('.')) return; // whole-chain refs carry a dotted name
+    const ir = ref.location?.identifierRange;
+    if (!ir) return;
+    const key = posKey(ir);
+    const bucket = invocationNameByPos.get(key);
+    if (bucket) bucket.add(ref.name.toLowerCase());
+    else invocationNameByPos.set(key, new Set([ref.name.toLowerCase()]));
+  };
+
+  for (const ref of table.getAllReferences()) {
+    recordInvocationName(ref);
+
+    const chain = ref.chainNodes;
+    if (chain && chain.length >= 2) {
+      for (let i = 0; i < chain.length; i++) {
+        const node = chain[i];
+        recordInvocationName(node);
+        const nir = node?.location?.identifierRange;
+        if (
+          node.context === ReferenceContext.METHOD_CALL &&
+          node.name.toLowerCase() === targetLeafLower &&
+          nir
+        ) {
+          const key = posKey(nir);
+          const entry = { index: i, root: chain[0] };
+          const bucket = chainMembersByPos.get(key);
+          if (bucket) bucket.push(entry);
+          else chainMembersByPos.set(key, [entry]);
+          // The whole call's arity lives on the top-level ref (`ref`).
+          recordArgInfo(key, ref.argumentCount, ref.argumentTypes);
+        }
+      }
+    }
+
+    const ir = ref.location?.identifierRange;
+    if (!ir) continue;
+    const key = posKey(ir);
+    if (
+      ref.context === ReferenceContext.METHOD_CALL &&
+      ref.name.toLowerCase() === targetLeafLower
+    ) {
+      // A simple (non-chained) call carries its own arity.
+      recordArgInfo(key, ref.argumentCount, ref.argumentTypes);
+    } else if (ref.context === ReferenceContext.CLASS_REFERENCE) {
+      const nameLower = ref.name.toLowerCase();
+      if (
+        nameLower !== 'this' &&
+        nameLower !== 'super' &&
+        !staticQualifierByPos.has(key)
+      ) {
+        staticQualifierByPos.set(key, ref);
+      }
+    }
+  }
+
+  // Type symbols (with a body range) + the declaring/family method declarations.
+  const typeSymbols: TypeSymbol[] = [];
+  for (const sym of table.getAllSymbols()) {
+    if (
+      (sym.kind === 'class' || sym.kind === 'interface') &&
+      sym.location?.symbolRange
+    ) {
+      typeSymbols.push(sym as TypeSymbol);
+    }
+  }
+
+  // Family-declared methods named the target, for overload-count ambiguity and
+  // arity resolution. A method is "in the family" when its enclosing type FQN is
+  // in the family set. When the declaring type is not present in this file this
+  // list is empty (a caller file) — the arity-only fallback then trusts arity.
+  const familyMethodsByName: MethodSymbol[] = [];
+  for (const sym of table.getAllSymbols()) {
+    if (!isMethodSymbol(sym)) continue;
+    if (sym.name.toLowerCase() !== targetLeafLower) continue;
+    const enclosing = getEnclosingType(
+      typeSymbols,
+      sym.location.identifierRange,
+    );
+    if (enclosing && familySet.has(computeTypeFqn(table, enclosing))) {
+      familyMethodsByName.push(sym);
+    }
+  }
+  const overloadsAtArity = (arity: number): number =>
+    familyMethodsByName.filter((m) => (m.parameters ?? []).length === arity)
+      .length;
+  // The specific target overload declaration (when local), for a real
+  // argument-type comparison via methodSignatureUtils when arg types exist.
+  const targetOverload = target.signature
+    ? familyMethodsByName.find((m) =>
+        doesSignatureMatch(m, target.name, target.signature!),
+      )
+    : undefined;
+
+  for (const candidate of candidates) {
+    const startKey = posKey(candidate.identifierRange);
+
+    // --- 1. Signature filter -------------------------------------------------
+    const argInfo = argInfoByPos.get(startKey);
+    const argc = argInfo?.argc;
+    const argt = argInfo?.argt;
+
+    if (targetArity !== undefined) {
+      if (argc !== undefined && argc !== targetArity) {
+        // Different arity → binds to a different overload → not our method.
+        skipped.push({
+          uri: fileUri,
+          identifierRange: candidate.identifierRange,
+          reason: `arity-mismatch:${argc}!=${targetArity}`,
+        });
+        continue;
+      }
+
+      if (argt !== undefined && target.signature) {
+        // Statically-typed call: compare argument types to the target overload.
+        const matches = targetOverload
+          ? doesSignatureMatch(targetOverload, target.name, argt)
+          : argt.length === target.signature.length &&
+            argt.every(
+              (t, i) => t.toLowerCase() === target.signature![i].toLowerCase(),
+            );
+        if (!matches) {
+          skipped.push({
+            uri: fileUri,
+            identifierRange: candidate.identifierRange,
+            reason: 'signature-mismatch',
+          });
+          continue;
+        }
+      } else if (overloadsAtArity(argc ?? targetArity) >= 2) {
+        // Arity-only fallback: an untyped call matching the target arity is
+        // ambiguous when the family declares multiple same-arity overloads.
+        unsafe.push({
+          uri: fileUri,
+          identifierRange: candidate.identifierRange,
+          reason: 'ambiguous-overload-untyped',
+        });
+        continue;
+      }
+      // else: single overload at this arity → arity is sufficient → matched.
+    }
+
+    // --- 2. Receiver + static/instance classification ------------------------
+    const chainEntries = chainMembersByPos.get(startKey) ?? [];
+    const isMultiHop = chainEntries.some((e) => e.index >= 2);
+    const singleReceiver = chainEntries.find((e) => e.index === 1);
+
+    if (isMultiHop) {
+      // Multi-hop chain (`a.b.foo()`): the immediate receiver's declared type
+      // cannot be attributed standalone. Decline.
+      unsafe.push({
+        uri: fileUri,
+        identifierRange: candidate.identifierRange,
+        reason: 'multi-hop-receiver-unprovable',
+      });
+      continue;
+    }
+
+    if (singleReceiver) {
+      // Single qualified receiver: `this`/`super`/instance-var/`Type`/call-result.
+      const resolved = classifyReceiver(
+        singleReceiver.root,
+        table,
+        typeSymbols,
+        invocationNameByPos,
+        staticQualifierByPos,
+      );
+      if (resolved.kind === 'unsafe') {
+        unsafe.push({
+          uri: fileUri,
+          identifierRange: candidate.identifierRange,
+          reason: resolved.reason,
+        });
+        continue;
+      }
+      classifyByType(
+        resolved.typeFqn,
+        candidate,
+        fileUri,
+        familySet,
+        table,
+        typeSymbols,
+        occurrences,
+        skipped,
+        unsafe,
+      );
+      continue;
+    }
+
+    // --- Bare `foo()` / `this.foo()` → implicit-this: classify by enclosing type.
+    const enclosing = getEnclosingType(typeSymbols, candidate.identifierRange);
+    if (!enclosing) {
+      skipped.push({
+        uri: fileUri,
+        identifierRange: candidate.identifierRange,
+        reason: 'implicit-this-no-enclosing-type',
+      });
+      continue;
+    }
+    const enclosingFqn = computeTypeFqn(table, enclosing);
+    if (familySet.has(enclosingFqn)) {
+      occurrences.push(candidate);
+    } else if (enclosingCouldInherit(enclosing)) {
+      // Enclosing type is outside the family but has supertypes/interfaces, so a
+      // bare `foo()` could be an inherited family method — unprovable standalone.
+      unsafe.push({
+        uri: fileUri,
+        identifierRange: candidate.identifierRange,
+        reason: `implicit-this-possible-inherited-in:${enclosing.name}`,
+      });
+    } else {
+      skipped.push({
+        uri: fileUri,
+        identifierRange: candidate.identifierRange,
+        reason: `implicit-this-unrelated-type:${enclosing.name}`,
+      });
+    }
+  }
+
+  return { occurrences, skipped, unsafe };
+}
+
+type ReceiverResolution =
+  { kind: 'type'; typeFqn: string } | { kind: 'unsafe'; reason: string };
+
+/**
+ * Classify a single method-call receiver (the root of a length-2 chain) into a
+ * resolved type FQN or an unprovable-receiver reason.
+ *
+ *  - `this` → the enclosing type (an instance self-call).
+ *  - `super` → an ancestor call, unresolvable standalone → unsafe.
+ *  - a method/constructor result (`getX().foo()`, `new T().foo()`) → unsafe: its
+ *    result type cannot be established from this parse.
+ *  - an instance variable/param/field → its declared type.
+ *  - a static type qualifier (`Type.foo()`) → the qualifier's resolved type FQN,
+ *    or the bare name when it only resolves to a simple name.
+ */
+function classifyReceiver(
+  root: SymbolReference,
+  table: SymbolTable,
+  typeSymbols: TypeSymbol[],
+  invocationNameByPos: Map<string, Set<string>>,
+  staticQualifierByPos: Map<string, SymbolReference>,
+): ReceiverResolution {
+  const nameLower = root.name.toLowerCase();
+  const rootIr = root.location?.identifierRange;
+
+  if (nameLower === 'this') {
+    if (!rootIr) return { kind: 'unsafe', reason: 'unresolvable-receiver' };
+    const enclosing = getEnclosingType(typeSymbols, rootIr);
+    return enclosing
+      ? { kind: 'type', typeFqn: computeTypeFqn(table, enclosing) }
+      : { kind: 'unsafe', reason: 'unresolvable-receiver' };
+  }
+  if (nameLower === 'super') {
+    return { kind: 'unsafe', reason: 'super-receiver-unprovable' };
+  }
+
+  // A method/constructor-result receiver: the root expression is itself an
+  // invocation (`getX()`, `new T()`), NOT a variable or type. Its context is
+  // CONSTRUCTOR_CALL / METHOD_CALL / FIELD_ACCESS directly, OR a CHAIN_STEP whose
+  // position carries a co-located invocation of the same name.
+  const rootKey = rootIr ? posKey(rootIr) : null;
+  if (
+    root.context === ReferenceContext.CONSTRUCTOR_CALL ||
+    root.context === ReferenceContext.METHOD_CALL ||
+    root.context === ReferenceContext.FIELD_ACCESS ||
+    (rootKey && invocationNameByPos.get(rootKey)?.has(nameLower))
+  ) {
+    return { kind: 'unsafe', reason: 'non-variable-receiver-unprovable' };
+  }
+
+  // Instance receiver: resolve the variable/param/field declared type.
+  let variableFound = false;
+  if (root.resolvedSymbolId) {
+    const symbol = table.getSymbolById(root.resolvedSymbolId);
+    if (symbol && isVariableLike(symbol)) {
+      variableFound = true;
+      const typeString = typeStringOf(symbol);
+      if (typeString)
+        return { kind: 'type', typeFqn: normalizeFqn(typeString) };
+    }
+  }
+  if (rootIr) {
+    const variable = table.resolveVariableAtPosition(
+      root.name,
+      rootIr.startLine,
+      rootIr.startColumn,
+    );
+    if (variable && isVariableLike(variable)) {
+      variableFound = true;
+      const typeString = typeStringOf(variable);
+      if (typeString)
+        return { kind: 'type', typeFqn: normalizeFqn(typeString) };
+    }
+  }
+  if (variableFound) {
+    // A variable receiver whose declared type we could not read.
+    return { kind: 'unsafe', reason: 'unresolvable-receiver' };
+  }
+
+  // Not a variable → a static TYPE qualifier (`Type.foo()`). Prefer the resolved
+  // CLASS_REFERENCE's type FQN; fall back to a unique local-type match; else the
+  // bare name (the documented simple-name limitation).
+  const qualifier = rootKey ? staticQualifierByPos.get(rootKey) : undefined;
+  if (qualifier?.resolvedSymbolId) {
+    const symbol = table.getSymbolById(qualifier.resolvedSymbolId);
+    if (symbol && (symbol.kind === 'class' || symbol.kind === 'interface')) {
+      return {
+        kind: 'type',
+        typeFqn: computeTypeFqn(table, symbol as TypeSymbol),
+      };
+    }
+  }
+  const local = findLocalType(table, typeSymbols, root.name);
+  return {
+    kind: 'type',
+    typeFqn: local ? computeTypeFqn(table, local) : normalizeFqn(root.name),
+  };
+}
+
+/**
+ * Keep the occurrence when its receiver type is in the family set; otherwise
+ * decide between a provable skip and an unprovable-subtype decline — mirroring
+ * `findFieldOccurrences`' cross-hierarchy caution. Static AND instance members
+ * are inherited in Apex, so a mismatched receiver is a proven non-occurrence
+ * ONLY when its type is declared locally with no superclass and no interfaces
+ * (cannot be a family subtype/implementor). Everything else is unprovable here.
+ */
+function classifyByType(
+  receiverTypeFqn: string,
+  candidate: OccurrenceMatch,
+  fileUri: string,
+  familySet: Set<string>,
+  table: SymbolTable,
+  typeSymbols: TypeSymbol[],
+  occurrences: OccurrenceMatch[],
+  skipped: MethodOccurrenceCandidateNote[],
+  unsafe: MethodOccurrenceCandidateNote[],
+): void {
+  if (familySet.has(receiverTypeFqn)) {
+    occurrences.push(candidate);
+    return;
+  }
+  const local = findLocalType(table, typeSymbols, receiverTypeFqn);
+  if (local && !local.superClass && (local.interfaces ?? []).length === 0) {
+    skipped.push({
+      uri: fileUri,
+      identifierRange: candidate.identifierRange,
+      reason: `receiver-type-mismatch:${receiverTypeFqn}`,
+    });
+  } else {
+    unsafe.push({
+      uri: fileUri,
+      identifierRange: candidate.identifierRange,
+      reason: `receiver-subtype-unprovable:${receiverTypeFqn}`,
+    });
+  }
+}
+
+/** Read a variable-like symbol's declared type string (prefers FQN-ish form). */
+function typeStringOf(symbol: ApexSymbol): string | undefined {
+  const varSym = symbol as {
+    type?: { name?: string; originalTypeString?: string };
+  };
+  return varSym.type?.originalTypeString ?? varSym.type?.name;
+}
+
+/**
+ * Find the local type this name refers to (by canonical FQN, else a UNIQUE leaf
+ * match), for the provably-unrelated check. Identical policy to
+ * `findFieldOccurrences.findLocalType`: an ambiguous short name returns null so
+ * the caller treats the receiver as unprovable.
+ */
+function findLocalType(
+  table: SymbolTable,
+  typeSymbols: TypeSymbol[],
+  typeName: string,
+): TypeSymbol | null {
+  const normReceiver = normalizeFqn(typeName);
+  const fqnMatches = typeSymbols.filter(
+    (sym) => computeTypeFqn(table, sym) === normReceiver,
+  );
+  if (fqnMatches.length === 1) return fqnMatches[0];
+  if (fqnMatches.length > 1) return null;
+
+  if (!typeName.includes('.')) {
+    const leaf = typeName.toLowerCase();
+    const leafMatches = typeSymbols.filter(
+      (sym) => sym.name.toLowerCase() === leaf,
+    );
+    if (leafMatches.length === 1) return leafMatches[0];
+  }
+  return null;
+}
+
+/**
+ * Whether a bare call inside `enclosingType` could bind to a family method
+ * inherited from a supertype or interface (interface `default` methods are
+ * callable). If the type extends nothing and implements nothing it cannot
+ * inherit a family method, so a same-named bare call is genuinely unrelated.
+ */
+function enclosingCouldInherit(enclosingType: TypeSymbol): boolean {
+  return (
+    !!enclosingType.superClass || (enclosingType.interfaces ?? []).length > 0
+  );
+}
+
+/**
+ * Get the INNERMOST type (class/interface) whose body range contains a position
+ * — identical selection to `findFieldOccurrences.getEnclosingType` (latest
+ * start, earliest end tie-break) so nested types resolve to the deepest one.
+ */
+function getEnclosingType(
+  typeSymbols: TypeSymbol[],
+  range: { startLine: number; startColumn: number },
+): TypeSymbol | null {
+  let best: TypeSymbol | null = null;
+  let bestBody: {
+    startLine: number;
+    startColumn: number;
+    endLine: number;
+    endColumn: number;
+  } | null = null;
+  for (const sym of typeSymbols) {
+    const body = sym.location?.symbolRange;
+    if (!body) continue;
+    const afterStart =
+      body.startLine < range.startLine ||
+      (body.startLine === range.startLine &&
+        body.startColumn <= range.startColumn);
+    const beforeEnd =
+      range.startLine < body.endLine ||
+      (range.startLine === body.endLine && range.startColumn <= body.endColumn);
+    if (!afterStart || !beforeEnd) continue;
+    if (bestBody === null) {
+      best = sym;
+      bestBody = body;
+      continue;
+    }
+    const startsLater =
+      body.startLine > bestBody.startLine ||
+      (body.startLine === bestBody.startLine &&
+        body.startColumn > bestBody.startColumn);
+    const startsSame =
+      body.startLine === bestBody.startLine &&
+      body.startColumn === bestBody.startColumn;
+    const endsEarlier =
+      body.endLine < bestBody.endLine ||
+      (body.endLine === bestBody.endLine &&
+        body.endColumn < bestBody.endColumn);
+    if (startsLater || (startsSame && endsEarlier)) {
+      best = sym;
+      bestBody = body;
+    }
+  }
+  return best;
+}

--- a/packages/apex-parser-ast/src/symbols/ops/findMethodOccurrences.ts
+++ b/packages/apex-parser-ast/src/symbols/ops/findMethodOccurrences.ts
@@ -41,8 +41,9 @@ export interface MethodOccurrenceCandidateNote {
  *   a distinct locally-declared type outside the family with no supertypes. Safe
  *   to omit while still renaming the declaration.
  * - `unsafe` — candidates that MIGHT be the target method but cannot be proven so
- *   from this single-file standalone parse: a `super.foo()` ancestor call, a
- *   multi-hop chained call (`a.b.foo()`), a method/constructor-result receiver
+ *   from this single-file standalone parse: a `super.foo()` ancestor call from a
+ *   type OUTSIDE the family (a `super.foo()` from a family type is a provable
+ *   occurrence), a multi-hop chained call (`a.b.foo()`), a method/constructor-result receiver
  *   (`getX().foo()`, `new T().foo()`), an unresolvable receiver, a receiver whose
  *   type could be a subtype/implementor in the family cone, or an untyped call
  *   that matches the target arity when the family declares multiple same-arity
@@ -71,6 +72,16 @@ export interface FindMethodOccurrencesOptions {
    * `familyFqns ∪ {declaringTypeFqn}`.
    */
   familyFqns?: ReadonlySet<string>;
+  /**
+   * True when the WHOLE FAMILY declares ≥2 distinct same-arity overloads named
+   * the target (computed on the complete graph by the data owner). This op runs
+   * on a single-file standalone parse where `argumentTypes` are never populated
+   * and only the current file's overload declarations are visible, so a caller
+   * file cannot detect same-arity ambiguity on its own. When set, an untyped
+   * call matching the target arity is `unsafe` in EVERY file — otherwise a call
+   * that binds a DIFFERENT overload would be silently rewritten (a broken edit).
+   */
+  familyArityAmbiguous?: boolean;
 }
 
 const isVariableLike = (symbol: ApexSymbol): boolean =>
@@ -322,9 +333,15 @@ export function findMethodOccurrences(
           });
           continue;
         }
-      } else if (overloadsAtArity(argc ?? targetArity) >= 2) {
+      } else if (
+        options?.familyArityAmbiguous ||
+        overloadsAtArity(argc ?? targetArity) >= 2
+      ) {
         // Arity-only fallback: an untyped call matching the target arity is
-        // ambiguous when the family declares multiple same-arity overloads.
+        // ambiguous when the family declares multiple same-arity overloads. The
+        // family-wide flag (from the complete graph) is authoritative — a caller
+        // file only sees its own declarations, so `overloadsAtArity` is 0 there
+        // and would fail OPEN without it.
         unsafe.push({
           uri: fileUri,
           identifierRange: candidate.identifierRange,
@@ -359,6 +376,7 @@ export function findMethodOccurrences(
         typeSymbols,
         invocationNameByPos,
         staticQualifierByPos,
+        familySet,
       );
       if (resolved.kind === 'unsafe') {
         unsafe.push({
@@ -423,7 +441,9 @@ type ReceiverResolution =
  * resolved type FQN or an unprovable-receiver reason.
  *
  *  - `this` → the enclosing type (an instance self-call).
- *  - `super` → an ancestor call, unresolvable standalone → unsafe.
+ *  - `super` → an ancestor call. When the enclosing type is itself IN THE FAMILY
+ *    the ancestor's method is provably the target being renamed → occurrence;
+ *    otherwise it's unresolvable standalone → unsafe.
  *  - a method/constructor result (`getX().foo()`, `new T().foo()`) → unsafe: its
  *    result type cannot be established from this parse.
  *  - an instance variable/param/field → its declared type.
@@ -436,6 +456,7 @@ function classifyReceiver(
   typeSymbols: TypeSymbol[],
   invocationNameByPos: Map<string, Set<string>>,
   staticQualifierByPos: Map<string, SymbolReference>,
+  familySet: ReadonlySet<string>,
 ): ReceiverResolution {
   const nameLower = root.name.toLowerCase();
   const rootIr = root.location?.identifierRange;
@@ -448,6 +469,16 @@ function classifyReceiver(
       : { kind: 'unsafe', reason: 'unresolvable-receiver' };
   }
   if (nameLower === 'super') {
+    // `super.foo()` calls the ancestor's `foo`. When the enclosing type is in the
+    // family cone, that ancestor method IS the target override set — arity was
+    // already matched upstream — so this call must be renamed. Outside the family
+    // we cannot prove the ancestor is the target standalone → unsafe.
+    if (rootIr) {
+      const enclosing = getEnclosingType(typeSymbols, rootIr);
+      if (enclosing && familySet.has(computeTypeFqn(table, enclosing))) {
+        return { kind: 'type', typeFqn: computeTypeFqn(table, enclosing) };
+      }
+    }
     return { kind: 'unsafe', reason: 'super-receiver-unprovable' };
   }
 

--- a/packages/apex-parser-ast/test/symbols/ops/findMethodOccurrences.test.ts
+++ b/packages/apex-parser-ast/test/symbols/ops/findMethodOccurrences.test.ts
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the
+ * repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { CompilerService } from '../../../src/parser/compilerService';
+import { FullSymbolCollectorListener } from '../../../src/parser/listeners/FullSymbolCollectorListener';
+import { SymbolTable } from '../../../src/types/symbol';
+import { findMethodOccurrences } from '../../../src/symbols/ops/findMethodOccurrences';
+
+describe('findMethodOccurrences', () => {
+  function parseSource(src: string, uri: string): SymbolTable {
+    const table = new SymbolTable();
+    const listener = new FullSymbolCollectorListener(table);
+    const compiler = new CompilerService();
+    const result = compiler.compile(src, uri, listener, {
+      collectReferences: true,
+      resolveReferences: true,
+    });
+    return result?.result instanceof SymbolTable ? result.result : table;
+  }
+
+  // --- Receiver forms -------------------------------------------------------
+
+  it('matches a bare implicit-this call in the declaring type', () => {
+    const src = `public class Svc {
+    public void foo() {}
+    public void run() {
+        foo();
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Svc.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Svc.cls',
+      { name: 'foo', kind: 'method', signature: [] },
+      'Svc',
+    );
+
+    expect(result.unsafe.length).toBe(0);
+    expect(
+      result.occurrences.some((o) => o.identifierRange.startLine === 4),
+    ).toBe(true);
+  });
+
+  it('matches an explicit this.foo() call', () => {
+    const src = `public class Svc {
+    public void foo() {}
+    public void run() {
+        this.foo();
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Svc.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Svc.cls',
+      { name: 'foo', kind: 'method', signature: [] },
+      'Svc',
+    );
+
+    expect(result.unsafe.length).toBe(0);
+    // `this.foo()` resolves to the enclosing type (Svc) → occurrence on line 4.
+    expect(
+      result.occurrences.some((o) => o.identifierRange.startLine === 4),
+    ).toBe(true);
+  });
+
+  it('matches an instance-variable-qualified call obj.foo()', () => {
+    const src = `public class Caller {
+    public void run(Svc s) {
+        s.foo();
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Caller.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Caller.cls',
+      { name: 'foo', kind: 'method', signature: [] },
+      'Svc',
+    );
+
+    // `s` is declared Svc → receiver in family → occurrence. No decline.
+    expect(result.unsafe.length).toBe(0);
+    expect(
+      result.occurrences.some((o) => o.identifierRange.startLine === 3),
+    ).toBe(true);
+  });
+
+  it('matches a static call Type.foo() of the declaring type', () => {
+    const src = `public class Caller {
+    public void run() {
+        Svc.foo();
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Caller.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Caller.cls',
+      { name: 'foo', kind: 'method', signature: [] },
+      'Svc',
+    );
+
+    expect(result.unsafe.length).toBe(0);
+    expect(
+      result.occurrences.some((o) => o.identifierRange.startLine === 3),
+    ).toBe(true);
+  });
+
+  // --- Not matched: unrelated receiver --------------------------------------
+
+  it('does NOT match a call in an unrelated class (receiver type not in family)', () => {
+    // `Other` has no superclass/interfaces and is outside the family, so a bare
+    // `foo()` inside it is a proven-unrelated method — safely skipped, never a
+    // decline.
+    const src = `public class Other {
+    public void foo() {}
+    public void run() {
+        foo();
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Other.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Other.cls',
+      { name: 'foo', kind: 'method', signature: [] },
+      'Svc', // renaming Svc.foo, not Other.foo
+    );
+
+    expect(result.occurrences.length).toBe(0);
+    expect(result.unsafe.length).toBe(0);
+    expect(
+      result.skipped.some((s) =>
+        s.reason.startsWith('implicit-this-unrelated-type'),
+      ),
+    ).toBe(true);
+  });
+
+  it('safely skips an instance call on an unrelated local type', () => {
+    const src = `public class Caller {
+    public class Other {
+        public void foo() {}
+    }
+    public void run() {
+        Other o = new Other();
+        o.foo();
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Caller.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Caller.cls',
+      { name: 'foo', kind: 'method', signature: [] },
+      'Svc',
+    );
+
+    expect(result.occurrences.length).toBe(0);
+    expect(result.unsafe.length).toBe(0);
+    expect(
+      result.skipped.some((s) => s.reason.startsWith('receiver-type-mismatch')),
+    ).toBe(true);
+  });
+
+  // --- Overloads ------------------------------------------------------------
+
+  it('separates arity-distinct overloads (0-arg target ignores 1-arg call)', () => {
+    const src = `public class Svc {
+    public void foo() {}
+    public void foo(Integer a) {}
+    public void run() {
+        foo();
+        foo(1);
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Svc.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Svc.cls',
+      { name: 'foo', kind: 'method', signature: [] }, // the 0-arg overload
+      'Svc',
+    );
+
+    expect(result.unsafe.length).toBe(0);
+    // The `foo(1)` call (arity 1) is a different overload → skipped by arity.
+    expect(
+      result.skipped.some((s) => s.reason.startsWith('arity-mismatch')),
+    ).toBe(true);
+    // The bare `foo()` (arity 0) is an occurrence; the declaration is too.
+    expect(
+      result.occurrences.some((o) => o.identifierRange.startLine === 5),
+    ).toBe(true);
+    expect(
+      result.occurrences.some((o) => o.identifierRange.startLine === 6),
+    ).toBe(false);
+  });
+
+  it('matches a single-overload arity-only call with an UNTYPED argument', () => {
+    // Only one `foo` at arity 1; the parser cannot statically type `x`, so the
+    // call is untyped. Arity alone is sufficient → still a match (the rename
+    // must not decline on ordinary code).
+    const src = `public class Svc {
+    public void foo(Integer a) {}
+    public void run(Integer x) {
+        foo(x);
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Svc.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Svc.cls',
+      { name: 'foo', kind: 'method', signature: ['Integer'] },
+      'Svc',
+    );
+
+    expect(result.unsafe.length).toBe(0);
+    expect(
+      result.occurrences.some((o) => o.identifierRange.startLine === 4),
+    ).toBe(true);
+  });
+
+  it('declines an untyped call when multiple same-arity overloads exist', () => {
+    // Two `foo` overloads at arity 1 and an untyped call `foo(x)` — cannot
+    // disambiguate which overload it binds → unsafe → decline.
+    const src = `public class Svc {
+    public void foo(Integer a) {}
+    public void foo(String a) {}
+    public void run(Object x) {
+        foo(x);
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Svc.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Svc.cls',
+      { name: 'foo', kind: 'method', signature: ['Integer'] },
+      'Svc',
+    );
+
+    expect(
+      result.unsafe.some((u) => u.reason === 'ambiguous-overload-untyped'),
+    ).toBe(true);
+  });
+
+  // --- Family cone ----------------------------------------------------------
+
+  it('matches an override call on a family member when familyFqns provided', () => {
+    // `Child c; c.foo()` — Child is a family member (subtype). With familyFqns
+    // supplied, the override call site is an occurrence.
+    const src = `public class Caller {
+    public void run(Child c) {
+        c.foo();
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Caller.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Caller.cls',
+      { name: 'foo', kind: 'method', signature: [] },
+      'Base',
+      { familyFqns: new Set(['Child']) },
+    );
+
+    expect(result.unsafe.length).toBe(0);
+    expect(
+      result.occurrences.some((o) => o.identifierRange.startLine === 3),
+    ).toBe(true);
+  });
+
+  it('without familyFqns, only the declaring type matches (family call skipped)', () => {
+    const src = `public class Caller {
+    public class Child {
+        public void foo() {}
+    }
+    public void run() {
+        Child c = new Child();
+        c.foo();
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Caller.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Caller.cls',
+      { name: 'foo', kind: 'method', signature: [] },
+      'Base', // Child not in family (no familyFqns)
+    );
+
+    // Child (local, no superclass/interfaces) is provably unrelated → skip.
+    expect(result.occurrences.length).toBe(0);
+    expect(result.unsafe.length).toBe(0);
+    expect(
+      result.skipped.some((s) => s.reason.startsWith('receiver-type-mismatch')),
+    ).toBe(true);
+  });
+
+  // --- Unsafe receiver forms ------------------------------------------------
+
+  it('declines a multi-hop chained call a.b.foo()', () => {
+    const src = `public class Svc {
+    public void foo() {}
+    public Svc a() { return null; }
+    public Svc b() { return null; }
+    public void run() {
+        a().b().foo();
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Svc.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Svc.cls',
+      { name: 'foo', kind: 'method', signature: [] },
+      'Svc',
+    );
+
+    expect(
+      result.unsafe.some((u) => u.reason === 'multi-hop-receiver-unprovable'),
+    ).toBe(true);
+    // The multi-hop `.foo()` (line 6) is never a confirmed occurrence.
+    expect(
+      result.occurrences.some((o) => o.identifierRange.startLine === 6),
+    ).toBe(false);
+  });
+
+  it('declines a super.foo() ancestor call', () => {
+    const src = `public class Child extends Base {
+    public void run() {
+        super.foo();
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Child.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Child.cls',
+      { name: 'foo', kind: 'method', signature: [] },
+      'Base',
+      { familyFqns: new Set(['Child']) },
+    );
+
+    expect(result.occurrences.length).toBe(0);
+    expect(
+      result.unsafe.some((u) => u.reason === 'super-receiver-unprovable'),
+    ).toBe(true);
+  });
+
+  it('declines a method-result receiver getSvc().foo()', () => {
+    const src = `public class Caller {
+    public Svc getSvc() { return null; }
+    public void run() {
+        getSvc().foo();
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Caller.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Caller.cls',
+      { name: 'foo', kind: 'method', signature: [] },
+      'Svc',
+    );
+
+    expect(result.occurrences.length).toBe(0);
+    expect(
+      result.unsafe.some(
+        (u) => u.reason === 'non-variable-receiver-unprovable',
+      ),
+    ).toBe(true);
+  });
+
+  it('flags a bare call in a SUBCLASS-like type (has superclass) as unsafe', () => {
+    // Sub extends Base and is NOT in the family set here, so a bare `foo()` in
+    // Sub could be an inherited Base.foo — unprovable standalone → unsafe.
+    const src = `public class Sub extends Base {
+    public void run() {
+        foo();
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Sub.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Sub.cls',
+      { name: 'foo', kind: 'method', signature: [] },
+      'Base', // Sub not in family
+    );
+
+    expect(result.occurrences.length).toBe(0);
+    expect(
+      result.unsafe.some((u) =>
+        u.reason.startsWith('implicit-this-possible-inherited'),
+      ),
+    ).toBe(true);
+  });
+
+  // --- No-body declarations (interface / abstract) --------------------------
+
+  it('matches an interface method declaration (no body)', () => {
+    // The interface method `area()` has no body; the op must still surface its
+    // declaration/reference set without error.
+    const src = `public interface Shape {
+    Double area();
+}`;
+    const table = parseSource(src, 'file:///t/Shape.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Shape.cls',
+      { name: 'area', kind: 'method', signature: [] },
+      'Shape',
+    );
+
+    // No call sites and no crash; nothing is flagged unsafe.
+    expect(result.unsafe.length).toBe(0);
+  });
+
+  it('handles an abstract (no-body) method plus a concrete call', () => {
+    const src = `public abstract class Base {
+    public abstract void foo();
+    public void run() {
+        foo();
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Base.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Base.cls',
+      { name: 'foo', kind: 'method', signature: [] },
+      'Base',
+    );
+
+    // The bare `foo()` inside Base resolves to the enclosing (declaring) type.
+    expect(result.unsafe.length).toBe(0);
+    expect(
+      result.occurrences.some((o) => o.identifierRange.startLine === 4),
+    ).toBe(true);
+  });
+});

--- a/packages/apex-parser-ast/test/symbols/ops/findMethodOccurrences.test.ts
+++ b/packages/apex-parser-ast/test/symbols/ops/findMethodOccurrences.test.ts
@@ -322,7 +322,9 @@ describe('findMethodOccurrences', () => {
     ).toBe(false);
   });
 
-  it('declines a super.foo() ancestor call', () => {
+  it('renames a super.foo() call from a FAMILY type (provably the target)', () => {
+    // `super.foo()` inside Child, which is IN the family cone: the ancestor's
+    // `foo` is the target override set → occurrence, not a decline (review P3).
     const src = `public class Child extends Base {
     public void run() {
         super.foo();
@@ -337,9 +339,57 @@ describe('findMethodOccurrences', () => {
       { familyFqns: new Set(['Child']) },
     );
 
+    expect(result.unsafe.length).toBe(0);
+    expect(
+      result.occurrences.some((o) => o.identifierRange.startLine === 3),
+    ).toBe(true);
+  });
+
+  it('declines a super.foo() call from a type OUTSIDE the family', () => {
+    // Stranger is not in the family cone, so we cannot prove its ancestor's
+    // `foo` is the target standalone → unsafe.
+    const src = `public class Stranger extends Something {
+    public void run() {
+        super.foo();
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Stranger.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Stranger.cls',
+      { name: 'foo', kind: 'method', signature: [] },
+      'Base',
+      { familyFqns: new Set(['Child']) },
+    );
+
     expect(result.occurrences.length).toBe(0);
     expect(
       result.unsafe.some((u) => u.reason === 'super-receiver-unprovable'),
+    ).toBe(true);
+  });
+
+  it('declines an untyped same-arity call in a CALLER file when the family is arity-ambiguous', () => {
+    // The caller declares no `foo` overloads, so it cannot detect same-arity
+    // ambiguity locally (argumentTypes are never populated). The family-wide flag
+    // (computed on the complete graph) must force the decline here, else the call
+    // — which may bind a DIFFERENT overload — would be silently rewritten (P1).
+    const src = `public class Caller {
+    public void run(Svc s, Object x) {
+        s.foo(x);
+    }
+}`;
+    const table = parseSource(src, 'file:///t/Caller.cls');
+    const result = findMethodOccurrences(
+      table,
+      'file:///t/Caller.cls',
+      { name: 'foo', kind: 'method', signature: ['Integer'] },
+      'Svc',
+      { familyFqns: new Set(['Svc']), familyArityAmbiguous: true },
+    );
+
+    expect(result.occurrences.length).toBe(0);
+    expect(
+      result.unsafe.some((u) => u.reason === 'ambiguous-overload-untyped'),
     ).toBe(true);
   });
 


### PR DESCRIPTION
### What does this PR do?

Implements **5.2 renameMethod: WorkspaceEdit construction across overrides + interfaces.** Renaming a method (F2) produces a multi-file `WorkspaceEdit` covering the method's declaration, every call across the type family, and every override/implementor declaration across the inheritance cone.

Built in slices:
- **`findMethodOccurrences`** (apex-parser-ast) — classifies `METHOD_CALL` occurrences by signature (arity-primary; `argumentTypes` is never populated in this build) + a method-specific receiver / static-vs-instance classifier; returns an `{occurrences, skipped, unsafe}` triad; unprovable receivers → `unsafe` → decline.
- **`dataOwner:ResolveMethodRenameFamily`** assist — walks the type family on the data-owner's **complete** graph (the pool's request-subset graph can't see unloaded subtypes/implementors) and returns the family FQN cone + the `{typeFqn, fileUri}` of each override **declaration** site. Extracted the shared `getTypeMembersFullDetail` reader (CheckMemberConflicts now delegates to it).
- **`resolveMethodRename`** — ties the op + assist + `methodDeclarationRangeFromParse` into the multi-file edit; wired into the `DispatchRename` fall-through (`local → field → method`, only `null` falling through). Declaration ranges come from a standalone parse (dodges the return-type-token graph hazard); a source-provenance guard rejects non-user-owned (stdlib / generated-SObject) methods.
- **Worker-topology tests** — cross-file override, interface implementer, static (no cone), overload disambiguation, unsafe→decline.

**Adversarial pre-PR review hardening** (fail-open correctness fixes, all with regression tests):
- **Cross-file same-arity overloads** no longer fail open — the family assist reports whether the target arity is ambiguous family-wide (computed on the complete graph), and the op declines untyped same-arity calls in **every** file, not just files that declare the overloads.
- **`methodDeclarationRangeFromParse`** disambiguates by owning-type FQN and **fails closed** (declines) on ambiguity instead of guessing the first match (shared with `fieldDeclarationRangeFromParse`).
- **Sibling overrides** are captured: the family walk expands from every introducer's full subtype cone, so a sibling override with no call sites is renamed rather than silently left behind.
- **`super.foo()` from a family type** is now a provable occurrence (previously forced a whole-rename decline); an empty signature slot (parse degradation) declines rather than dropping the declaration.

Out of scope (later WIs): conflict detection + validation wiring + method `prepareRename` (**5.3**); editor F2 e2e (**5.4**). Qualify-on-conflict is deferred, matching the renameField precedent. The nested same-leaf cursor→type resolution limitation surfaced during review is tracked separately as **W-24093717**.

**Stacked on #667 (4.3 renameField).** The base is the 4.3 branch, so this diff shows only the renameMethod work; it should merge after #667. Kept as a **draft** until then.

Validation: full pre-commit matrix green (5543 passed, 0 failed); `findMethodOccurrences` 19/19; renameMethod worker-topology 7/7; declaration-range unit 9/9.

### What issues does this PR fix or reference?

@W-23631132@

### Functionality Before

Renaming a method via F2 was unsupported — the rename dispatch returned `null` (LSP "nothing to rename") for a method cursor.

### Functionality After

F2 on a method renames its declaration, every call across the type family, and each override/implementor declaration across files as a single `WorkspaceEdit`; it declines safely (no partial edit) when a receiver, overload, or declaration can't be proven to bind to the family.
