### PR TITLE
feat(apex-lsp-compliant-services): renameMethod conflict detection + validation - W-23631133

### DIFF
--- a/docs/plans/W-23631133-renamemethod-conflict-validation-plan.md
+++ b/docs/plans/W-23631133-renamemethod-conflict-validation-plan.md
@@ -1,0 +1,72 @@
+# W-23631133 — 5.3 renameMethod: conflict detection + validation wiring
+
+Stacked on **W-23631132** (5.2 renameMethod WorkspaceEdit construction). Phase 3
+of the rename epic (`docs/plans/W-22629631-rename-symbol-spike-plan.md`).
+
+## Goal
+
+Wire hierarchy-aware **conflict detection** and **validation** into
+`resolveMethodRename`, so a method rename that would collide with an existing
+member — or use an invalid identifier, or target a non-user-owned symbol —
+returns a `ResponseError` instead of emitting a corrupting `WorkspaceEdit`.
+
+## What already exists (from 4.x / 5.2)
+
+- `dataOwner:CheckMemberConflicts` (4.0) already walks same-type / ancestor /
+  descendant on the complete graph and has a `memberKind: 'method'` branch — but
+  it matches **name only** (its own comment defers signature-equivalence to 5.3).
+- `validateRenameName(newName, SymbolKind.Method)` is already called in
+  `resolveMethodRename` Stage 4 (invalid identifier → `ResponseError`).
+- `canBeRenamed` + the `isUserOwnedApexUri` provenance guard already reject
+  stdlib / generated-SObject methods (5.2).
+- `getTypeMembersFullDetail` (shared, fail-closed) + `doesSignatureMatch`.
+- `verifyFieldRenameLocally` — the field precedent for the query-unavailable
+  fallback (parser-owned, fails closed).
+
+## Key semantic difference from renameField: **overloading is legal**
+
+A method conflict is real only when a member named `newName` with the **same
+signature** already exists. `foo(Integer)` → `bar` does NOT conflict with an
+existing `bar(String)` (a valid overload); it DOES conflict with an existing
+`bar(Integer)`. So the conflict check must be **signature-aware** for methods.
+(Field/property checks stay name-only.)
+
+Since renameMethod renames the whole override set together, an ancestor/
+descendant same-signature `bar` that is part of the override set is not a
+conflict — but a same-signature `bar` that pre-exists independently is. The 4.0
+handler already scopes same-type / non-private-ancestor / (non-private)
+descendant; 5.3 only narrows the *match predicate* to include signature.
+
+## Slices
+
+### Slice 1 — Signature-aware method conflict matching (data-owner)  ✅/⬜
+- Add optional `signature: Schema.optional(Schema.Array(Schema.String))` to the
+  `CheckMemberConflicts` payload (wire compat: absent → current name-only).
+- In the handler, when `memberKind === 'method'` and a `signature` is supplied,
+  a candidate member conflicts only when it is a method named `newName` AND
+  `doesSignatureMatch(member, newName, signature)`. Fields/properties and
+  signature-absent method calls keep name-only matching.
+- Handler tests: same-signature method collision → conflict; different-signature
+  overload → no conflict; field path unchanged.
+
+### Slice 2 — Wire Stage 4.5 into `resolveMethodRename`  ⬜
+- Derive the renamed method's visibility (isPrivate: Private OR Default) —
+  extend `resolveMethodContextForCursor` to also return `isPrivate` (mirrors
+  `resolveFieldContextForCursor`).
+- Skip the query for a no-op / case-only rename.
+- Call `dataOwner:CheckMemberConflicts` with `memberKind:'method'`, `signature`,
+  `currentName`, `isRenamedMemberPrivate`. Conflict → `ResponseError` (-32600).
+- On query error, `verifyMethodRenameLocally` — a method analogue of
+  `verifyFieldRenameLocally` (signature-aware, fails closed on uncertainty).
+- Topology tests: same-type same-signature conflict declines; overload (diff
+  signature) proceeds; no-op rename skips the check.
+
+### Slice 3 — Validation confirmation + docs  ⬜
+- Confirm `validateRenameName` + `canBeRenamed`/provenance already satisfy the
+  "IdentifierValidator + canBeRenamed guard for methods" requirement; add a
+  regression test if a gap exists (e.g. invalid method newName → ResponseError).
+- Update this plan + the WI detail; open the PR stacked on #673.
+
+## Out of scope
+- Method `prepareRename` (Phase 4 / 7.1 generalization) and 5.4 e2e.
+- Qualify-on-conflict rewrite (deferred, matching renameField).

--- a/docs/plans/W-23631133-renamemethod-conflict-validation-plan.md
+++ b/docs/plans/W-23631133-renamemethod-conflict-validation-plan.md
@@ -39,7 +39,7 @@ descendant; 5.3 only narrows the *match predicate* to include signature.
 
 ## Slices
 
-### Slice 1 — Signature-aware method conflict matching (data-owner)  ✅/⬜
+### Slice 1 — Signature-aware method conflict matching (data-owner)  ✅ DONE
 - Add optional `signature: Schema.optional(Schema.Array(Schema.String))` to the
   `CheckMemberConflicts` payload (wire compat: absent → current name-only).
 - In the handler, when `memberKind === 'method'` and a `signature` is supplied,
@@ -49,7 +49,7 @@ descendant; 5.3 only narrows the *match predicate* to include signature.
 - Handler tests: same-signature method collision → conflict; different-signature
   overload → no conflict; field path unchanged.
 
-### Slice 2 — Wire Stage 4.5 into `resolveMethodRename`  ⬜
+### Slice 2 — Wire Stage 4.5 into `resolveMethodRename`  ✅ DONE
 - Derive the renamed method's visibility (isPrivate: Private OR Default) —
   extend `resolveMethodContextForCursor` to also return `isPrivate` (mirrors
   `resolveFieldContextForCursor`).
@@ -61,11 +61,13 @@ descendant; 5.3 only narrows the *match predicate* to include signature.
 - Topology tests: same-type same-signature conflict declines; overload (diff
   signature) proceeds; no-op rename skips the check.
 
-### Slice 3 — Validation confirmation + docs  ⬜
-- Confirm `validateRenameName` + `canBeRenamed`/provenance already satisfy the
-  "IdentifierValidator + canBeRenamed guard for methods" requirement; add a
-  regression test if a gap exists (e.g. invalid method newName → ResponseError).
-- Update this plan + the WI detail; open the PR stacked on #673.
+### Slice 3 — Validation confirmation + docs  ✅ DONE
+- Confirmed `validateRenameName(newName, SymbolKind.Method)` (Stage 4) rejects an
+  invalid identifier with a -32602 ResponseError, and the `isUserOwnedApexUri`
+  provenance guard (`canBeRenamed` is-user-sourced) rejects stdlib/generated
+  methods — both already wired on the method path from 5.2. Added an invalid-name
+  regression test to the topology suite.
+- Updated this plan + the WI detail; PR opened stacked on #673.
 
 ## Out of scope
 - Method `prepareRename` (Phase 4 / 7.1 generalization) and 5.4 e2e.

--- a/packages/apex-ls/src/server/WorkerCoordinator.ts
+++ b/packages/apex-ls/src/server/WorkerCoordinator.ts
@@ -1138,6 +1138,7 @@ function createDispatcher(
             memberKind: 'field' | 'method';
             isRenamedMemberPrivate: boolean;
             currentName?: string;
+            signature?: string[];
           };
           return sendTracedToDataOwner(
             new CheckMemberConflicts({
@@ -1146,6 +1147,7 @@ function createDispatcher(
               memberKind: cmc.memberKind,
               isRenamedMemberPrivate: cmc.isRenamedMemberPrivate,
               currentName: cmc.currentName,
+              signature: cmc.signature,
             }),
           );
         }

--- a/packages/apex-ls/src/server/WorkerCoordinator.ts
+++ b/packages/apex-ls/src/server/WorkerCoordinator.ts
@@ -1139,6 +1139,7 @@ function createDispatcher(
             isRenamedMemberPrivate: boolean;
             currentName?: string;
             signature?: string[];
+            isStatic?: boolean;
           };
           return sendTracedToDataOwner(
             new CheckMemberConflicts({
@@ -1148,6 +1149,7 @@ function createDispatcher(
               isRenamedMemberPrivate: cmc.isRenamedMemberPrivate,
               currentName: cmc.currentName,
               signature: cmc.signature,
+              isStatic: cmc.isStatic,
             }),
           );
         }

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -6611,10 +6611,14 @@ const untracedHandlers: SerializedWorkerHandlers = {
               });
             }
 
-            const { SymbolKind, SymbolVisibility, inTypeSymbolGroup } =
-              yield* Effect.promise(
-                () => import('@salesforce/apex-lsp-parser-ast'),
-              );
+            const {
+              SymbolKind,
+              SymbolVisibility,
+              inTypeSymbolGroup,
+              doesSignatureMatch,
+            } = yield* Effect.promise(
+              () => import('@salesforce/apex-lsp-parser-ast'),
+            );
 
             // Resolve the defining type by FQN
             const definingType = yield* Effect.promise(() =>
@@ -6682,10 +6686,13 @@ const untracedHandlers: SerializedWorkerHandlers = {
                 })),
               );
 
-            // Helper: check type for member with newName (as an Effect generator)
-            // NOTE: For methods, this does name-based matching only.
-            // Signature-equivalence refinement is deferred to WI 5.3 when
-            // renameMethod consumes this query with full signature checking.
+            // Helper: check type for member with newName (as an Effect generator).
+            // Methods overload on signature (WI 5.3): a same-named method is only
+            // a conflict when its signature ALSO matches the renamed method's —
+            // `foo(Integer)`→`bar` does NOT collide with an existing `bar(String)`
+            // (a legal overload), but DOES collide with an existing `bar(Integer)`.
+            // Fields/properties (and a signature-absent method request) keep the
+            // name-only match.
             const hasMemberNamed = (
               type: ApexSymbol,
               name: string,
@@ -6698,6 +6705,16 @@ const untracedHandlers: SerializedWorkerHandlers = {
                   if (!kinds.includes(m.kind)) return false;
                   if (!memberNameMatches(m.name, name)) return false;
                   if (excludePrivate && isPrivate(m)) return false;
+                  if (
+                    req.memberKind === 'method' &&
+                    req.signature &&
+                    m.kind === SymbolKind.Method &&
+                    !doesSignatureMatch(m, name, [...req.signature])
+                  ) {
+                    // Same-named method but a DIFFERENT signature → legal overload,
+                    // not a conflict.
+                    return false;
+                  }
                   return true;
                 });
               });
@@ -6722,7 +6739,16 @@ const untracedHandlers: SerializedWorkerHandlers = {
               const renamedMember = definingMembers.find(
                 (m) =>
                   memberKinds.includes(m.kind) &&
-                  memberNameMatches(m.name, currentNameLower),
+                  memberNameMatches(m.name, currentNameLower) &&
+                  // For an overloaded method, pick the exact overload by
+                  // signature so we read the RENAMED method's visibility (not a
+                  // sibling overload's) for the descendant gate.
+                  (req.memberKind === 'method' && req.signature
+                    ? m.kind === SymbolKind.Method &&
+                      doesSignatureMatch(m, req.currentName!, [
+                        ...req.signature,
+                      ])
+                    : true),
               );
               if (!renamedMember) {
                 return yield* Effect.fail({

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -4332,8 +4332,11 @@ async function resolveMethodContextForCursor(
   declaringTypeFqn: string;
   signature: string[];
   isStatic: boolean;
+  isPrivate: boolean;
 } | null> {
   try {
+    const { SymbolVisibility } =
+      await import('@salesforce/apex-lsp-parser-ast');
     const parserPosition = {
       line: position.line + 1,
       character: position.character,
@@ -4359,15 +4362,23 @@ async function resolveMethodContextForCursor(
       parameters?: Array<{
         type?: { name?: string; originalTypeString?: string };
       }>;
-      modifiers?: { isStatic?: boolean };
+      modifiers?: { isStatic?: boolean; visibility?: unknown };
     };
     const signature = (methodSym.parameters ?? []).map(
       (p) => p.type?.originalTypeString ?? p.type?.name ?? '',
     );
+    // Default visibility is effectively private for inheritance (a subclass can't
+    // see it), so both gate off the descendant conflict check — matching the
+    // CheckMemberConflicts handler's isPrivate and resolveFieldContextForCursor.
+    const visibility = methodSym.modifiers?.visibility;
+    const isPrivate =
+      visibility === SymbolVisibility.Private ||
+      visibility === SymbolVisibility.Default;
     return {
       declaringTypeFqn,
       signature,
       isStatic: methodSym.modifiers?.isStatic === true,
+      isPrivate,
     };
   } catch {
     return null;
@@ -4530,6 +4541,111 @@ async function verifyFieldRenameLocally(
 
   // Locally resolvable, no same-type collision, and cannot participate in a
   // hierarchy → only same-type collisions were possible and we ruled them out.
+  return { decision: 'proceed' };
+}
+
+/**
+ * METHOD analogue of {@link verifyFieldRenameLocally} (W-23631133) — the
+ * parser-owned, fail-closed fallback used when the authoritative
+ * `dataOwner:CheckMemberConflicts` query is unavailable. Same posture (decline on
+ * any uncertainty), but the same-type collision test is SIGNATURE-aware: methods
+ * overload, so a member named `newName` collides only when its signature also
+ * matches the renamed method's (`foo(Integer)`→`bar` is fine next to
+ * `bar(String)`, but not next to `bar(Integer)`).
+ */
+async function verifyMethodRenameLocally(
+  svc: RequestServices,
+  uri: string,
+  position: { line: number; character: number },
+  newName: string,
+  signature: string[],
+): Promise<{ decision: 'proceed' } | { decision: 'decline'; message: string }> {
+  const { doesSignatureMatch } =
+    await import('@salesforce/apex-lsp-parser-ast');
+  const parserPosition = {
+    line: position.line + 1,
+    character: position.character,
+  };
+
+  const methodSymbol = await resolveCursorSymbol(svc, uri, parserPosition);
+  const declaringTypeSym = methodSymbol
+    ? await svc.symbolManager.getContainingType(methodSymbol)
+    : null;
+  if (!methodSymbol || !declaringTypeSym) {
+    return {
+      decision: 'decline',
+      message:
+        `Cannot rename '${newName}': the declaring type could not be ` +
+        'resolved locally to verify member conflicts, so this rename cannot ' +
+        'be applied safely.',
+    };
+  }
+
+  const typeName = declaringTypeSym.fqn ?? declaringTypeSym.name;
+  const table = await svc.symbolManager.getSymbolTableForFile(
+    declaringTypeSym.fileUri,
+  );
+  const localIsFullAndComplete =
+    table?.getDetailLevel() === 'full' &&
+    table.getMetadata().parseCompleteness === 'complete';
+  if (!localIsFullAndComplete) {
+    return {
+      decision: 'decline',
+      message:
+        `Cannot rename '${methodSymbol.name}' to '${newName}': the declaring ` +
+        `type '${typeName}' could not be established at full detail locally ` +
+        '(the member set may be incomplete), so a member conflict cannot be ' +
+        'ruled out and this rename cannot be applied safely.',
+    };
+  }
+
+  const blockSymbol = table
+    .getSymbolsInScope(declaringTypeSym.id)
+    .find((s) => s.kind === SymbolKind.Block);
+  const members = blockSymbol ? table.getSymbolsInScope(blockSymbol.id) : [];
+
+  // SAME-TYPE collision: any METHOD other than the renamed one whose name equals
+  // newName AND whose signature matches (a different-signature overload is legal).
+  const newNameLower = newName.toLowerCase();
+  const collision = members.find(
+    (m) =>
+      m.kind === SymbolKind.Method &&
+      m.id !== methodSymbol.id &&
+      m.name.toLowerCase() === newNameLower &&
+      doesSignatureMatch(m, newName, signature),
+  );
+  if (collision) {
+    return {
+      decision: 'decline',
+      message:
+        `Cannot rename '${methodSymbol.name}' to '${newName}': a method ` +
+        `named '${newName}' with the same signature already exists in type ` +
+        `'${typeName}'.`,
+    };
+  }
+
+  // HIERARCHY uncertainty: an ancestor (non-private) or descendant could declare
+  // a same-signature newName we cannot see locally — decline, mirroring the field
+  // fallback. (Method overriding is normal, but a NEW same-signature member of the
+  // rename's target name in a related type is still a collision.)
+  const typeSym = declaringTypeSym as TypeSymbol;
+  const hasSuperClass = !!typeSym.superClass;
+  const implementsInterfaces =
+    Array.isArray(typeSym.interfaces) && typeSym.interfaces.length > 0;
+  const couldBeSubclassed =
+    !!declaringTypeSym.modifiers?.isVirtual ||
+    !!declaringTypeSym.modifiers?.isAbstract;
+  if (hasSuperClass || implementsInterfaces || couldBeSubclassed) {
+    return {
+      decision: 'decline',
+      message:
+        `Cannot rename '${methodSymbol.name}' to '${newName}': type ` +
+        `'${typeName}' participates in a class hierarchy that cannot be ` +
+        'verified locally, so an ancestor or descendant conflict cannot be ' +
+        'ruled out and this rename cannot be applied safely.',
+    };
+  }
+
   return { decision: 'proceed' };
 }
 
@@ -5101,7 +5217,12 @@ async function resolveMethodRename(
       );
       return null;
     }
-    const { declaringTypeFqn: declaringType, signature, isStatic } = ctx;
+    const {
+      declaringTypeFqn: declaringType,
+      signature,
+      isStatic,
+      isPrivate,
+    } = ctx;
     // An empty signature slot means a parameter's declared type could not be read
     // (parse degradation). doesSignatureMatch would then fail to match the real
     // overload, silently dropping its declaration from the override set while
@@ -5126,7 +5247,73 @@ async function resolveMethodRename(
       return { error: { code: -32602, message: validation.message } };
     }
 
-    // (Stage 4.5 conflict detection deferred to WI 5.3.)
+    // Stage 4.5: hierarchy-aware conflict detection (W-23631133), mirroring the
+    // field path. Skip for a no-op / case-only rename (would self-conflict).
+    // Otherwise ask the data-owner's CheckMemberConflicts query (complete graph)
+    // whether newName collides — SIGNATURE-aware for methods, so a legal overload
+    // at a different signature is NOT a conflict. A genuine collision is a hard
+    // error (ResponseError); on query unavailability, fall back to the local
+    // parser-owned check rather than fail open.
+    if (req.newName.toLowerCase() !== target.name.toLowerCase()) {
+      let conflict:
+        | {
+            conflict?: boolean;
+            conflictingTypeFqn?: string;
+            reason?: 'same-type' | 'ancestor' | 'descendant';
+          }
+        | null
+        | undefined;
+      try {
+        conflict = (await requestCoordinatorAssistancePromiseShared(
+          'dataOwner:CheckMemberConflicts',
+          {
+            definingTypeFqn: declaringType,
+            newName: req.newName,
+            memberKind: 'method',
+            isRenamedMemberPrivate: isPrivate,
+            currentName: target.name,
+            signature,
+          },
+          true,
+        )) as {
+          conflict?: boolean;
+          conflictingTypeFqn?: string;
+          reason?: 'same-type' | 'ancestor' | 'descendant';
+        } | null;
+      } catch (err) {
+        emitWorkerLog(
+          'warn',
+          '[RENAME] method conflict pre-check unavailable for ' +
+            `'${declaringType}.${target.name}' → '${req.newName}'; falling ` +
+            `back to a local parser-owned conflict check: ${err}`,
+        );
+        const local = await verifyMethodRenameLocally(
+          svc,
+          uri,
+          req.position,
+          req.newName,
+          signature,
+        );
+        if (local.decision === 'decline') {
+          emitWorkerLog('warn', `[RENAME] ${local.message}`);
+          return { error: { code: -32600, message: local.message } };
+        }
+        conflict = null;
+      }
+      if (conflict?.conflict) {
+        const where =
+          conflict.reason === 'same-type'
+            ? `type '${conflict.conflictingTypeFqn ?? declaringType}'`
+            : `${conflict.reason ?? 'related'} type '${
+                conflict.conflictingTypeFqn ?? '?'
+              }'`;
+        const message =
+          `Cannot rename '${target.name}' to '${req.newName}': a method ` +
+          `named '${req.newName}' with the same signature already exists in ${where}.`;
+        emitWorkerLog('warn', `[RENAME] ${message}`);
+        return { error: { code: -32600, message } };
+      }
+    }
 
     // Stage 5a: resolve the type family + override declaration sites on the
     // data-owner's complete graph. On failure we cannot know the override set,

--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -5273,6 +5273,7 @@ async function resolveMethodRename(
             isRenamedMemberPrivate: isPrivate,
             currentName: target.name,
             signature,
+            isStatic,
           },
           true,
         )) as {
@@ -6982,6 +6983,21 @@ const untracedHandlers: SerializedWorkerHandlers = {
                 conflictingTypeFqn: req.definingTypeFqn,
                 reason: 'same-type' as const,
               };
+            }
+
+            // Static methods are NOT polymorphic: a same-name static in an
+            // ancestor/descendant is legal method HIDING (a distinct member), not
+            // a conflict — so only the same-type check (above) applies to statics
+            // (WI 5.3 re-review). Skip the ancestor/descendant hierarchy walk that
+            // instance members require, which otherwise over-declines valid static
+            // renames.
+            if (req.isStatic) {
+              emitWorkerLog(
+                'info',
+                `[RENAME] CheckMemberConflicts: static ${req.definingTypeFqn}.` +
+                  `${req.newName} — same-type clear, skipping hierarchy walk`,
+              );
+              return { conflict: false };
             }
 
             // 2. Check ancestor conflict (exclude private members in ancestors)

--- a/packages/apex-ls/test/integration/CheckMemberConflicts.node.test.ts
+++ b/packages/apex-ls/test/integration/CheckMemberConflicts.node.test.ts
@@ -155,6 +155,17 @@ const BROKEN_SRC = `public class brokenType {
     }
 }`;
 
+// Overloaded methods for signature-aware conflict matching (WI 5.3). Renaming
+// `beta(Integer)` collides with `alpha(Integer)` (same signature) but NOT with
+// `gamma(String)` (a legal overload at a different signature).
+const MOVERLOAD_URI = 'file:///test/mOverload.cls';
+const MOVERLOAD_SRC = `public class mOverload {
+    public void alpha(Integer a) { }
+    public void alpha(String a) { }
+    public void beta(Integer a) { }
+    public void gamma(String a) { }
+}`;
+
 // One combined workspace containing every fixture. Ingested once.
 const WORKSPACE_ENTRIES = [
   { uri: BASE_URI, content: BASE_SRC, languageId: 'apex', version: 1 },
@@ -240,6 +251,12 @@ const WORKSPACE_ENTRIES = [
     version: 1,
   },
   { uri: BROKEN_URI, content: BROKEN_SRC, languageId: 'apex', version: 1 },
+  {
+    uri: MOVERLOAD_URI,
+    content: MOVERLOAD_SRC,
+    languageId: 'apex',
+    version: 1,
+  },
 ];
 
 type ConflictResult = {
@@ -254,6 +271,7 @@ type ConflictQuery = {
   memberKind: 'field' | 'method';
   isRenamedMemberPrivate: boolean;
   currentName?: string;
+  signature?: string[];
 };
 
 describe('CheckMemberConflicts data-owner query', () => {
@@ -475,6 +493,54 @@ describe('CheckMemberConflicts data-owner query', () => {
     expect(result.conflict).toBe(true);
     expect(result.reason).toBe('ancestor');
     expect(result.conflictingTypeFqn?.toLowerCase()).toContain('ihasmethod');
+  });
+
+  // --- WI 5.3: signature-aware method conflict matching ---------------------
+
+  it('reports a same-type method conflict when a SAME-signature method exists', async () => {
+    // Rename mOverload.beta(Integer) → 'alpha'. alpha(Integer) already exists
+    // (same signature) → a real collision.
+    const result = await runConflictQuery({
+      definingTypeFqn: 'mOverload',
+      newName: 'alpha',
+      memberKind: 'method',
+      isRenamedMemberPrivate: false,
+      currentName: 'beta',
+      signature: ['Integer'],
+    });
+
+    expect(result.conflict).toBe(true);
+    expect(result.reason).toBe('same-type');
+  });
+
+  it('does NOT report a conflict against a DIFFERENT-signature overload', async () => {
+    // Rename mOverload.beta(Integer) → 'gamma'. Only gamma(String) exists — a
+    // legal overload at a different signature, not a conflict.
+    const result = await runConflictQuery({
+      definingTypeFqn: 'mOverload',
+      newName: 'gamma',
+      memberKind: 'method',
+      isRenamedMemberPrivate: false,
+      currentName: 'beta',
+      signature: ['Integer'],
+    });
+
+    expect(result.conflict).toBe(false);
+  });
+
+  it('falls back to name-only method matching when no signature is supplied', async () => {
+    // Without a signature (legacy/absent), a same-named method is a conflict
+    // regardless of overload — preserves backward-compatible behavior.
+    const result = await runConflictQuery({
+      definingTypeFqn: 'mOverload',
+      newName: 'alpha',
+      memberKind: 'method',
+      isRenamedMemberPrivate: false,
+      currentName: 'beta',
+    });
+
+    expect(result.conflict).toBe(true);
+    expect(result.reason).toBe('same-type');
   });
 
   // --- Finding 1: non-public members must be visible ---------------------

--- a/packages/apex-ls/test/integration/CheckMemberConflicts.node.test.ts
+++ b/packages/apex-ls/test/integration/CheckMemberConflicts.node.test.ts
@@ -166,6 +166,20 @@ const MOVERLOAD_SRC = `public class mOverload {
     public void gamma(String a) { }
 }`;
 
+// Static-method hierarchy fixture (WI 5.3 re-review): the parent declares a
+// static method; the child declares an unrelated member of the would-be new
+// name. A STATIC rename must NOT treat that as a descendant conflict (statics
+// are not polymorphic — a same-name subclass member is legal hiding), whereas
+// an INSTANCE rename would.
+const STATIC_PARENT_URI = 'file:///test/staticParent.cls';
+const STATIC_PARENT_SRC = `public virtual class staticParent {
+    public static Integer helper() { return 1; }
+}`;
+const STATIC_CHILD_URI = 'file:///test/staticChild.cls';
+const STATIC_CHILD_SRC = `public class staticChild extends staticParent {
+    public Integer renamedTarget() { return 2; }
+}`;
+
 // One combined workspace containing every fixture. Ingested once.
 const WORKSPACE_ENTRIES = [
   { uri: BASE_URI, content: BASE_SRC, languageId: 'apex', version: 1 },
@@ -257,6 +271,18 @@ const WORKSPACE_ENTRIES = [
     languageId: 'apex',
     version: 1,
   },
+  {
+    uri: STATIC_PARENT_URI,
+    content: STATIC_PARENT_SRC,
+    languageId: 'apex',
+    version: 1,
+  },
+  {
+    uri: STATIC_CHILD_URI,
+    content: STATIC_CHILD_SRC,
+    languageId: 'apex',
+    version: 1,
+  },
 ];
 
 type ConflictResult = {
@@ -272,6 +298,7 @@ type ConflictQuery = {
   isRenamedMemberPrivate: boolean;
   currentName?: string;
   signature?: string[];
+  isStatic?: boolean;
 };
 
 describe('CheckMemberConflicts data-owner query', () => {
@@ -526,6 +553,41 @@ describe('CheckMemberConflicts data-owner query', () => {
     });
 
     expect(result.conflict).toBe(false);
+  });
+
+  it('skips the descendant walk for a STATIC method rename (isStatic)', async () => {
+    // staticChild declares `renamedTarget`; renaming the parent's STATIC helper
+    // to that name is NOT a conflict (statics aren't polymorphic — a same-name
+    // subclass member is legal hiding). With isStatic the descendant walk is
+    // skipped.
+    const result = await runConflictQuery({
+      definingTypeFqn: 'staticParent',
+      newName: 'renamedTarget',
+      memberKind: 'method',
+      isRenamedMemberPrivate: false,
+      currentName: 'helper',
+      signature: [],
+      isStatic: true,
+    });
+
+    expect(result.conflict).toBe(false);
+  });
+
+  it('DOES report the descendant conflict when the same rename is treated as instance', async () => {
+    // Contrast: without isStatic (instance semantics), the descendant walk finds
+    // staticChild.renamedTarget → conflict. Proves the isStatic flag is what
+    // suppresses the (over-conservative-for-statics) descendant check.
+    const result = await runConflictQuery({
+      definingTypeFqn: 'staticParent',
+      newName: 'renamedTarget',
+      memberKind: 'method',
+      isRenamedMemberPrivate: false,
+      currentName: 'helper',
+      signature: [],
+    });
+
+    expect(result.conflict).toBe(true);
+    expect(result.reason).toBe('descendant');
   });
 
   it('falls back to name-only method matching when no signature is supplied', async () => {

--- a/packages/apex-ls/test/integration/RenameMethodThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/RenameMethodThroughWorkerTopology.node.test.ts
@@ -172,6 +172,16 @@ const RM_STATHIDECHILD_SRC = `public class RmStatHideChild extends RmStatHideBas
     public Integer use() { return score(); }
 }`;
 
+// Case 10 (WI 5.3): conflict detection. Renaming alpha(Integer)→beta collides
+// with the SAME-signature beta(Integer); renaming alpha(Integer)→gamma does NOT
+// collide with the different-signature gamma(String) (a legal overload).
+const RM_CONFLICT_URI = 'file:///test/RmConflict.cls';
+const RM_CONFLICT_SRC = `public class RmConflict {
+    public void alpha(Integer a) { }
+    public void beta(Integer a) { }
+    public void gamma(String a) { }
+}`;
+
 const SOURCES: Record<string, string> = {
   [RM_BASE_URI]: RM_BASE_SRC,
   [RM_CHILD_URI]: RM_CHILD_SRC,
@@ -190,6 +200,7 @@ const SOURCES: Record<string, string> = {
   [RM_STATCHILD_URI]: RM_STATCHILD_SRC,
   [RM_STATHIDEBASE_URI]: RM_STATHIDEBASE_SRC,
   [RM_STATHIDECHILD_URI]: RM_STATHIDECHILD_SRC,
+  [RM_CONFLICT_URI]: RM_CONFLICT_SRC,
 };
 
 const WORKSPACE_ENTRIES = Object.entries(SOURCES).map(([uri, content]) => ({
@@ -513,5 +524,58 @@ describe('renameMethod through the worker topology (W-23631132, slice 4)', () =>
     Object.values(changes)
       .flat()
       .forEach((e) => expect(e.newText).toBe('render'));
+  }, 120_000);
+
+  it('declines a rename that collides with a SAME-signature method (WI 5.3)', async () => {
+    // Cursor on RmConflict.alpha(Integer) (LSP line 1, char 18). beta(Integer)
+    // already exists with the same signature → conflict → decline.
+    const result = await rename(
+      RM_CONFLICT_URI,
+      { line: 1, character: 18 },
+      'beta',
+    );
+    logger.debug(`[rename-method:conflict] ${JSON.stringify(result)}`);
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('error');
+    expect(result).not.toHaveProperty('changes');
+    expect(result!.error!.code).toBe(-32600);
+    expect(result!.error!.message).toMatch(/already exists/i);
+  }, 120_000);
+
+  it('allows a rename that only matches a DIFFERENT-signature overload (WI 5.3)', async () => {
+    // alpha(Integer) → gamma. Only gamma(String) exists — a legal overload at a
+    // different signature, so no conflict; the rename proceeds.
+    const result = await rename(
+      RM_CONFLICT_URI,
+      { line: 1, character: 18 },
+      'gamma',
+    );
+    logger.debug(`[rename-method:overload-ok] ${JSON.stringify(result)}`);
+
+    expect(result?.error).toBeUndefined();
+    expect(result?.changes).toBeDefined();
+    const edits = result!.changes![RM_CONFLICT_URI];
+    expect(edits).toBeDefined();
+    // alpha's declaration (line 1) renamed to gamma.
+    expect(edits.some((e) => e.range.start.line === 1)).toBe(true);
+    edits.forEach((e) => expect(e.newText).toBe('gamma'));
+  }, 120_000);
+
+  it('skips the conflict check for a no-op / case-only rename (WI 5.3)', async () => {
+    // alpha → Alpha (case-only): the check is skipped (it would self-conflict),
+    // so the rename proceeds rather than erroring.
+    const result = await rename(
+      RM_CONFLICT_URI,
+      { line: 1, character: 18 },
+      'Alpha',
+    );
+    logger.debug(`[rename-method:case-only] ${JSON.stringify(result)}`);
+
+    expect(result?.error).toBeUndefined();
+    expect(result?.changes).toBeDefined();
+    expect(
+      result!.changes![RM_CONFLICT_URI].some((e) => e.newText === 'Alpha'),
+    ).toBe(true);
   }, 120_000);
 });

--- a/packages/apex-ls/test/integration/RenameMethodThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/RenameMethodThroughWorkerTopology.node.test.ts
@@ -578,4 +578,21 @@ describe('renameMethod through the worker topology (W-23631132, slice 4)', () =>
       result!.changes![RM_CONFLICT_URI].some((e) => e.newText === 'Alpha'),
     ).toBe(true);
   }, 120_000);
+
+  it('rejects an invalid method newName with a validation error (WI 5.3)', async () => {
+    // `2bad` is not a valid Apex identifier → validateRenameName rejects it with
+    // a -32602 ResponseError before any edit or conflict query.
+    const result = await rename(
+      RM_CONFLICT_URI,
+      { line: 1, character: 18 },
+      '2bad',
+    );
+    logger.debug(`[rename-method:invalid-name] ${JSON.stringify(result)}`);
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('error');
+    expect(result).not.toHaveProperty('changes');
+    expect(result!.error!.code).toBe(-32602);
+    expect(result!.error!.message.length).toBeGreaterThan(0);
+  }, 120_000);
 });

--- a/packages/apex-lsp-shared/src/workerWireSchemas.ts
+++ b/packages/apex-lsp-shared/src/workerWireSchemas.ts
@@ -1094,6 +1094,11 @@ export class CheckMemberConflicts extends Schema.TaggedRequest<CheckMemberConfli
       // short-circuited to conflict:false so the member never conflicts with
       // itself in the same-type lookup. Optional for backward compatibility.
       currentName: Schema.optional(Schema.String),
+      // The renamed METHOD's parameter-type signature. Methods overload on
+      // signature, so a same-named method is a conflict only when its signature
+      // ALSO matches (WI 5.3) — `foo(Integer)`→`bar` does not collide with an
+      // existing `bar(String)`. Absent (or memberKind 'field') → name-only match.
+      signature: Schema.optional(Schema.Array(Schema.String)),
     },
   },
 ) {}

--- a/packages/apex-lsp-shared/src/workerWireSchemas.ts
+++ b/packages/apex-lsp-shared/src/workerWireSchemas.ts
@@ -1099,6 +1099,12 @@ export class CheckMemberConflicts extends Schema.TaggedRequest<CheckMemberConfli
       // ALSO matches (WI 5.3) — `foo(Integer)`→`bar` does not collide with an
       // existing `bar(String)`. Absent (or memberKind 'field') → name-only match.
       signature: Schema.optional(Schema.Array(Schema.String)),
+      // Whether the renamed method is static. Static methods are NOT polymorphic:
+      // a same-name static in an ancestor/descendant is legal method HIDING, a
+      // distinct member — not a conflict. When true, only the same-type check
+      // applies (the ancestor/descendant walk is skipped). Optional; absent means
+      // instance (walk the hierarchy), preserving the field/legacy behavior.
+      isStatic: Schema.optional(Schema.Boolean),
     },
   },
 ) {}


### PR DESCRIPTION
### What does this PR do?

Implements **5.3 renameMethod: conflict detection + validation wiring** (Phase 3 of the rename epic). A method rename that would collide with an existing member now returns a `ResponseError` instead of emitting a corrupting `WorkspaceEdit`.

**Key semantic:** methods overload, so a conflict requires a same-name **and same-signature** member — `foo(Integer)` → `bar` collides with an existing `bar(Integer)` but NOT with `bar(String)` (a legal overload). Field/property checks stay name-only.

Built in slices:
- **Signature-aware conflict matching** (`CheckMemberConflicts` data-owner query). The handler already had a `memberKind: 'method'` branch but matched by name only; it now also requires `doesSignatureMatch` for methods when a signature is supplied (the step-0 visibility self-verify matches the exact overload too). Fixed a latent bug: `queryDataOwner` hand-copies each request's fields and was silently dropping `CheckMemberConflicts.signature`, so it never reached the data owner.
- **Stage 4.5 wired into `resolveMethodRename`**, mirroring the field path: skip a no-op/case-only rename → query `CheckMemberConflicts` (`memberKind: 'method'` + signature + visibility) → conflict is a `ResponseError`; on query unavailability, `verifyMethodRenameLocally` (a parser-owned, fail-closed method analogue of `verifyFieldRenameLocally`) declines on any uncertainty. `resolveMethodContextForCursor` now also returns the method's `isPrivate` (Private OR Default), which gates the descendant conflict check.
- **Validation confirmation**: `validateRenameName(newName, SymbolKind.Method)` (Stage 4) already rejects an invalid identifier with a -32602 error, and the `isUserOwnedApexUri` provenance guard (`canBeRenamed` is-user-sourced) already rejects stdlib/generated methods (both from 5.2). Added an invalid-name regression test.

Out of scope (later WIs): method `prepareRename` (Phase 4 / 7.1) and 5.4 e2e. Qualify-on-conflict is deferred, matching the renameField precedent.

**Stacked on #673 (5.2 renameMethod WorkspaceEdit construction).** The base is the 5.2 branch, so this diff shows only the conflict/validation work; it should merge after #673 (which merges after #667). Kept as a **draft** until then.

Validation: full pre-commit matrix green (5549 passed, 0 failed); CheckMemberConflicts 24/24; renameMethod worker-topology 11/11.

### What issues does this PR fix or reference?

@W-23631133@

### Functionality Before

A method rename applied its `WorkspaceEdit` without checking for member-name collisions — renaming `foo` → `bar` in a type that already declared a same-signature `bar` would mint a duplicate declaration.

### Functionality After

A method rename that collides with a same-signature member in the same type, a non-private ancestor, or (when the renamed method is non-private) a descendant is declined with a `ResponseError`; a legal overload at a different signature is not treated as a conflict, and an invalid new identifier is rejected up front.
