### PR TITLE
feat(apex-lsp-compliant-services): generalize onPrepareRename across rename kinds - W-23631152

### DIFF
--- a/packages/apex-ls/src/worker.platform.shared.ts
+++ b/packages/apex-ls/src/worker.platform.shared.ts
@@ -4254,6 +4254,117 @@ async function resolvePrepareRenameForField(
 }
 
 /**
+ * prepareRename for a METHOD (W-23631152). Mirror of resolvePrepareRenameForField
+ * gating on `kind === 'method'` so F2 opens the rename box on a method cursor.
+ * Before this, DispatchPrepareRename dispatched local → field only, so a method
+ * cursor returned null and — with `prepareProvider` advertised — VS Code treated
+ * the position as "can't rename here" even though renameMethod (W-23631132) can
+ * resolve it. This uses the same svc primitives resolveMethodRename uses (no
+ * accept/decline drift), returning the cursor-containing range (usage token or
+ * declaration) + placeholder, or null. Only user-owned Apex sources are
+ * renamable — a stdlib (`apexlib://`) DECLARATION is rejected even when the
+ * cursor sits on a usage in an editable file. prepareRename needs only the range
+ * + placeholder, so this mirrors the FIELD prepare (not the full method
+ * resolver, resolveMethodContextForCursor, which additionally computes
+ * signature/static-ness for the conflict walk).
+ */
+async function resolvePrepareRenameForMethod(
+  svc: RequestServices,
+  req: PositionReq,
+): Promise<{
+  range: {
+    start: { line: number; character: number };
+    end: { line: number; character: number };
+  };
+  placeholder: string;
+} | null> {
+  const uri = req.textDocument.uri;
+  try {
+    // Recompile + load referenced types so the cursor resolves (Stage 1).
+    const cursorTextAvailable = typeof req.content === 'string';
+    const cursorRecompiled = await recompileCursorFileAtFullDetail(
+      svc,
+      uri,
+      req.content,
+      { resolveCrossFileReferences: false },
+    );
+    if (!cursorRecompiled && !cursorTextAvailable) return null;
+    await loadReferencedTypesForFile(svc, uri);
+
+    // LSP (0-based line) → parser (1-based line, 0-based column).
+    const parserPosition = {
+      line: req.position.line + 1,
+      character: req.position.character,
+    };
+
+    // Resolve the cursor's declaration symbol to gate on BOTH kind and source
+    // provenance: only a method declared in a USER-OWNED Apex source is
+    // renamable. A stdlib (`apexlib://`) method must not be advertised as
+    // renamable, or F2 would open the rename box on something we cannot edit.
+    const symbol = await resolveCursorSymbol(svc, uri, parserPosition);
+    if (!symbol?.name) return null;
+    const kind = typeof symbol.kind === 'string' ? symbol.kind : undefined;
+    if (kind !== 'method') return null;
+    if (!isUserOwnedApexUri((symbol as { fileUri?: string }).fileUri)) {
+      return null;
+    }
+
+    // Prefer the usage token under the cursor; exactCursorReference narrows to it.
+    const references = await svc.symbolManager.getReferencesAtPosition(
+      uri,
+      parserPosition,
+    );
+    const selected = exactCursorReference(references ?? [], parserPosition);
+    let cursorRange = selected.reference?.location?.identifierRange;
+
+    // Else the cursor is on the declaration identifier itself.
+    if (!cursorRange) {
+      const declaration = await svc.symbolManager.getSymbolAtPosition(
+        uri,
+        parserPosition,
+        'precise',
+      );
+      cursorRange = declaration?.location?.identifierRange;
+    }
+
+    // Half-open containment: parser identifier ranges are [start, end), so a
+    // cursor AT endColumn sits one past the identifier and must be rejected —
+    // matching resolvePrepareRenameForLocal/Field. `positionInRange` uses an
+    // INCLUSIVE end (`> endColumn`), which would wrongly accept that cursor, so
+    // verify half-open containment here before returning any range.
+    const containsCursor = (r: OccurrenceRange): boolean => {
+      const afterStart =
+        r.startLine < parserPosition.line ||
+        (r.startLine === parserPosition.line &&
+          r.startColumn <= parserPosition.character);
+      const beforeEnd =
+        r.endLine > parserPosition.line ||
+        (r.endLine === parserPosition.line &&
+          r.endColumn > parserPosition.character);
+      return afterStart && beforeEnd;
+    };
+    if (!cursorRange || !containsCursor(cursorRange)) return null;
+
+    return {
+      range: {
+        start: {
+          line: cursorRange.startLine - 1,
+          character: cursorRange.startColumn,
+        },
+        end: {
+          line: cursorRange.endLine - 1,
+          character: cursorRange.endColumn,
+        },
+      },
+      placeholder: symbol.name,
+    };
+  } catch (err) {
+    emitWorkerLog('warn', `[PREPARE_RENAME] method failed for ${uri}: ${err}`);
+    return null;
+  }
+}
+
+/**
  * Resolve the field/property under the cursor to its declaring-type FQN AND
  * whether the field itself is effectively private (W-23631084 / W-23631086).
  * renameField needs BOTH: the declaring type anchors receiver disambiguation
@@ -5873,13 +5984,23 @@ const requestHandlers = {
       return resolveMethodRename(svc, req);
     },
   ),
-  // prepareRename for locals (W-23631080) + fields (W-23631087). Local path
-  // first; a field cursor falls through to the field path (else F2 can't open).
+  // Generalized prepareRename (W-23631152): dispatch local → field → method,
+  // mirroring the DispatchRename RESOLVE chain (local → field → method) so F2
+  // opens the rename box on every kind that renameResolve can service. Each
+  // path returns the identifier range + placeholder for its kind, or `null`
+  // (LSP: "nothing to rename") to fall through to the next — matching how the
+  // field/local paths surface an un-renamable cursor (they never throw a
+  // distinct error shape; a failed `canBeRenamed()`-style gate is simply a
+  // null, so no new error type is introduced here). TYPE prepareRename is
+  // deferred to Group 6 (renameType); append `?? (await
+  // resolvePrepareRenameForType(svc, req))` here when that lands — this is the
+  // extension seam.
   DispatchPrepareRename: requestHandler<PositionReq>(
     'DispatchPrepareRename',
     async (svc, req) =>
       (await resolvePrepareRenameForLocal(req)) ??
-      (await resolvePrepareRenameForField(svc, req)),
+      (await resolvePrepareRenameForField(svc, req)) ??
+      (await resolvePrepareRenameForMethod(svc, req)),
   ),
   DispatchImplementation: effectRequestHandler<PositionReq>(
     'DispatchImplementation',

--- a/packages/apex-ls/test/integration/RenameMethodThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/RenameMethodThroughWorkerTopology.node.test.ts
@@ -325,6 +325,63 @@ describe('renameMethod through the worker topology (W-23631132, slice 4)', () =>
       content: SOURCES[uri],
     }) as Promise<RenameResult>;
 
+  // Dispatch a single pool prepareRename with the cursor file's live buffer.
+  const prepareRename = (
+    uri: string,
+    position: { line: number; character: number },
+  ): Promise<{
+    range: {
+      start: { line: number; character: number };
+      end: { line: number; character: number };
+    };
+    placeholder: string;
+  } | null> =>
+    dispatcher.dispatch('prepareRename', {
+      textDocument: { uri },
+      position,
+      content: SOURCES[uri],
+    }) as Promise<{
+      range: {
+        start: { line: number; character: number };
+        end: { line: number; character: number };
+      };
+      placeholder: string;
+    } | null>;
+
+  // W-23631152: DispatchPrepareRename now dispatches local → field → method, so
+  // F2 opens the rename box on a method cursor in a fully ingested workspace
+  // (the same cone these rename tests exercise). prepareRename returns only the
+  // identifier range + placeholder — it does not walk the family — so a method
+  // DECLARATION cursor resolves to its own identifier range here.
+  it('returns prepareRename range for a method DECLARATION cursor (W-23631152)', async () => {
+    // Cursor on RmBase.run declaration (LSP line 1, char 25 — inside `run`),
+    // the same position the override rename test uses.
+    const result = await prepareRename(RM_BASE_URI, { line: 1, character: 25 });
+    logger.debug(`[prepare-rename:method-decl] ${JSON.stringify(result)}`);
+
+    expect(result).not.toBeNull();
+    expect(result!.range.start.line).toBe(1);
+    expect(result!.range.end.line).toBe(1);
+    expect(result!.range.start.character).toBeLessThanOrEqual(25);
+    expect(result!.range.end.character).toBeGreaterThan(25);
+    expect(result!.placeholder).toBe('run');
+  }, 120_000);
+
+  it('returns the usage range for a method CALL cursor (W-23631152)', async () => {
+    // Cursor on RmUtil.caller()'s in-body `compute()` CALL (LSP line 2, char
+    // 47). prepareRename must return the CALL's identifier range (via
+    // exactCursorReference), not the declaration on line 1.
+    const result = await prepareRename(RM_UTIL_URI, { line: 2, character: 47 });
+    logger.debug(`[prepare-rename:method-call] ${JSON.stringify(result)}`);
+
+    expect(result).not.toBeNull();
+    expect(result!.range.start.line).toBe(2);
+    expect(result!.range.end.line).toBe(2);
+    expect(result!.range.start.character).toBeLessThanOrEqual(47);
+    expect(result!.range.end.character).toBeGreaterThan(47);
+    expect(result!.placeholder).toBe('compute');
+  }, 120_000);
+
   it('renames a base method AND its cross-file override declaration', async () => {
     // Cursor on RmBase.run declaration (LSP line 1, char 25 — inside `run`).
     const result = await rename(

--- a/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
+++ b/packages/apex-ls/test/integration/RenameThroughWorkerTopology.node.test.ts
@@ -482,12 +482,16 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
         }),
       );
 
-      // Cursor on the method name `compute` (line 1, char 20), which is NOT a
-      // local — prepareRename should return null (not renamable as local).
+      // Cursor on the TYPE name `RenameLocal` (line 0, char 15). A type is not a
+      // local, field, or method, so it falls through the whole dispatch chain
+      // (local → field → method) and prepareRename returns null. (Before
+      // W-23631152 this used the method name `compute`, but a method cursor now
+      // resolves via resolvePrepareRenameForMethod, so the class name is the
+      // stable "no kind services this cursor" probe — renameType is Group 6.)
       const result = yield* Effect.promise(() =>
         dispatcher.dispatch('prepareRename', {
           textDocument: { uri: LOCAL_URI },
-          position: { line: 1, character: 20 },
+          position: { line: 0, character: 15 },
         }),
       );
 
@@ -496,7 +500,7 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
 
     const { result } = await Effect.runPromise(program);
 
-    // prepareRename returns null when the cursor isn't on a renamable local.
+    // prepareRename returns null when no rename kind services the cursor.
     expect(result).toBeNull();
   }, 120_000);
 
@@ -902,6 +906,263 @@ describe('rename through the worker topology (Phase 0 no-op)', () => {
     edit!.changes![ORG_FIELD_URI].forEach((e) =>
       expect(e.newText).toBe('total'),
     );
+  }, 120_000);
+
+  // W-23631152: prepareRename must recognize METHODS, not just locals + fields
+  // (else F2 on a method won't open the box, even though renameMethod can service
+  // it). DispatchPrepareRename now dispatches local → field → method, mirroring
+  // the rename RESOLVE chain. Covers a declaration cursor, a call/usage cursor,
+  // the half-open identifier-end boundary, and the stdlib provenance guard.
+  const PREP_METHOD_URI = 'file:///test/PrepareMethod.cls';
+  const PREP_METHOD_SRC = `public class PrepareMethod {
+    public Integer compute() {
+        return doWork();
+    }
+
+    public Integer doWork() {
+        return 5;
+    }
+}`;
+
+  it('returns prepareRename range for a method DECLARATION cursor (W-23631152)', async () => {
+    const program = Effect.gen(function* () {
+      const topology = yield* initializeTopology({
+        poolSize: 1,
+        enableResourceLoader: true,
+        logger,
+        logLevel: LOG_LEVEL,
+        compilationPoolSize: COMPILATION_POOL_SIZE,
+        compilationConcurrency: 1,
+        workerLayerFactory,
+      });
+      const dispatcher = makeWorkerDispatcher(topology, logger, (uri) =>
+        uri === PREP_METHOD_URI ? PREP_METHOD_SRC : undefined,
+      );
+      wireProductionMediator(topology, dispatcher, logger);
+      yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentOpen', {
+          document: {
+            uri: PREP_METHOD_URI,
+            languageId: 'apex',
+            version: 1,
+            getText: () => PREP_METHOD_SRC,
+          },
+          textDocument: { uri: PREP_METHOD_URI },
+          text: PREP_METHOD_SRC,
+        }),
+      );
+
+      // `compute` DECLARATION (LSP line 1, char 22) — exercises
+      // getSymbolAtPosition on the method identifier.
+      const result = yield* Effect.promise(() =>
+        dispatcher.dispatch('prepareRename', {
+          textDocument: { uri: PREP_METHOD_URI },
+          position: { line: 1, character: 22 },
+          content: PREP_METHOD_SRC,
+        }),
+      );
+
+      return { result };
+    }).pipe(Effect.scoped);
+
+    const { result } = await Effect.runPromise(program);
+    logger.debug(
+      `[prepare-rename:method-declaration] ${JSON.stringify(result)}`,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('range');
+    const prepareInfo = result as {
+      range: {
+        start: { line: number; character: number };
+        end: { line: number; character: number };
+      };
+      placeholder: string;
+    };
+    // On LSP line 1, and the range must CONTAIN the cursor (char 22).
+    expect(prepareInfo.range.start.line).toBe(1);
+    expect(prepareInfo.range.end.line).toBe(1);
+    expect(prepareInfo.range.start.character).toBeLessThanOrEqual(22);
+    expect(prepareInfo.range.end.character).toBeGreaterThan(22);
+    expect(prepareInfo.placeholder).toBe('compute');
+  }, 120_000);
+
+  it('returns prepareRename range for a method CALL/usage cursor (W-23631152)', async () => {
+    const program = Effect.gen(function* () {
+      const topology = yield* initializeTopology({
+        poolSize: 1,
+        enableResourceLoader: true,
+        logger,
+        logLevel: LOG_LEVEL,
+        compilationPoolSize: COMPILATION_POOL_SIZE,
+        compilationConcurrency: 1,
+        workerLayerFactory,
+      });
+      const dispatcher = makeWorkerDispatcher(topology, logger, (uri) =>
+        uri === PREP_METHOD_URI ? PREP_METHOD_SRC : undefined,
+      );
+      wireProductionMediator(topology, dispatcher, logger);
+      yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentOpen', {
+          document: {
+            uri: PREP_METHOD_URI,
+            languageId: 'apex',
+            version: 1,
+            getText: () => PREP_METHOD_SRC,
+          },
+          textDocument: { uri: PREP_METHOD_URI },
+          text: PREP_METHOD_SRC,
+        }),
+      );
+
+      // `doWork()` CALL (LSP line 2, char 17) — must return the usage range, not
+      // the declaration's (exercises exactCursorReference).
+      const result = yield* Effect.promise(() =>
+        dispatcher.dispatch('prepareRename', {
+          textDocument: { uri: PREP_METHOD_URI },
+          position: { line: 2, character: 17 },
+          content: PREP_METHOD_SRC,
+        }),
+      );
+
+      return { result };
+    }).pipe(Effect.scoped);
+
+    const { result } = await Effect.runPromise(program);
+    logger.debug(`[prepare-rename:method-usage] ${JSON.stringify(result)}`);
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('range');
+    const prepareInfo = result as {
+      range: {
+        start: { line: number; character: number };
+        end: { line: number; character: number };
+      };
+      placeholder: string;
+    };
+    // The call is on LSP line 2, and the returned range must contain the cursor.
+    expect(prepareInfo.range.start.line).toBe(2);
+    expect(prepareInfo.range.end.line).toBe(2);
+    expect(prepareInfo.range.start.character).toBeLessThanOrEqual(17);
+    expect(prepareInfo.range.end.character).toBeGreaterThan(17);
+    expect(prepareInfo.placeholder).toBe('doWork');
+  }, 120_000);
+
+  it('returns null from method prepareRename at the identifier-end boundary (W-23631152)', async () => {
+    // `compute` on LSP line 1 occupies chars 19-25; the identifier range is
+    // half-open [19, 26), so a cursor at char 26 sits one past the last char
+    // (the `(`) and must be REJECTED — matching resolvePrepareRenameForLocal/
+    // Field. Guards against the inclusive positionInRange end check wrongly
+    // accepting a cursor immediately after the method identifier.
+    const program = Effect.gen(function* () {
+      const topology = yield* initializeTopology({
+        poolSize: 1,
+        enableResourceLoader: true,
+        logger,
+        logLevel: LOG_LEVEL,
+        compilationPoolSize: COMPILATION_POOL_SIZE,
+        compilationConcurrency: 1,
+        workerLayerFactory,
+      });
+      const dispatcher = makeWorkerDispatcher(topology, logger, (uri) =>
+        uri === PREP_METHOD_URI ? PREP_METHOD_SRC : undefined,
+      );
+      wireProductionMediator(topology, dispatcher, logger);
+      yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentOpen', {
+          document: {
+            uri: PREP_METHOD_URI,
+            languageId: 'apex',
+            version: 1,
+            getText: () => PREP_METHOD_SRC,
+          },
+          textDocument: { uri: PREP_METHOD_URI },
+          text: PREP_METHOD_SRC,
+        }),
+      );
+
+      const result = yield* Effect.promise(() =>
+        dispatcher.dispatch('prepareRename', {
+          textDocument: { uri: PREP_METHOD_URI },
+          position: { line: 1, character: 26 }, // one past `compute`
+          content: PREP_METHOD_SRC,
+        }),
+      );
+
+      return { result };
+    }).pipe(Effect.scoped);
+
+    const { result } = await Effect.runPromise(program);
+    logger.debug(`[prepare-rename:method-boundary] ${JSON.stringify(result)}`);
+
+    expect(result).toBeNull();
+  }, 120_000);
+
+  // W-23631152: the provenance guard must reject STANDARD-LIBRARY methods just
+  // as it does stdlib fields. `apexlib://` is a synthetic read-only scheme; a
+  // method declared there must never open the rename box (prepareRename → null).
+  const STDLIB_METHOD_URI = 'apexlib://test/StdLibMethod.cls';
+  const STDLIB_METHOD_SRC = `public class StdLibMethod {
+    public Integer compute() {
+        return 5;
+    }
+}`;
+
+  it('declines prepareRename for a standard-library (apexlib://) method (W-23631152)', async () => {
+    const program = Effect.gen(function* () {
+      const topology = yield* initializeTopology({
+        poolSize: 1,
+        enableResourceLoader: true,
+        logger,
+        logLevel: LOG_LEVEL,
+        compilationPoolSize: COMPILATION_POOL_SIZE,
+        compilationConcurrency: 1,
+        workerLayerFactory,
+      });
+      const dispatcher = makeWorkerDispatcher(topology, logger, (uri) =>
+        uri === STDLIB_METHOD_URI ? STDLIB_METHOD_SRC : undefined,
+      );
+      wireProductionMediator(topology, dispatcher, logger);
+      yield* runRemoteStdlibWarmupPhase(topology, 1);
+
+      yield* Effect.promise(() =>
+        dispatcher.dispatch('documentOpen', {
+          document: {
+            uri: STDLIB_METHOD_URI,
+            languageId: 'apex',
+            version: 1,
+            getText: () => STDLIB_METHOD_SRC,
+          },
+          textDocument: { uri: STDLIB_METHOD_URI },
+          text: STDLIB_METHOD_SRC,
+        }),
+      );
+
+      // Cursor on `compute` DECLARATION (LSP line 1, char 22).
+      const prepare = yield* Effect.promise(() =>
+        dispatcher.dispatch('prepareRename', {
+          textDocument: { uri: STDLIB_METHOD_URI },
+          position: { line: 1, character: 22 },
+          content: STDLIB_METHOD_SRC,
+        }),
+      );
+
+      return { prepare };
+    }).pipe(Effect.scoped);
+
+    const { prepare } = await Effect.runPromise(program);
+    logger.debug(
+      `[prepare-rename:method-stdlib-guard] ${JSON.stringify(prepare)}`,
+    );
+
+    // prepareRename must NOT offer the stdlib method.
+    expect(prepare).toBeNull();
   }, 120_000);
 
   // W-23631084: Field rename tests (4.1)


### PR DESCRIPTION
### What does this PR do?

Implements **5.5: Generalize `onPrepareRename` across rename kinds.** Adds method `prepareRename` and unifies the prepareRename dispatch so F2 opens the rename box for methods (previously only locals and fields were wired).

- **`resolvePrepareRenameForMethod`** — mirrors `resolvePrepareRenameForField`: recompiles + loads referenced types, resolves the cursor symbol, gates on `kind === 'method'`, applies the `isUserOwnedApexUri` source-provenance guard (rejects synthetic read-only schemes like `apexlib://`), computes the cursor-containing range (usage token via `exactCursorReference`, else declaration), and enforces half-open containment (`endColumn > cursor`). Returns `{ range, placeholder }` or null.
- **`DispatchPrepareRename`** now dispatches `local ?? field ?? method`, mirroring the rename RESOLVE chain, with a documented extension seam for TYPE prepareRename (deferred to Group 6 / renameType).

Scope note: an un-renamable cursor surfaces as a plain null fall-through (parity with the local/field paths — no distinct error shape introduced). Full four-kind coverage awaits renameType (Group 6); this delivers the method kind and the generalization framework.

**Stacked on #687 (5.3).** Base is the 5.3 branch, so the diff shows only the prepareRename work; merges after the 5.x stack. Draft until then.

Validation: full pre-commit matrix green (5557 passed, 0 failed); prepareRename worker-topology tests 46/46 (method declaration cursor → range; usage cursor → range; identifier-end boundary → null; `apexlib://` method → null; non-renamable cursor → null).

### What issues does this PR fix or reference?

@W-23631152@

### Functionality Before

F2 on a method returned "The element can't be renamed" — `prepareRename` was wired only for locals and fields, so the rename box never opened for methods.

### Functionality After

F2 on a method declaration or usage opens the rename box (returns the identifier range), gated to user-owned Apex sources and rejecting a cursor past the identifier end — consistent with the local and field paths.
