### PR TITLE
test(apex-lsp-extension): renameMethod e2e coverage + openFile harness fix - W-23631134

### DIFF
--- a/e2e-tests/pages/ApexEditorPage.ts
+++ b/e2e-tests/pages/ApexEditorPage.ts
@@ -51,14 +51,9 @@ export class ApexEditorPage extends BasePage {
    * @param filename - Name of the file to open (e.g., "ApexClassExample.cls")
    */
   async openFile(filename: string): Promise<void> {
-    const fileLocator = this.page
-      .locator(`[aria-label*="${filename}"]`)
-      .first();
-
-    const fileExists = await fileLocator.count();
-    if (fileExists > 0) {
-      await fileLocator.dblclick();
-    } else {
+    // Open via quick-open (Ctrl+P style). Reused for the initial open and the
+    // fallback below.
+    const openViaQuickInput = async (): Promise<void> => {
       await this.executeCommand('File: Open File');
       const quickInput = this.page.locator('.quick-input-widget');
       await quickInput.waitFor({ state: 'visible', timeout: 5000 });
@@ -67,6 +62,29 @@ export class ApexEditorPage extends BasePage {
       await quickInput
         .waitFor({ state: 'hidden', timeout: 5000 })
         .catch(() => {});
+    };
+
+    const fileLocator = this.page
+      .locator(`[aria-label*="${filename}"]`)
+      .first();
+    if ((await fileLocator.count()) > 0) {
+      await fileLocator.dblclick();
+    } else {
+      await openViaQuickInput();
+    }
+
+    // The `[aria-label*=...]` locator can match a stale explorer node or the
+    // wrong tab, and a lingering rename widget can steal focus, so the dblclick
+    // does not guarantee the requested file became the ACTIVE editor. Since
+    // getContent()/activeEditorContent read the ACTIVE group, asserting without
+    // confirming the active tab reads the WRONG file (observed in the serial
+    // renameMethod e2e, which read a different fixture's content). Confirm the
+    // active tab is the target; if not, recover once via quick-open.
+    try {
+      await this.waitForActiveTab(filename, 8000);
+    } catch {
+      await openViaQuickInput();
+      await this.waitForActiveTab(filename, this.defaultTimeout);
     }
 
     await this.editor.waitFor({
@@ -77,6 +95,34 @@ export class ApexEditorPage extends BasePage {
       .locator('.view-line')
       .first()
       .waitFor({ state: 'visible', timeout: this.defaultTimeout });
+  }
+
+  /**
+   * Wait until the ACTIVE editor tab is `filename`. openFile/getContent operate
+   * on the active editor group, so callers that switch files must confirm the
+   * switch landed before asserting — otherwise stale focus (e.g. a lingering
+   * rename widget in a shared serial context) reads a different file's content.
+   * Matches the active tab's `.label-name` (falling back to its aria-label's
+   * filename segment), mirroring waitForNavigation's detection.
+   * @param filename - Expected active-tab basename (e.g. "Foo.cls")
+   * @param timeout - Max wait in ms (defaults to the page default)
+   */
+  async waitForActiveTab(filename: string, timeout?: number): Promise<void> {
+    await this.page.waitForFunction(
+      (target: string) => {
+        const labelText = document
+          .querySelector('.tab.active .label-name')
+          ?.textContent?.trim();
+        if (labelText) return labelText === target;
+        const ariaLabel =
+          document
+            .querySelector('.tab.active[aria-label]')
+            ?.getAttribute('aria-label') ?? '';
+        return ariaLabel.split(',')[0].trim() === target;
+      },
+      filename,
+      { timeout: timeout ?? this.defaultTimeout },
+    );
   }
 
   /**

--- a/e2e-tests/pages/ApexEditorPage.ts
+++ b/e2e-tests/pages/ApexEditorPage.ts
@@ -79,9 +79,11 @@ export class ApexEditorPage extends BasePage {
     // getContent()/activeEditorContent read the ACTIVE group, asserting without
     // confirming the active tab reads the WRONG file (observed in the serial
     // renameMethod e2e, which read a different fixture's content). Confirm the
-    // active tab is the target; if not, recover once via quick-open.
+    // active tab is the target; if not, recover once via quick-open. Use the
+    // mode-aware defaultTimeout (not a hardcoded ceiling) so a cold open on a
+    // slow CI host isn't cut short into a needless quick-open recovery.
     try {
-      await this.waitForActiveTab(filename, 8000);
+      await this.waitForActiveTab(filename, this.defaultTimeout);
     } catch {
       await openViaQuickInput();
       await this.waitForActiveTab(filename, this.defaultTimeout);

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodAncestorBase.cls
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodAncestorBase.cls
@@ -1,0 +1,11 @@
+/*
+ * Ancestor-override renameMethod e2e (W-23631134, case 1). Base virtual class
+ * declaring `evaluateScore()`. Renaming THIS declaration must also rename the
+ * subclass `override` declaration and the instance call site over in
+ * RenameMethodAncestorChild.cls (cross-file, down the type-family cone).
+ */
+public virtual class RenameMethodAncestorBase {
+    public virtual Integer evaluateScore() {
+        return 1;
+    }
+}

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodAncestorBase.cls-meta.xml
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodAncestorBase.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodAncestorChild.cls
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodAncestorChild.cls
@@ -1,0 +1,18 @@
+/*
+ * Subclass override + call site for the ancestor-override case
+ * (W-23631134, case 1). Extends RenameMethodAncestorBase from a separate file.
+ * The `override evaluateScore()` declaration and the `child.evaluateScore()`
+ * instance call below must both be renamed when the base method is renamed —
+ * `child` is declared as the family subtype, so the call is a provable
+ * occurrence (not a decline-triggering unprovable receiver).
+ */
+public class RenameMethodAncestorChild extends RenameMethodAncestorBase {
+    public override Integer evaluateScore() {
+        return 2;
+    }
+
+    public Integer runScore() {
+        RenameMethodAncestorChild child = new RenameMethodAncestorChild();
+        return child.evaluateScore();
+    }
+}

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodAncestorChild.cls-meta.xml
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodAncestorChild.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodContract.cls
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodContract.cls
@@ -1,0 +1,9 @@
+/*
+ * Interface-implementer renameMethod e2e (W-23631134, case 3). Interface
+ * declaring `handleRecord()`. Renaming THIS interface method must also rename
+ * the implementing class's method declaration and its call site over in
+ * RenameMethodImplementer.cls (the implementor is in the type-family cone).
+ */
+public interface RenameMethodContract {
+    void handleRecord();
+}

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodContract.cls-meta.xml
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodContract.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodDescendantBase.cls
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodDescendantBase.cls
@@ -1,0 +1,10 @@
+/*
+ * Descendant-override renameMethod e2e (W-23631134, case 2). Base virtual class
+ * declaring `refreshCache()`. The rename is driven from a SUBCLASS override
+ * (RenameMethodDescendantChild); renaming up the cone must also rename THIS base
+ * declaration and the sibling override in RenameMethodDescendantSibling.cls.
+ */
+public virtual class RenameMethodDescendantBase {
+    public virtual void refreshCache() {
+    }
+}

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodDescendantBase.cls-meta.xml
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodDescendantBase.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodDescendantChild.cls
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodDescendantChild.cls
@@ -1,0 +1,16 @@
+/*
+ * Descendant override that is the RENAME SOURCE for case 2 (W-23631134).
+ * Renaming `refreshCache()` from this override must propagate UP to the base
+ * declaration (RenameMethodDescendantBase) and ACROSS to the sibling override
+ * (RenameMethodDescendantSibling). The `child.refreshCache()` call below is a
+ * provable occurrence because `child` is declared as this family subtype.
+ */
+public class RenameMethodDescendantChild extends RenameMethodDescendantBase {
+    public override void refreshCache() {
+    }
+
+    public void runRefresh() {
+        RenameMethodDescendantChild child = new RenameMethodDescendantChild();
+        child.refreshCache();
+    }
+}

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodDescendantChild.cls-meta.xml
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodDescendantChild.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodDescendantSibling.cls
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodDescendantSibling.cls
@@ -1,0 +1,10 @@
+/*
+ * Sibling override for case 2 (W-23631134). A SECOND subclass of
+ * RenameMethodDescendantBase that also overrides `refreshCache()`. When the
+ * rename is driven from RenameMethodDescendantChild, this sibling override must
+ * also be renamed (it shares the base declaration in the type-family cone).
+ */
+public class RenameMethodDescendantSibling extends RenameMethodDescendantBase {
+    public override void refreshCache() {
+    }
+}

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodDescendantSibling.cls-meta.xml
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodDescendantSibling.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodImplementer.cls
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodImplementer.cls
@@ -1,0 +1,16 @@
+/*
+ * Implementing class for the interface-implementer case (W-23631134, case 3).
+ * Implements RenameMethodContract from a separate file. The `handleRecord()`
+ * method declaration and the `impl.handleRecord()` call below must both be
+ * renamed when the interface method is renamed — `impl` is declared as this
+ * implementor type, so the call is a provable family occurrence.
+ */
+public class RenameMethodImplementer implements RenameMethodContract {
+    public void handleRecord() {
+    }
+
+    public void runHandle() {
+        RenameMethodImplementer impl = new RenameMethodImplementer();
+        impl.handleRecord();
+    }
+}

--- a/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodImplementer.cls-meta.xml
+++ b/e2e-tests/test-data/apex-samples/force-app/main/default/classes/RenameMethodImplementer.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/e2e-tests/tests/apex-rename-symbol.spec.ts
+++ b/e2e-tests/tests/apex-rename-symbol.spec.ts
@@ -357,3 +357,261 @@ test.describe('Apex Rename Symbol - Field', () => {
     });
   });
 });
+
+/**
+ * E2E for textDocument/rename of METHODS (W-23631134 / 5.4) — hierarchy-aware
+ * rename across the type-family cone via F2, like the renameField tests. Each
+ * case renames a method that participates in an inheritance / interface
+ * relationship and asserts that the declaration, the override/implementation
+ * declarations in OTHER files, and the modeled call sites are all rewritten.
+ *
+ * !!! DEPENDENCY ON WI 7.1 (W-23631152) — method `prepareRename` !!!
+ * F2 fires `textDocument/prepareRename` FIRST (prepareProvider is advertised in
+ * DEVELOPMENT_CAPABILITIES). The renameLocal (3.x) and renameField (W-23631087)
+ * branches only wired prepareRename for LOCALS and FIELDS. METHOD prepareRename
+ * — the range/eligibility probe that lets F2 open the rename box on a method
+ * name — is delivered separately by WI 7.1. Until 7.1 is integrated into this
+ * branch, F2 on a method declaration returns "The element can't be renamed" and
+ * these three tests CANNOT pass. They are authored against the EXPECTED F2
+ * method-rename UX so they go green the moment 7.1 lands; do not treat a failure
+ * here as a regression before that integration.
+ *
+ * Fixture design (so the rename is PROVABLE and never declines): call sites use
+ * receivers declared as a family type (`Child child = new Child(); child.foo()`),
+ * plus `override`/`implements` declarations — no overloads, no multi-hop chains,
+ * and no method/constructor-result receivers, all of which findMethodOccurrences
+ * marks `unsafe` → decline. Method names are globally unique across the fixture
+ * set so no out-of-family same-named call can force a decline.
+ *
+ * @group rename
+ */
+test.describe('Apex Rename Symbol - Method', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('ancestor override: renaming a base method renames the subclass override + call site cross-file', async ({
+    apexEditor,
+    outlineView,
+  }) => {
+    await test.step('Open the subclass (consumer) then the base (rename source)', async () => {
+      // Open the consumer first so its override + call are ingested, then the
+      // declaring file last (it is the rename source and gets warmed below).
+      await apexEditor.openFile('RenameMethodAncestorChild.cls');
+      await apexEditor.waitForLanguageServerReady();
+      await apexEditor.openFile('RenameMethodAncestorBase.cls');
+      await apexEditor.waitForLanguageServerReady();
+    });
+
+    await test.step('Wait for full workspace ingestion', async () => {
+      // renameMethod declines mid-load rather than emit a partial edit; gate on
+      // full ingestion so the subclass file is stored and the type-family cone
+      // (base → subtype) is resolvable before F2.
+      await apexEditor.waitForWorkspaceReady();
+    });
+
+    await test.step('Warm the request pool for prepareRename on the base file', async () => {
+      await apexEditor.openFile('RenameMethodAncestorBase.cls');
+      await outlineView.open();
+      const mainClass = await outlineView.findSymbol(
+        'RenameMethodAncestorBase',
+        20000,
+      );
+      expect(
+        mainClass,
+        'Outline (documentSymbol) must resolve RenameMethodAncestorBase before F2',
+      ).not.toBeNull();
+    });
+
+    await test.step('Position on the base `evaluateScore` declaration', async () => {
+      // Line 8: `    public virtual Integer evaluateScore() {` — `evaluateScore`
+      // starts at column 28; column 31 is INSIDE the token (prepareRename uses a
+      // half-open range, so land in-word, not at the boundary).
+      await apexEditor.goToPosition(8, 31);
+    });
+
+    await test.step('Rename `evaluateScore` to `computeRank`', async () => {
+      await apexEditor.rename('computeRank');
+    });
+
+    await test.step('Assert the base declaration is renamed', async () => {
+      await apexEditor.waitForContentToInclude('computeRank');
+      const content = await apexEditor.getContent();
+      const normalized = content.replace(/ /g, ' ');
+      // `public virtual Integer computeRank() {`
+      expect(normalized).toMatch(
+        /public\s+virtual\s+Integer\s+computeRank\s*\(\s*\)/,
+      );
+      // Old name gone from the class body (slice past the comment that names it).
+      const classBody = normalized.slice(
+        normalized.indexOf('public virtual class'),
+      );
+      expect(classBody).not.toContain('evaluateScore');
+    });
+
+    await test.step('Assert the subclass override + call site are renamed cross-file', async () => {
+      await apexEditor.openFile('RenameMethodAncestorChild.cls');
+      await apexEditor.waitForContentToInclude('computeRank');
+      const content = await apexEditor.getContent();
+      const normalized = content.replace(/ /g, ' ');
+
+      // Override declaration: `public override Integer computeRank() {`
+      expect(normalized).toMatch(
+        /public\s+override\s+Integer\s+computeRank\s*\(\s*\)/,
+      );
+      // Call site: `return child.computeRank();`
+      expect(normalized).toMatch(/return\s+child\.computeRank\s*\(\s*\)/);
+
+      // Old name gone from the class body (slice past the naming comment).
+      const classBody = normalized.slice(normalized.indexOf('public class'));
+      expect(classBody).not.toContain('evaluateScore');
+    });
+  });
+
+  test('descendant override: renaming from a subclass override renames base + sibling', async ({
+    apexEditor,
+    outlineView,
+  }) => {
+    await test.step('Open the base + sibling (consumers) then the child (rename source)', async () => {
+      await apexEditor.openFile('RenameMethodDescendantBase.cls');
+      await apexEditor.waitForLanguageServerReady();
+      await apexEditor.openFile('RenameMethodDescendantSibling.cls');
+      await apexEditor.waitForLanguageServerReady();
+      await apexEditor.openFile('RenameMethodDescendantChild.cls');
+      await apexEditor.waitForLanguageServerReady();
+    });
+
+    await test.step('Wait for full workspace ingestion', async () => {
+      // The base + sibling must be stored so the cone (child → base → sibling)
+      // resolves; renameMethod declines against a partially-loaded graph.
+      await apexEditor.waitForWorkspaceReady();
+    });
+
+    await test.step('Warm the request pool for prepareRename on the child file', async () => {
+      await apexEditor.openFile('RenameMethodDescendantChild.cls');
+      await outlineView.open();
+      const mainClass = await outlineView.findSymbol(
+        'RenameMethodDescendantChild',
+        20000,
+      );
+      expect(
+        mainClass,
+        'Outline (documentSymbol) must resolve RenameMethodDescendantChild before F2',
+      ).not.toBeNull();
+    });
+
+    await test.step('Position on the child `refreshCache` override declaration', async () => {
+      // Line 9: `    public override void refreshCache() {` — `refreshCache`
+      // starts at column 26; column 29 is INSIDE the token.
+      await apexEditor.goToPosition(9, 29);
+    });
+
+    await test.step('Rename `refreshCache` to `reloadCache`', async () => {
+      await apexEditor.rename('reloadCache');
+    });
+
+    await test.step('Assert the child override + call site are renamed', async () => {
+      await apexEditor.waitForContentToInclude('reloadCache');
+      const content = await apexEditor.getContent();
+      const normalized = content.replace(/ /g, ' ');
+      // Override declaration: `public override void reloadCache() {`
+      expect(normalized).toMatch(
+        /public\s+override\s+void\s+reloadCache\s*\(\s*\)/,
+      );
+      // Call site: `child.reloadCache();`
+      expect(normalized).toMatch(/child\.reloadCache\s*\(\s*\)/);
+      const classBody = normalized.slice(normalized.indexOf('public class'));
+      expect(classBody).not.toContain('refreshCache');
+    });
+
+    await test.step('Assert the base declaration is renamed (propagated up the cone)', async () => {
+      await apexEditor.openFile('RenameMethodDescendantBase.cls');
+      await apexEditor.waitForContentToInclude('reloadCache');
+      const content = await apexEditor.getContent();
+      const normalized = content.replace(/ /g, ' ');
+      // `public virtual void reloadCache() {`
+      expect(normalized).toMatch(
+        /public\s+virtual\s+void\s+reloadCache\s*\(\s*\)/,
+      );
+      const classBody = normalized.slice(
+        normalized.indexOf('public virtual class'),
+      );
+      expect(classBody).not.toContain('refreshCache');
+    });
+
+    await test.step('Assert the sibling override is renamed (propagated across the cone)', async () => {
+      await apexEditor.openFile('RenameMethodDescendantSibling.cls');
+      await apexEditor.waitForContentToInclude('reloadCache');
+      const content = await apexEditor.getContent();
+      const normalized = content.replace(/ /g, ' ');
+      // `public override void reloadCache() {`
+      expect(normalized).toMatch(
+        /public\s+override\s+void\s+reloadCache\s*\(\s*\)/,
+      );
+      const classBody = normalized.slice(normalized.indexOf('public class'));
+      expect(classBody).not.toContain('refreshCache');
+    });
+  });
+
+  test('interface implementer: renaming an interface method renames the implementing class method + call site', async ({
+    apexEditor,
+    outlineView,
+  }) => {
+    await test.step('Open the implementer (consumer) then the interface (rename source)', async () => {
+      await apexEditor.openFile('RenameMethodImplementer.cls');
+      await apexEditor.waitForLanguageServerReady();
+      await apexEditor.openFile('RenameMethodContract.cls');
+      await apexEditor.waitForLanguageServerReady();
+    });
+
+    await test.step('Wait for full workspace ingestion', async () => {
+      // The implementor must be stored so the interface's cone (interface →
+      // implementor) resolves before F2; otherwise renameMethod declines.
+      await apexEditor.waitForWorkspaceReady();
+    });
+
+    await test.step('Warm the request pool for prepareRename on the interface file', async () => {
+      await apexEditor.openFile('RenameMethodContract.cls');
+      await outlineView.open();
+      const mainType = await outlineView.findSymbol(
+        'RenameMethodContract',
+        20000,
+      );
+      expect(
+        mainType,
+        'Outline (documentSymbol) must resolve RenameMethodContract before F2',
+      ).not.toBeNull();
+    });
+
+    await test.step('Position on the interface `handleRecord` declaration', async () => {
+      // Line 8: `    void handleRecord();` — `handleRecord` starts at column 10;
+      // column 13 is INSIDE the token.
+      await apexEditor.goToPosition(8, 13);
+    });
+
+    await test.step('Rename `handleRecord` to `processRecord`', async () => {
+      await apexEditor.rename('processRecord');
+    });
+
+    await test.step('Assert the interface declaration is renamed', async () => {
+      await apexEditor.waitForContentToInclude('processRecord');
+      const content = await apexEditor.getContent();
+      const normalized = content.replace(/ /g, ' ');
+      // `void processRecord();`
+      expect(normalized).toMatch(/void\s+processRecord\s*\(\s*\)\s*;/);
+      const bodyText = normalized.slice(normalized.indexOf('public interface'));
+      expect(bodyText).not.toContain('handleRecord');
+    });
+
+    await test.step('Assert the implementing class method + call site are renamed cross-file', async () => {
+      await apexEditor.openFile('RenameMethodImplementer.cls');
+      await apexEditor.waitForContentToInclude('processRecord');
+      const content = await apexEditor.getContent();
+      const normalized = content.replace(/ /g, ' ');
+      // Implementation declaration: `public void processRecord() {`
+      expect(normalized).toMatch(/public\s+void\s+processRecord\s*\(\s*\)/);
+      // Call site: `impl.processRecord();`
+      expect(normalized).toMatch(/impl\.processRecord\s*\(\s*\)/);
+      const classBody = normalized.slice(normalized.indexOf('public class'));
+      expect(classBody).not.toContain('handleRecord');
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Implements **5.4: renameMethod e2e coverage.** Adds Playwright web e2e cases for renaming a method across an inheritance hierarchy, plus a harness reliability fix.

- **Three method-rename e2e cases** in `apex-rename-symbol.spec.ts` (+ 7 fixtures under `test-data/apex-samples/.../classes/`, mirroring the field-rename e2e):
  - **ancestor override** — rename a base method; the subclass `override` declaration + a cross-file call site are renamed.
  - **descendant override** — rename from a subclass override; the base declaration + a sibling override are renamed.
  - **interface implementer** — rename an interface method; the implementing class's method declaration + a call site are renamed.
  Each asserts the specific declaration shape and that the old name is gone from the class/interface body — asserting the right ranges/files were edited, not just "an edit happened".
- **Harness fix:** `ApexEditorPage.openFile` now confirms the requested file became the ACTIVE editor tab (with a quick-open recovery), via the new `waitForActiveTab`. Previously it waited only for "an editor" to be visible, so in a shared serial browser context a lingering rename widget / stale focus could leave a different fixture's content under assertion. This is a central improvement benefiting all specs.

**Stacked on #691 (7.1).** These cases require 7.1's method `prepareRename` (F2 won't open the rename box otherwise), so this PR is based on the 7.1 branch and merges after it.

Validation: the full `apex-rename-symbol.spec.ts` web run is **7/7** (local + field + all three method cases) in a single serial pass, zero flaky; full unit/topology matrix green (5557 passed, 0 failed).

### What issues does this PR fix or reference?

@W-23631134@

### Functionality Before

No e2e coverage for method rename; the web spec's `openFile` did not verify the active editor, making serial cross-file rename assertions read the wrong file.

### Functionality After

F2 method rename is exercised end-to-end in the browser across ancestor/descendant/interface hierarchies, and the shared e2e harness reliably switches editors before asserting.
